### PR TITLE
Add section about StarCoder for Enterprise

### DIFF
--- a/docs/cody/clients/enable-cody-enterprise.mdx
+++ b/docs/cody/clients/enable-cody-enterprise.mdx
@@ -129,6 +129,29 @@ In Sourcegraph 5.2 and earlier, you should use the feature flag `cody` to turn C
 />
 
 
+## Use StarCoder for Autocomplete
+
+Over the past months, we've run extensive tests comparing many coder models for the Autocomplete use case and found that StarCoder offers significant improvements in both quality as well as latency for our users on Sourcegraph.com. You can read about the improvements in [October 2023 release notes](https://sourcegraph.com/blog/feature-release-october-2023) and the [GA release notes](https://sourcegraph.com/blog/cody-is-generally-available).
+
+To be able to offer our Enterprise users the best experience for Cody Autocomplete, we have partnered with [Fireworks](https://fireworks.ai/) and have set up an enterprise-grade deployment with dedicated hardware capacity. Since Sourcegraph 5.3, every Cody setup that uses Cody Gateway is able to opt-in to using [StarCoder](https://huggingface.co/blog/starcoder) as an alternative to Claude Instant as the AI model for Autocomplete.
+
+To enable StarCoder go to **Site admin > Site configuration** (`/site-admin/configuration`) and change the `completionModel`:
+
+```json
+{
+  // [...]
+  "cody.enabled": true,
+  "completions": {
+    "provider": "sourcegraph",
+    "completionModel": "fireworks/starcoder"
+  }
+}
+```
+
+Clients will automatically pick up this change when they connect to your Enterprise instance.
+
+We highly recommend every instance admin to make this change and plan to make this the default in a future release.
+
 ## Using a third-party LLM provider
 
 Instead of [Sourcegraph Cody Gateway](/cody/core-concepts/cody-gateway), you can also configure Sourcegraph to use a third-party provider directly, like:


### PR DESCRIPTION
Adds a section about StarCoder for Enterprise. This should be shipped around the time we release 5.3. 

Ideally we have folks from the Cody Strat team also looking over the wording here. I’m happy to answer any questions, of course!