### PR TITLE
Document new GraphQL rate limits

### DIFF
--- a/docs/api/graphql/index.mdx
+++ b/docs/api/graphql/index.mdx
@@ -115,3 +115,12 @@ To ensure system performance and stability, configurable GraphQL query cost limi
 
 - **Default Value**: 500
 - Sets a cap on the number of aliases in a single GraphQL query, mitigating the risk of resource-intensive queries due to excessive aliasing.
+
+
+### GraphqlMaxDuplicateFieldCount
+- **Default Value**: 500
+- Limits the number of duplicate fields in a GraphQL query to prevent queries with unnecessary duplication from consuming excessive resources.
+
+### GraphqlMaxUniqueFieldCount
+- **Default Value**: 500
+- Restricts the number of unique fields in a GraphQL query to prevent queries with unnecessary broadness from consuming excessive resources.

--- a/docs/api/graphql/index.mdx
+++ b/docs/api/graphql/index.mdx
@@ -116,7 +116,6 @@ To ensure system performance and stability, configurable GraphQL query cost limi
 - **Default Value**: 500
 - Sets a cap on the number of aliases in a single GraphQL query, mitigating the risk of resource-intensive queries due to excessive aliasing.
 
-
 ### GraphqlMaxDuplicateFieldCount
 - **Default Value**: 500
 - Limits the number of duplicate fields in a GraphQL query to prevent queries with unnecessary duplication from consuming excessive resources.


### PR DESCRIPTION
This adds documentation for rate limits that were introduced here: https://github.com/sourcegraph/sourcegraph/pull/58563/.