### PR TITLE
Rename crate in example error message

### DIFF
--- a/docs/dev/background-information/bazel/faq.mdx
+++ b/docs/dev/background-information/bazel/faq.mdx
@@ -313,17 +313,11 @@ Bazel uses a separate lock file to track the dependencies, which need to be upda
 ### `syntax-highlighter` fails to build and has the error `failed to resolve: use of undeclared crate or module`
 The error looks something like this:
 ```
-error[E0433]: failed to resolve: use of undeclared crate or module `scip_treesitter_languages`
-  --> docker-images/syntax-highlighter/src/main.rs:56:5
-   |
-56 |     scip_treesitter_languages::highlights::CONFIGURATIONS
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared crate or module `scip_treesitter_languages`
-
-error[E0433]: failed to resolve: use of undeclared crate or module `scip_treesitter_languages`
+error[E0433]: failed to resolve: use of undeclared crate or module `tree_sitter_all_languages`
   --> docker-images/syntax-highlighter/src/main.rs:57:15
    |
-57 |         .get(&scip_treesitter_languages::parsers::BundledParser::Go);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared crate or module `scip_treesitter_languages`
+57 |         .get(&tree_sitter_all_languages::ParserId::Go);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared crate or module `tree_sitter_all_languages`
 
 error: aborting due to 2 previous errors
 ```


### PR DESCRIPTION
Updated to reflect new naming scheme.
Simplifies the example error message too.