### PR TITLE
Update CHANGELOG.mdx

### DIFF
--- a/docs/CHANGELOG.mdx
+++ b/docs/CHANGELOG.mdx
@@ -2896,7 +2896,7 @@ This is `3.12.8` release with internal infrastructure fixes to publish the docke
 ### Fixed
 
 - The `/.auth/saml/metadata` endpoint has been fixed. Previously it panicked if no encryption key was set.
-- The version updating logic has been fixed for `sourcegraph/server`. Users running `sourcegraph/server:5.2.7` will need to manually modify their `docker run` command to use `sourcegraph/server:5.2.7` or higher. [#7442](https://github.com/sourcegraph/sourcegraph/issues/7442)
+- The version updating logic has been fixed for `sourcegraph/server`. Users running `sourcegraph/server:3.11.1` will need to manually modify their `docker run` command to use `sourcegraph/server:3.11.4` or higher. [#7442](https://github.com/sourcegraph/sourcegraph/issues/7442)
 
 ## 3.11.1
 


### PR DESCRIPTION
The batch change incorrectly updated the `CHANGELOG.mdx` during the `5.2.7` release.