### PR TITLE
fix: custom commands mode

### DIFF
--- a/docs/cody/capabilities/commands.mdx
+++ b/docs/cody/capabilities/commands.mdx
@@ -204,9 +204,8 @@ See the [examples](#examples) and [configuration properties](#configuration-prop
 
   Values:
   - `"ask"` — Focus the chat view and add to the current chat
-  - `"inline"` — Start a new inline chat
   - `"insert"` — Insert the response above the code
-  - `"replace"` — Replace the code with the response
+  - `"edit"` — Edit selected code with the response
 
 #### `commands.<id>.context`
 


### PR DESCRIPTION
Close https://github.com/sourcegraph/cody/issues/2186
Moved from https://github.com/sourcegraph/sourcegraph/pull/59281

There is no `replace` mode in custom command. The correct mode should be `edit`: https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/lib/shared/src/chat/prompts/index.ts?L81

Also remove `inline` mode as inline chat has been removed.