### PR TITLE
updates to cloud trials

### DIFF
--- a/docs/cloud/index.mdx
+++ b/docs/cloud/index.mdx
@@ -7,20 +7,12 @@ Sourcegraph provisions each instance in an isolated and secure cloud environment
 ## Start a Sourcegraph Cloud trial
 
 <QuickLinks>
-  <QuickLink title="Get single-tenant instance managed by Sourcegraph." icon='lightbulb' href="https://about.sourcegraph.com/get-started?t=enterprise" description="Sign up and get a 30 day free trial for your team." />
+  <QuickLink title="Get single-tenant instance managed by Sourcegraph." icon='lightbulb' href="https://about.sourcegraph.com/get-started?t=enterprise" description="Sign up for a free trial for your team." />
 </QuickLinks>
 
-Use the button above to sign up for a free 15-day trial of Sourcegraph Cloud. Please [contact us](https://sourcegraph.com/contact/sales) if you have specific VPN requirements or you require a large deployment with >500 users, >1,000 repos, or monorepos >5 GB.
+Use the button above to sign up for a free trial of Sourcegraph Cloud. When you request a trial, you will receive an email indicating the status of your request. If eligible for a cloud instance, you will receive a link to the instance URL once it's provisioned. This normally takes less than one hour during business hours. From there, we recommend using the [onboarding checklist](../getting-started/cloud-instance.md) to set up your instance quickly.
 
-### Trial limitations
-
-We currently have a limited capacity of single-tenant cloud instances and are prioritizing organizations with more than 100 developers. When you request a trial, you will receive an email indicating the status of your request.
-
-If your organization has fewer than 100 developers, we recommend trying [Sourcegraph self-hosted](https://docs.sourcegraph.com/#self-hosted).
-
-If you're eligible for a cloud instance, you will receive a link to the instance URL once it's provisioned. This normally takes less than one hour during business hours. From there, we recommend using the [onboarding checklist](../getting-started/cloud-instance.md) to set up your instance quickly.
-
-Trials last 15 days. When the end of the trial approaches, Sourcegraph's Customer Support team will check in with you to either help you set up a Cloud subscription or end your trial.
+Please [contact us](https://sourcegraph.com/contact/sales) if you have specific VPN requirements or you require a large deployment with >500 users, >1,000 repos, or monorepos >5 GB.
 
 ## Cloud subscription
 
@@ -28,7 +20,6 @@ As part of this service you will receive a number of benefits from our team, inc
 
 ### Initial setup, configuration, and cost estimation
 
-- Advising if managed instances are right for your organization.
 - Initial resource estimations based on your organization & code size.
 - Putting forward a transparent deployment & cost estimate plan.
 - Your own `example.sourcegraphcloud.com` domain with fully managed [DNS & HTTPS](/admin/http_https_configuration). Optionally, you can [bring your own domain](#custom-domain).
@@ -40,11 +31,13 @@ As part of this service you will receive a number of benefits from our team, inc
 
 ### Access to all Sourcegraph features
 
-All Sourcegraph features are avilable on Sourcegraph Cloud instances out-of-the-box, including but not limited to:
+All of Sourcegraph's features are available on Sourcegraph Cloud instances out-of-the-box, including but not limited to:
 
+- [Cody](../cody/index.mdx)
 - [Server-side Batch Changes](/batch_changes/explanations/server_side)
 - [Precise code navigation powered by auto-indexing](/code_navigation/explanations/auto_indexing)
 - [Code Monitoring](/code_monitoring/) (including [email delivery](#managed-smtp) of notifications)
+- [Code Insights](../code_insights/index.mdx)
 
 ### Access restrictions
 
@@ -157,41 +150,6 @@ By default, emails will be sent from an `@cloud.sourcegraph.com` email address. 
 To opt out of managed SMTP, please let your Sourcegraph Account team know when requesting a trial. You can also opt out by [overriding the managed `email.address` and `email.smtp` configuration with your own in site configuration](/admin/config/email). If you have specific requests for managed SMTP, please [reach out regarding special requirements](#accommodating-special-requirements).
 
 To learn more about how the Sourcegraph team operates managed SMTP internally, refer to [our handbook](https://handbook.sourcegraph.com/departments/cloud/technical-docs/managed-smtp/).
-
-### Cody
-
-Cody is an AI coding assistant that lives in your editor that can find, explain, and write code. Cody uses a combination of Large Language Models (LLMs), Sourcegraph search, and Sourcegraph code intelligence to provide answers that eliminate toil and keep human programmers in flow. You can think of Cody as your programmer buddy who has read through all the code in open source, all the questions on StackOverflow, and all your organization's private code, and is always there to answer questions you might have or suggest ways of doing something based on prior knowledge. Learn more from [Cody documentation](/cody/overview/) about how Cody can help you.
-
-On Cloud, Cody can be enabled by contacting your Sourcegraph account team. Once Cody has been enabled by us, you can follow the instruction below to try it out.
-
-#### Step 1: Configure the VS Code extension
-
-Now that Cody is turned on on your Sourcegraph Cloud instance, any user can configure and use the Cody VS Code extension. This does not require admin privilege.
-
-1. If you currently have a previous version of Cody installed, uninstall it and reload VS Code before proceeding to the next steps.
-1. Search for “Sourcegraph Cody” in your VS Code extension marketplace, and install it.
-
-<img width="500" alt="image" src="https://user-images.githubusercontent.com/25070988/227508342-cc6f29c0-ed91-4381-b651-16870c7c676b.png" />
-
-3. Reload VS Code, and open the Cody extension. Review and accept the terms.
-
-4. Now you'll need to point the Cody extension to your Sourcegraph instance. On your instance, go to `settings` / `access token` (`https://<your-instance>.sourcegraphcloud.com/users/<your-username>/settings/tokens`). Generate an access token, copy it, and set it in the Cody extension.
-
-<img width="1369" alt="image" src="https://user-images.githubusercontent.com/25070988/227510686-4afcb1f9-a3a5-495f-b1bf-6d661ba53cce.png" />
-
-5. In the Cody VS Code extension, set your instance URL and the access token
-
-<img width="553" alt="image" src="https://user-images.githubusercontent.com/25070988/227510233-5ce37649-6ae3-4470-91d0-71ed6c68b7ef.png" />
-
-You're all set!
-
-#### Step 2: Try Cody!
-
-A few things you can ask Cody:
-
-- "What are popular go libraries for building CLIs?"
-- Open your workspace, and ask "Do we have a React date picker component in this repository?"
-- Right click on a function, and ask Cody to explain it
 
 ## Requirements
 

--- a/docs/cloud/index.mdx
+++ b/docs/cloud/index.mdx
@@ -37,7 +37,7 @@ All of Sourcegraph's features are available on Sourcegraph Cloud instances out-o
 - [Server-side Batch Changes](/batch_changes/explanations/server_side)
 - [Precise code navigation powered by auto-indexing](/code_navigation/explanations/auto_indexing)
 - [Code Monitoring](/code_monitoring/) (including [email delivery](#managed-smtp) of notifications)
-- [Code Insights](../code_insights/index.mdx)
+- [Code Insights](/code_insights/)
 
 ### Access restrictions
 

--- a/docs/cloud/index.mdx
+++ b/docs/cloud/index.mdx
@@ -33,7 +33,7 @@ As part of this service you will receive a number of benefits from our team, inc
 
 All of Sourcegraph's features are available on Sourcegraph Cloud instances out-of-the-box, including but not limited to:
 
-- [Cody](../cody/index.mdx)
+- [Cody](/cody)
 - [Server-side Batch Changes](/batch_changes/explanations/server_side)
 - [Precise code navigation powered by auto-indexing](/code_navigation/explanations/auto_indexing)
 - [Code Monitoring](/code_monitoring/) (including [email delivery](#managed-smtp) of notifications)


### PR DESCRIPTION
This PR does the following:

1. Updates to cloud trial language, removing previous restrictions and reference to 30 day trials (account team will align on timeline)
2. Updates references to features compatible with cloud
3. Removes section on Cody and instead directs user to Cody pages