### PR TITLE
Disables test plan check for this repo

### DIFF
--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -1,4 +1,3 @@
-# See https://docs.sourcegraph.com/dev/background-information/ci#pr-auditor
 name: pr-auditor
 on:
   pull_request_target:
@@ -20,6 +19,7 @@ jobs:
           GITHUB_EVENT_PATH: ${{ env.GITHUB_EVENT_PATH }}
           GITHUB_TOKEN: ${{ secrets.PR_AUDITOR_TOKEN }}
           GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SKIP_CHECK_TEST_PLAN: true
   report_failure:
     needs: check-pr
     if: ${{ failure() }}


### PR DESCRIPTION
This disables the test plan check from PR auditor so that we can re-enable it to check for reviewers, etc. as well as future proof it for any features added to PR auditor. 

When this is merged, I will reenable the pr-auditor GitHub action.