### PR TITLE
Fix typo on main docs page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -8,7 +8,7 @@ Sourcegraph is a Code AI platform that deeply understands your code, no matter h
 ## Quickstart
 
 <QuickLinks>
-	<QuickLink href="/cody" icon="cody" imgAlt="Cody" title="Cody" description="Wite, fix, and maintain code with Sourcegraph’s AI coding assistant, Cody. " />
+	<QuickLink href="/cody" icon="cody" imgAlt="Cody" title="Cody" description="Write, fix, and maintain code with Sourcegraph’s AI coding assistant, Cody. " />
 	<QuickLink href="/code_search" icon="codesearch" imgAlt="Code Search" title="Code Search" description="Search all of your repositories across all branches and all code hosts." />
 	<QuickLink title="Sourcegraph 101" icon="plugins" href="/getting-started" description="Learn how to use Sourcegraph." />
 	<QuickLink title="Sourcegraph Tour" icon="codegraph" href="/getting-started/tour" description="Take a tour of Sourcegraph’s features using real-world examples and use cases." />


### PR DESCRIPTION
Fix typo here:

![CleanShot 2023-12-19 at 10 30 34@2x](https://github.com/sourcegraph/docs/assets/12712988/dc9a54dc-a208-4a38-bd34-6e87d7528df5)
