### PR TITLE
Add new auth token settings

### DIFF
--- a/docs/admin/config/site_config.mdx
+++ b/docs/admin/config/site_config.mdx
@@ -817,7 +817,7 @@ All site configuration options and their default values are shown below.
 		"expirationOptionDays": [7,14,30,60,90],
     	"defaultExpirationDays": 90,
 		"allowNoExpiration": false,
-		"maxTokensPerUser: 25
+		"maxTokensPerUser": 25
 	},
 	// Other example values:
 	// - {"allow":"site-admin-create"}

--- a/docs/admin/config/site_config.mdx
+++ b/docs/admin/config/site_config.mdx
@@ -813,7 +813,11 @@ All site configuration options and their default values are shown below.
 
 	// Settings for access tokens, which enable external tools to access the Sourcegraph API with the privileges of the user.
 	"auth.accessTokens": {
-		"allow": "all-users-create"
+		"allow": "all-users-create",
+		"expirationOptionDays": [7,14,30,60,90],
+    	"defaultExpirationDays": 90,
+		"allowNoExpiration": false,
+		"maxTokensPerUser: 25
 	},
 	// Other example values:
 	// - {"allow":"site-admin-create"}

--- a/docs/cli/how-tos/creating_an_access_token.mdx
+++ b/docs/cli/how-tos/creating_an_access_token.mdx
@@ -15,7 +15,7 @@ Creating an access token is done through your user settings. This video shows th
 5. Enter a description, such as `src`.
 
     > NOTE: The `user:all` scope that is selected by default is sufficient for all normal `src` usage, and most uses of the GraphQL API. If you're an admin, you should only enable `site-admin:sudo` if you intend to impersonate other users.
-6. Select a duration for the validity of the access token.  
+6. Select how long the access token should remain valid.  
 7. Click **Generate token**.
 8. Sourcegraph will now display your access token. You **must copy it from this screen**: once this page is closed, you cannot access the token again and can only revoke it and issue a new one.
 

--- a/docs/cli/how-tos/creating_an_access_token.mdx
+++ b/docs/cli/how-tos/creating_an_access_token.mdx
@@ -15,7 +15,8 @@ Creating an access token is done through your user settings. This video shows th
 5. Enter a description, such as `src`.
 
     > NOTE: The `user:all` scope that is selected by default is sufficient for all normal `src` usage, and most uses of the GraphQL API. If you're an admin, you should only enable `site-admin:sudo` if you intend to impersonate other users.
-6. Click **Generate token**.
-7. Sourcegraph will now display your access token. You **must copy it from this screen**: once this page is closed, you cannot access the token again and can only revoke it and issue a new one.
+6. Select a duration for the validity of the access token.  
+7. Click **Generate token**.
+8. Sourcegraph will now display your access token. You **must copy it from this screen**: once this page is closed, you cannot access the token again and can only revoke it and issue a new one.
 
 You can then set [the `SRC_ACCESS_TOKEN` environment variable](/cli/explanations/env) to the token to use it with `src`.


### PR DESCRIPTION
Adds examples of the default new auth token settings values to the tokens docs.  Also updates the steps to create an access token to select the validity period.

closes https://github.com/sourcegraph/sourcegraph/issues/59774
