### PR TITLE
Remove the context.codebase custom command property

### DIFF
--- a/docs/cody/capabilities/commands.mdx
+++ b/docs/cody/capabilities/commands.mdx
@@ -213,12 +213,6 @@ See the [examples](#examples) and [configuration properties](#configuration-prop
 - Type: `object`
 - Default: `{ "codebase": true }`
 
-#### `commands.<id>.context.codebase`
-
-- Include embeddings and/or keyword code search (depending on availability)
-- Type: `boolean`
-- Default: `true`
-
 #### `commands.<id>.context.command`
 
 - Terminal command to run and include the output of


### PR DESCRIPTION
This property is being removed in Cody for VS Code v1.2.0

Related:
- https://github.com/sourcegraph/cody/pull/2892
- https://github.com/sourcegraph/cody/pull/2848