### PR TITLE
Remove installation links and add warning callouts in Cody App docs

### DIFF
--- a/docs/cody/clients/app/app_configuration.mdx
+++ b/docs/cody/clients/app/app_configuration.mdx
@@ -1,5 +1,7 @@
 # Cody App Configuration
 
+<Callout type="warning">Starting December 2023, we are completely sunsetting the Cody App, which has been deprecated.</Callout>
+
 ## Using a third-party LLM provider
 
 Instead of using Sourcegraph Cody Gateway, you can configure the Cody app to use a third-party provide directly. Currently this can only be Anthropic or OpenAI.

--- a/docs/cody/clients/app/index.mdx
+++ b/docs/cody/clients/app/index.mdx
@@ -4,19 +4,6 @@
 
 The Cody app is a free, lightweight, native desktop application that connects your local code to our AI coding assistant, Cody. You can ask Cody questions about your code using the app's interface. However, Cody will be available directly inside your code editor if connected to the VS Code extension.
 
-## Installation
-
-You can download and install the Cody desktop app for the following:
-
-<ProductCards>
-	<ProductCard href="https://sourcegraph.com/.api/app/latest?arch=aarch64&target=darwin" imgSrc="https://storage.googleapis.com/sourcegraph-assets/Docs/mac-logo.png" imgAlt="macOS" title="macOS (Apple Silicon)" description="Install Cody app for your Apple Silicon computers. " />
-  <ProductCard href="https://sourcegraph.com/.api/app/latest?arch=x86_64&target=darwin" imgSrc="https://storage.googleapis.com/sourcegraph-assets/Docs/mac-logo.png" imgAlt="macOS" title="macOS (Intel)" description="Install Cody app for your Apple Intel-based computers." />
-  <ProductCard href="https://sourcegraph.com/.api/app/latest?arch=x86_64&target=linux" imgSrc="https://storage.googleapis.com/sourcegraph-assets/Docs/linux-icon.png" imgAlt="Linux" title="Linux" description="Install Cody app for your Linux-based computers." />
-
-</ProductCards>
-
-> NOTE: The Cody app is not yet available for Windows. However, you can use the [Cody extension for VS Code](/cody/clients/install-vscode) on Windows.
-
 ## Setup
 
 After a successful installation, follow these steps to complete the app setup:

--- a/docs/cody/clients/app/index.mdx
+++ b/docs/cody/clients/app/index.mdx
@@ -1,6 +1,6 @@
 # Cody App
 
-<p className="subtitle">Learn how to use Cody and its features with the native Cody app.</p>
+<Callout type="warning">Starting December 2023, we are completely sunsetting the Cody App, which has been deprecated.</Callout>
 
 The Cody app is a free, lightweight, native desktop application that connects your local code to our AI coding assistant, Cody. You can ask Cody questions about your code using the app's interface. However, Cody will be available directly inside your code editor if connected to the VS Code extension.
 

--- a/docs/cody/clients/app/integrations.mdx
+++ b/docs/cody/clients/app/integrations.mdx
@@ -1,5 +1,7 @@
 # Cody app API integrations
 
+<Callout type="warning">Starting December 2023, we are completely sunsetting the Cody App, which has been deprecated.</Callout>
+
 This page outlines how extensions and other clients can integrate with Cody app.
 
 ## API

--- a/docs/cody/clients/app/release-pipeline.mdx
+++ b/docs/cody/clients/app/release-pipeline.mdx
@@ -1,5 +1,7 @@
 # Cody App release pipeline
 
+<Callout type="warning">Starting December 2023, we are completely sunsetting the Cody App, which has been deprecated.</Callout>
+
 The Cody App release pipeline utilizes buildkite to build and bundle Cody App for all current [supported platforms](#supported-platforms). The primary definition of the buildkite pipeline can be found at `.buildkite/pipeline.app.yml` in the Sourcegraph mono repo.
 
 ## Branches that trigger the release pipeline

--- a/docs/cody/clients/app/troubleshooting.mdx
+++ b/docs/cody/clients/app/troubleshooting.mdx
@@ -1,5 +1,7 @@
 # Cody App troubleshooting guide
 
+<Callout type="warning">Starting December 2023, we are completely sunsetting the Cody App, which has been deprecated.</Callout>
+
 ### VS Code extension isn't indexing repositories correctly
 If you've confirmed that your repositories have been added to your app and embeddings have been generated successfully (check Settings > Advanced settings > Embedding jobs), the issue may be that your repositories don't have a git remote. If that's the case, try updating your extension settings (Settings > Settings > Extensions > Cody) to set `Cody: Codebase` to your path. For example, if the path on your local repositories pages is `User/myname/projects/my-repo`, you'd set `Cody: Codebase` to `my-repo`.
 


### PR DESCRIPTION
The PR adds warning Callouts everywhere in Cody App docs stating:

```
<Callout type="warning">Starting December 2023, we are completely sunsetting the Cody App, which has been deprecated.</Callout>
```
All remove installation links. 


## Test Plan

No test plan required for docs PRs.