### PR TITLE
search: mention disabled structural search

### DIFF
--- a/docs/code_search/reference/structural.mdx
+++ b/docs/code_search/reference/structural.mdx
@@ -1,5 +1,7 @@
 # Structural search
 
+<Callout type="note"> Changed in version 5.3. Structural search is disabled by default. To enable it, ask your site administrator to set `experimentalFeatures.structuralSearch = "enabled" in site configuration.</Callout>
+
 With structural search, you can match richer syntax patterns specifically in code and structured data formats like JSON. It can be awkward or difficult to match code blocks or nested expressions with regular expressions. To meet this challenge we've introduced a new and easier way to search code that operates more closely on a program's parse tree. We use [Comby syntax](https://comby.dev/docs/syntax-reference) for structural matching. Below you'll find examples and notes for this language-aware search functionality.
 
 ## Example


### PR DESCRIPTION
Relates to https://github.com/sourcegraph/sourcegraph/pull/57584

Structural search will be disabled by default from 5.3 on.
