### PR TITLE
Fix docs in Admin Repo Permissions

### DIFF
--- a/docs/admin/permissions/index.mdx
+++ b/docs/admin/permissions/index.mdx
@@ -15,7 +15,7 @@ Imagine a scenario, with 2 users, `alice` and `bob`:
 - There is a public repository `my-organisation/public`
 - All of the mentioned repositories are synced to Sourcegraph
 
-With permissions set up, when `alice` tries to run a search on Sourcegraph, the results will only contain data from the public `my-organisation/global` repository and the ones she has access to (`my-organisation/global` and `my-organisation/alice`). `alice` will not be able to see results from the `my-organisation/docs`. If `alice` creates a code insight, she will only see results from the repositories she has access to.
+With permissions set up, when `alice` tries to run a search on Sourcegraph, the results will only contain data from the public `my-organisation/public` repository and the ones she has access to (`my-organisation/global` and `my-organisation/alice`). `alice` will not be able to see results from the `my-organisation/docs`. If `alice` creates a code insight, she will only see results from the repositories she has access to.
 
 Same for `bob`, the search results or any other feature will not show him the existence of `my-organisation/alice` repository on Sourcegraph, since `bob` does not have access to it on the code host.
 


### PR DESCRIPTION
Fix docs in Admin Repo Permissions.

## Reference

- https://sourcegraph.slack.com/archives/C01DXLN3D0T/p1705555658168439

## Test Plan

No plan needed for docs