### PR TITLE
Deemphasizing Kustomize over Helm and minor doc updates

### DIFF
--- a/docs/admin/audit_log.mdx
+++ b/docs/admin/audit_log.mdx
@@ -2,7 +2,7 @@
 
 ## Philosophy
 
-The audit log will capture all critical events that affect entities of interest within Sourcegraph services. The audit log is built on top of our [logging standard](https://docs.sourcegraph.com/dev/how-to/add_logging), using structured logs as the base building block. Every captured entry is aligned with the following design mantra:
+The audit log will capture all critical events that affect entities of interest within Sourcegraph services. The audit log is built on top of our [logging standard](https://sourcegraph.com/docs/dev/how-to/add_logging), using structured logs as the base building block. Every captured entry is aligned with the following design mantra:
 
 > Actor takes action on an entity within a context
 

--- a/docs/admin/deploy/index.mdx
+++ b/docs/admin/deploy/index.mdx
@@ -45,15 +45,13 @@ Sourcegraph provides an install script that can deploy Sourcegraph instances to 
 
 **For large Enterprises that require a multi-node, self-hosted solution.**
 
-- **Kustomize** utilizes the built-in features of kubectl to provide maximum flexibility in configuring your deployment
 - **Helm** offers a simpler deployment process but with less customization flexibility
-
-We highly recommend deploying Sourcegraph on Kubernetes with Kustomize due to the flexibility it provides.
+- **Kustomize** utilizes the built-in features of kubectl to provide maximum flexibility in configuring your deployment
 
 <QuickLinks>
 
-<QuickLink title="Kustomize" icon='lightbulb' href="/admin/deploy/kubernetes" />
 <QuickLink title="Helm" icon='theming' href="/admin/deploy/kubernetes/helm" />
+<QuickLink title="Kustomize" icon='lightbulb' href="/admin/deploy/kubernetes" />
 
 </QuickLinks>
 

--- a/docs/admin/deploy/index.mdx
+++ b/docs/admin/deploy/index.mdx
@@ -45,8 +45,8 @@ Sourcegraph provides an install script that can deploy Sourcegraph instances to 
 
 **For large Enterprises that require a multi-node, self-hosted solution.**
 
-- **Helm** offers a simpler deployment process but with less customization flexibility
-- **Kustomize** utilizes the built-in features of kubectl to provide maximum flexibility in configuring your deployment
+- **Helm** utilizes pre-packaged charts for templating Sourcegraph deployments
+- **Kustomize** utilizes built-in features of kubectl for configuring Sourcegraph deployments
 
 <QuickLinks>
 

--- a/docs/admin/deploy/scale.mdx
+++ b/docs/admin/deploy/scale.mdx
@@ -124,7 +124,7 @@ A PostgreSQL instance for storing code insights data.
 | `Type`      | Persistent Volumes for Kubernetes                                          |
 |             | Persistent SSD for Docker Compose                                          |
 
-> WARNING: The database must be configured properly to consume resources effectively and efficiently for better performance and to avoid regular usage from overwhelming built-in utilities (like autovacuum for example). For example, a Postgres database running out of memory indicates that it is currently misconfigured and the amount of memory each worker can utilize should be reduced. See our [Postgres database configuration guide](https://docs.sourcegraph.com/admin/config/postgres-conf) for more information.
+> WARNING: The database must be configured properly to consume resources effectively and efficiently for better performance and to avoid regular usage from overwhelming built-in utilities (like autovacuum for example). For example, a Postgres database running out of memory indicates that it is currently misconfigured and the amount of memory each worker can utilize should be reduced. See our [Postgres database configuration guide](https://sourcegraph.com/docs/admin/config/postgres-conf) for more information.
 
 ---
 
@@ -168,7 +168,7 @@ A PostgreSQL instance for storing large-volume code graph data.
 | `Type`      | Persistent Volumes for Kubernetes                                            |
 |             | Persistent SSD for Docker Compose                                            |
 
-> WARNING: The database must be configured properly to consume resources effectively and efficiently for better performance and to avoid regular usage from overwhelming built-in utilities (like autovacuum for example). For example, a Postgres database running out of memory indicates that it is currently misconfigured and the amount of memory each worker can utilize should be reduced. See our [Postgres database configuration guide](https://docs.sourcegraph.com/admin/config/postgres-conf) for more information.
+> WARNING: The database must be configured properly to consume resources effectively and efficiently for better performance and to avoid regular usage from overwhelming built-in utilities (like autovacuum for example). For example, a Postgres database running out of memory indicates that it is currently misconfigured and the amount of memory each worker can utilize should be reduced. See our [Postgres database configuration guide](https://sourcegraph.com/docs/admin/config/postgres-conf) for more information.
 
 ---
 
@@ -336,13 +336,13 @@ Basically anything not related to code-intel.
 | :---------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Overview`  | Executes queries                                                                                                                                                                        |
 | `Factors`   | The default setup should be sufficient for most deployments                                                                                                                             |
-| `Guideline` | The database must be configured properly following our [Postgres configuration guide](https://docs.sourcegraph.com/admin/config/postgres-conf)to use the assigned resources efficiently |
+| `Guideline` | The database must be configured properly following our [Postgres configuration guide](https://sourcegraph.com/docs/admin/config/postgres-conf)to use the assigned resources efficiently |
 
 | Memory      |                                                                                                                                                                                         |
 | :---------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Overview`  | Linear to the concurrent number of API requests proxied                                                                                                                                 |
 | `Factors`   | The default setup should be sufficient for most deployments                                                                                                                             |
-| `Guideline` | The database must be configured properly following our [Postgres configuration guide](https://docs.sourcegraph.com/admin/config/postgres-conf)to use the assigned resources efficiently |
+| `Guideline` | The database must be configured properly following our [Postgres configuration guide](https://sourcegraph.com/docs/admin/config/postgres-conf)to use the assigned resources efficiently |
 
 | Storage     |                                                                                                                                                                                         |
 | :---------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -350,11 +350,11 @@ Basically anything not related to code-intel.
 | `Factors`   | Size of all repositories                                                                                                                                                                |
 |             | Number of insight queries                                                                                                                                                               |
 | `Guideline` | Starts at default as the value grows depending on the number of active users and activity                                                                                               |
-|             | The database must be configured properly following our [Postgres configuration guide](https://docs.sourcegraph.com/admin/config/postgres-conf)to use the assigned resources efficiently |
+|             | The database must be configured properly following our [Postgres configuration guide](https://sourcegraph.com/docs/admin/config/postgres-conf)to use the assigned resources efficiently |
 | `Type`      | Persistent Volumes for Kubernetes                                                                                                                                                       |
 |             | Persistent SSD for Docker Compose                                                                                                                                                       |
 
-> WARNING: The database must be configured properly to consume resources effectively and efficiently for better performance and to avoid regular usage from overwhelming built-in utilities (like autovacuum for example). For example, a Postgres database running out of memory indicates that it is currently misconfigured and the amount of memory each worker can utilize should be reduced. See our [Postgres database configuration guide](https://docs.sourcegraph.com/admin/config/postgres-conf) for more information.
+> WARNING: The database must be configured properly to consume resources effectively and efficiently for better performance and to avoid regular usage from overwhelming built-in utilities (like autovacuum for example). For example, a Postgres database running out of memory indicates that it is currently misconfigured and the amount of memory each worker can utilize should be reduced. See our [Postgres database configuration guide](https://sourcegraph.com/docs/admin/config/postgres-conf) for more information.
 
 ---
 
@@ -641,7 +641,7 @@ An HTTP server that exposes the Rust Syntect syntax highlighting library to othe
 Runs a collection of background jobs periodically in response to internal requests and external events.
 ```
 
-> NOTE: See the docs on [Worker services](https://docs.sourcegraph.com/admin/workers#worker-jobs) for a list of worker jobs.
+> NOTE: See the docs on [Worker services](https://sourcegraph.com/docs/admin/workers#worker-jobs) for a list of worker jobs.
 
 | Replica     |                                                         |
 | :---------- | :------------------------------------------------------ |

--- a/docs/admin/deploy/scale.mdx
+++ b/docs/admin/deploy/scale.mdx
@@ -168,7 +168,7 @@ A PostgreSQL instance for storing large-volume code graph data.
 | `Type`      | Persistent Volumes for Kubernetes                                            |
 |             | Persistent SSD for Docker Compose                                            |
 
-> WARNING: The database must be configured properly to consume resources effectively and efficiently for better performance and to avoid regular usage from overwhelming built-in utilities (like autovacuum for example). For example, a Postgres database running out of memory indicates that it is currently misconfigured and the amount of memory each worker can utilize should be reduced. See our [Postgres database configuration guide](https://sourcegraph.com/docs/admin/config/postgres-conf) for more information.
+<Callout type="warning"> The database must be configured properly to consume resources effectively and efficiently for better performance and to avoid regular usage from overwhelming built-in utilities (like autovacuum for example). For example, a Postgres database running out of memory indicates that it is currently misconfigured, and the amount of memory each worker can utilize should be reduced. See our [Postgres database configuration guide](/admin/config/postgres-conf) for more information.</Callout>
 
 ---
 

--- a/docs/admin/deploy/scale.mdx
+++ b/docs/admin/deploy/scale.mdx
@@ -641,7 +641,7 @@ An HTTP server that exposes the Rust Syntect syntax highlighting library to othe
 Runs a collection of background jobs periodically in response to internal requests and external events.
 ```
 
-> NOTE: See the docs on [Worker services](https://sourcegraph.com/docs/admin/workers#worker-jobs) for a list of worker jobs.
+<Callout type="note"> See the docs on [Worker services](https://sourcegraph.com/docs/admin/workers#worker-jobs) for a list of worker jobs.</Callout>
 
 | Replica     |                                                         |
 | :---------- | :------------------------------------------------------ |

--- a/docs/admin/deploy/scale.mdx
+++ b/docs/admin/deploy/scale.mdx
@@ -11,7 +11,7 @@ Scaling is unnecessary if your resource usage is kept below 80%.
 
 For example, if you plan to add 100% more engaged users, and the resource usage for all services is currently at around 70%, we’d recommend using this documentation as a reference to adjust the resources that list “Number of active users” as one of their scaling factors. You can also use the output from the Resource Estimator as references alternatively.
 
-> NOTE: For assistance when scaling and tuning Sourcegraph, [contact us](https://about.sourcegraph.com/contact/). We're happy to help!
+<Callout type="note"> For assistance when scaling and tuning Sourcegraph, [contact us](https://sourcegraph.com/contact/). We're happy to help!</Callout>
 
 ---
 
@@ -76,7 +76,7 @@ It exports container monitoring metrics scraped by Prometheus and visualized in 
 | :---------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Overview`  | Scaling is not necessary as it is designed to be a small footprint service                                                                                                  |
 | `Factors`   | Its primary traffic are the requests coming from Prometheus                                                                                                                 |
-| `Guideline` | Read [the list of known issues](https://docs.sourcegraph.com/dev/background-information/observability/cadvisor#known-issues) that can cause performance issues for cAdvisor |
+| `Guideline` | Read [the list of known issues](/dev/background-information/observability/cadvisor#known-issues) that can cause performance issues for cAdvisor |
 
 ---
 
@@ -276,7 +276,7 @@ A Jaeger instance for end-to-end distributed tracing
 | `Factors`   | Number of Site Admins                                                                                  |
 | `Guideline` | Memory depends on the size of buffers, like the number of traces and the size of the queue for example |
 
-> NOTE: The jaeger service does not have to be enabled for Sourcegraph work, however, the ability to troubleshoot the system will be disabled.
+<Callout type="note"> The jaeger service does not have to be enabled for Sourcegraph work, however, the ability to troubleshoot the system will be disabled.</Callout>
 
 ---
 
@@ -336,13 +336,13 @@ Basically anything not related to code-intel.
 | :---------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Overview`  | Executes queries                                                                                                                                                                        |
 | `Factors`   | The default setup should be sufficient for most deployments                                                                                                                             |
-| `Guideline` | The database must be configured properly following our [Postgres configuration guide](https://sourcegraph.com/docs/admin/config/postgres-conf)to use the assigned resources efficiently |
+| `Guideline` | The database must be configured properly following our [Postgres configuration guide](/admin/config/postgres-conf) to use the assigned resources efficiently |
 
 | Memory      |                                                                                                                                                                                         |
 | :---------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Overview`  | Linear to the concurrent number of API requests proxied                                                                                                                                 |
 | `Factors`   | The default setup should be sufficient for most deployments                                                                                                                             |
-| `Guideline` | The database must be configured properly following our [Postgres configuration guide](https://sourcegraph.com/docs/admin/config/postgres-conf)to use the assigned resources efficiently |
+| `Guideline` | The database must be configured properly following our [Postgres configuration guide](/admin/config/postgres-conf) to use the assigned resources efficiently |
 
 | Storage     |                                                                                                                                                                                         |
 | :---------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -350,11 +350,11 @@ Basically anything not related to code-intel.
 | `Factors`   | Size of all repositories                                                                                                                                                                |
 |             | Number of insight queries                                                                                                                                                               |
 | `Guideline` | Starts at default as the value grows depending on the number of active users and activity                                                                                               |
-|             | The database must be configured properly following our [Postgres configuration guide](https://sourcegraph.com/docs/admin/config/postgres-conf)to use the assigned resources efficiently |
+|             | The database must be configured properly following our [Postgres configuration guide](/admin/config/postgres-conf) to use the assigned resources efficiently |
 | `Type`      | Persistent Volumes for Kubernetes                                                                                                                                                       |
 |             | Persistent SSD for Docker Compose                                                                                                                                                       |
 
-> WARNING: The database must be configured properly to consume resources effectively and efficiently for better performance and to avoid regular usage from overwhelming built-in utilities (like autovacuum for example). For example, a Postgres database running out of memory indicates that it is currently misconfigured and the amount of memory each worker can utilize should be reduced. See our [Postgres database configuration guide](https://sourcegraph.com/docs/admin/config/postgres-conf) for more information.
+<Callout type="warning"> The database must be configured properly to consume resources effectively and efficiently for better performance and to avoid regular usage from overwhelming built-in utilities (like autovacuum for example). For example, a Postgres database running out of memory indicates that it is currently misconfigured and the amount of memory each worker can utilize should be reduced. See our [Postgres database configuration guide](/admin/config/postgres-conf) for more information.</Callout>
 
 ---
 
@@ -557,7 +557,7 @@ It relies on the OS file page cache to speed up future searches
 |             | The request size of the ephemeral storage is used as a limit for the zip cache |
 |             | Non-persistent SSD for Docker Compose                                          |
 
-> NOTE: For example, if you search all branches on all repositories, that translates into lots of concurrent unindexed requests.
+<Callout type="note"> For example, if you search all branches on all repositories, that translates into lots of concurrent unindexed requests.</Callout>
 
 ---
 
@@ -597,7 +597,7 @@ Indexes symbols in repositories using Ctags.
 | `Type`      | Ephemeral storage for Kubernetes deployments                                                                         |
 |             | Non-persistent SSD for Docker Compose                                                                                |
 
-> NOTE: If Rockskip is enabled, the symbols for repositories indexed by Rockskip are stored in codeintel-db instead.
+<Callout type="note"> If Rockskip is enabled, the symbols for repositories indexed by [Rockskip](/code_navigation/explanations/rockskip) are stored in codeintel-db instead.</Callout>
 
 ---
 
@@ -641,7 +641,7 @@ An HTTP server that exposes the Rust Syntect syntax highlighting library to othe
 Runs a collection of background jobs periodically in response to internal requests and external events.
 ```
 
-<Callout type="note"> See the docs on [Worker services](https://sourcegraph.com/docs/admin/workers#worker-jobs) for a list of worker jobs.</Callout>
+<Callout type="note"> See the docs on [Worker services](/admin/workers#worker-jobs) for a list of worker jobs.</Callout>
 
 | Replica     |                                                         |
 | :---------- | :------------------------------------------------------ |
@@ -683,7 +683,7 @@ Lives inside the indexed-search pod in a Kubernetes deployment.
 The main guideline for scaling a zoekt-indexserver is the size of your largest repository.
 ```
 
-> NOTE: As indexserver currently only indexes one repository at a time, having more CPU and memory are not as important here than in webserver.
+<Callout type="note"> As indexserver currently only indexes one repository at a time, having more CPU and memory are not as important here than in webserver.</Callout>
 
 | Replica     |                                                       |
 | :---------- | :---------------------------------------------------- |
@@ -714,7 +714,7 @@ The main guideline for scaling a zoekt-indexserver is the size of your largest r
 | `Type`      | Persistent Volumes for Kubernetes                                     |
 |             | Persistent SSD for Docker Compose                                     |
 
-> WARNING: We recommend providing zoekt-indexserver with more resources when trying to add a lot of new repositories that requires indexing from a new external service, and then scale down once indexing is completed.
+<Callout type="warning"> We recommend providing zoekt-indexserver with more resources when trying to add a lot of new repositories that requires indexing from a new external service, and then scale down once indexing is completed.</Callout>
 
 ---
 
@@ -727,7 +727,7 @@ The indexes are persisted to disk to avoid re-indexing on startup.
 Lives inside the indexed-search pod in a Kubernetes deployment.
 ```
 
-> NOTE: Adding more CPU and memory helps speed up searches.
+<Callout type="note"> Adding more CPU and memory helps speed up searches.</Callout>
 
 | Replica     |                                                         |
 | :---------- | :------------------------------------------------------ |
@@ -763,6 +763,6 @@ Lives inside the indexed-search pod in a Kubernetes deployment.
 | `Type`      | Persistent Volumes for Kubernetes                                     |
 |             | Persistent SSD for Docker Compose                                     |
 
-> WARNING: Check the peak bursts rather than the average over time when monitoring CPU usage for zoekt as it depends on when the searches happen.
+<Callout type="warning"> Check the peak bursts rather than the average over time when monitoring CPU usage for zoekt as it depends on when the searches happen.</Callout>
 
 ---

--- a/docs/admin/deploy/scale.mdx
+++ b/docs/admin/deploy/scale.mdx
@@ -124,7 +124,7 @@ A PostgreSQL instance for storing code insights data.
 | `Type`      | Persistent Volumes for Kubernetes                                          |
 |             | Persistent SSD for Docker Compose                                          |
 
-> WARNING: The database must be configured properly to consume resources effectively and efficiently for better performance and to avoid regular usage from overwhelming built-in utilities (like autovacuum for example). For example, a Postgres database running out of memory indicates that it is currently misconfigured and the amount of memory each worker can utilize should be reduced. See our [Postgres database configuration guide](https://sourcegraph.com/docs/admin/config/postgres-conf) for more information.
+<Callout type="warning">The database must be configured properly to consume resources effectively and efficiently for better performance and to avoid regular usage from overwhelming built-in utilities (like autovacuum for example). For example, a Postgres database running out of memory indicates that it is currently misconfigured, and the amount of memory each worker can utilize should be reduced. See our [Postgres database configuration guide](/admin/config/postgres-conf) for more information.</Callout>
 
 ---
 

--- a/docs/admin/executors/deploy_executors_kubernetes.mdx
+++ b/docs/admin/executors/deploy_executors_kubernetes.mdx
@@ -30,7 +30,7 @@ at [`sourcegraph/executor-kubernetes`](https://hub.docker.com/r/sourcegraph/exec
 ### Environment Variables
 
 The following are Environment Variables that are specific to the Kubernetes deployment method. These environment variables can be
-set on the Executor `Deployment` and will configure the `Job`s that it spawns. Executor environmnet variables can also be defined on a Kubernetes `ConfigMap` or `Secret` that is [mounted to the executor deployment](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables).
+set on the Executor `Deployment` and will configure the `Job`s that it spawns. Executor environment variables can also be defined on a Kubernetes `ConfigMap` or `Secret` that is [mounted to the executor deployment](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables).
 
 |                             Name                             |   Default Value   |                                                                                              Description                                                                                               |
 | ------------------------------------------------------------ | :---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/docs/admin/pings.mdx
+++ b/docs/admin/pings.mdx
@@ -245,7 +245,7 @@ Sourcegraph telemetry pings are handled by a goroutine running on Sourcegraphs f
 
 
 ### Misconfigured update.channel
-The most common scenario in which Sourcegraph stops sending pings is a change to the `update.channel` setting in an instance's [site config](https://docs.sourcegraph.com/admin/config/site_config)
+The most common scenario in which Sourcegraph stops sending pings is a change to the `update.channel` setting in an instance's [site config](https://sourcegraph.com/docs/admin/config/site_config)
 ```
 "update.channel": "release",
 ```

--- a/docs/admin/repo/auth.mdx
+++ b/docs/admin/repo/auth.mdx
@@ -32,7 +32,7 @@ In Sourcegraph 5.1.0 and later, the insecure SSH rsa-sha1 signature algorithm is
 
 If you use an RSA SSH key to authenticate to your code host, you should ensure that your code host runs OpenSSL 7.2 or newer.
 
-If it is not possible to update the code host, you should generate a new ed25519 SSH key to use for authentication. This can be achieved by running `ssh-keygen -t ed25519`, and [configuring Sourcegraph](https://docs.sourcegraph.com/admin/repo/git_config) to use this new key.
+If it is not possible to update the code host, you should generate a new ed25519 SSH key to use for authentication. This can be achieved by running `ssh-keygen -t ed25519`, and [configuring Sourcegraph](https://sourcegraph.com/docs/admin/repo/git_config) to use this new key.
 
 ### Error: `Host key verification failed`
 


### PR DESCRIPTION
- removed suggestion that customers should select kustomize over helm for Kubernetes based deployments
- small typo fix in k8s executor documentation
- updated a number of links that redirect users to the old https://docs.sourcegraph.com docsite