### PR TITLE
vscode: add files.associations for mdx

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    "*.mdx": "markdown",
+  }
+}


### PR DESCRIPTION
Helps extensions render `.mdx` as Markdown

![image](https://github.com/sourcegraph/docs/assets/23356519/4932a3ba-effb-4c66-a216-c228af6f1f02)
