### PR TITLE
search: remove links to .com for structural search

### DIFF
--- a/docs/code_search/reference/structural.mdx
+++ b/docs/code_search/reference/structural.mdx
@@ -12,8 +12,6 @@ The `fmt.Sprintf` function is a popular print function in Go. Here is a pattern 
 fmt.Sprintf(...)
 ```
 
-[See it live on Sourcegraph's code ↗](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+fmt.Sprintf%28...%29&patternType=structural)
-
 The `...` part is special syntax that matches all characters inside the _balanced_ parentheses `(...)`. Let's look at two interesting variants of
 matches in our codebase. Here's one:
 
@@ -67,8 +65,6 @@ Taking the original `fmt.Sprintf(...)` example, let's modify the original patter
 fmt.Sprintf("...", ...)
 ```
 
-[See it live on Sourcegraph's code ↗](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+fmt.Sprintf%28%22...%22%2C+...%29&patternType=structural)
-
 Some matched examples are:
 
 ```go
@@ -97,8 +93,6 @@ return :[v.], :[v.]
 
 will match code where two identifier-like tokens in the `return` statement are the same. For example, `return true, true`, `return nil, nil`, or `return 0, 0`.
 
-[See it live on Sourcegraph's code ↗](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+lang:go+return+:%5Bv.%5D%2C+:%5Bv.%5D&patternType=structural)
-
 #### Match JSON
 
 Structural search also works on structured data, like JSON. Use patterns to declaratively describe pieces of data to match. For example, the pattern:
@@ -108,8 +102,6 @@ Structural search also works on structured data, like JSON. Use patterns to decl
 ```
 
 matches all parts of a JSON document that have a member `"exclude"` where the value is an array of items.
-
-[See it live on Sourcegraph's code ↗](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24++%22exclude%22:+%5B...%5D+lang:json+file:tsconfig.json&patternType=structural)
 
 ### Current functionality and configuration
 


### PR DESCRIPTION
We remove the links because structural search will be disabled on .com and the links will not work anymore.