### PR TITLE
Docs: Add search filters panel doc

### DIFF
--- a/docs/code-search/working/search_filters.mdx
+++ b/docs/code-search/working/search_filters.mdx
@@ -34,6 +34,8 @@ three search types
 
 If you want to search within some specific type, you can pick this type in the "By Type" filter section.
 
+**Note:** This is not the desired end state. We're exploring being able to display only code by default (currently `type:content'), but our currently support for `AND` and `OR` operators in the query doesn't sensible allow for this.
+
 ## 3. Search filters are not exhaustive
 
 By default, if your query has no `count:` filter Sourcegraph provides only 10k first results.
@@ -43,6 +45,8 @@ To increase this limit and make sure your query and filters are exhaustive, incl
 or select this option in the filter panel UI.
 
 ![Snippets are in the search side panel](https://storage.googleapis.com/sourcegraph-assets/Docs/search-filters-exhastive.png)
+
+**Note:** This is not the desired end state. We're working to move the `count` options from the filter panel into the results summary.
 
 ## 4. Move filters to the query
 

--- a/docs/code-search/working/search_filters.mdx
+++ b/docs/code-search/working/search_filters.mdx
@@ -34,7 +34,7 @@ three search types
 
 If you want to search within some specific type, you can pick this type in the "By Type" filter section.
 
-**Note:** This is not the desired end state. We're exploring being able to display only code by default (currently `type:content'), but our currently support for `AND` and `OR` operators in the query doesn't sensible allow for this.
+**Note:** This is not the desired end state. We're exploring being able to display only code by default (currently `type:content'), but our current support for `AND` and `OR` operators in the query doesn't sensibly allow for this.
 
 ## 3. Search filters are not exhaustive
 

--- a/docs/code-search/working/search_filters.mdx
+++ b/docs/code-search/working/search_filters.mdx
@@ -1,0 +1,65 @@
+# Search Filters
+
+This page provides docs about how Search Filters work with Sourcegraph.
+
+Search Query Syntax might not be that straightforward for new Sourcegraph users. It has a lot of
+query filters and operators, and it isn't easy sometimes to figure out how to use filters
+properly. With Search Filters UI, you can filter down your search results through the UI panel
+without manually modifying your query.
+
+![Search filters are in the search result side panel](https://storage.googleapis.com/sourcegraph-assets/Docs/search-results-with-filters.png)
+
+The search filters UI panel tries to represent most of the filters we have in the search query syntax,
+and it should be straightforward enough to use without any additional knowledge about search
+query filters. However, here is a short list of facts to help you use them more effectively.
+
+## 1. Search filters are built by provided search results
+
+All filters that you can see in the panel are calculated by search matches that Sourcegraph
+found based on your query. This means that your query doesn't return any symbols, diff or commit
+matches. There won't be a symbol, commit, diff related filters in the panel.
+
+## 2. Default search filters
+
+If you try to run a search query without any `type:` filters, Sourcegraph will search results within
+three search types
+
+- `type:content` matches within file content
+- `type:repo` matches with repositories names
+- `type:file` matches with file names
+
+![Snippets are in the search side panel](https://storage.googleapis.com/sourcegraph-assets/Docs/search-filters-by-type.png)
+
+If you want to search within some specific type, you can pick this type in the "By Type" filter section.
+
+## 3. Search filters are not exhaustive
+
+By default, if your query has no `count:` filter Sourcegraph provides only 10k first results.
+This means that it is possible that you won't see some repositories in the "By repository" section
+if the search result limit is hit, even if this repository exists on your Sourcegraph's instance.
+To increase this limit and make sure your query and filters are exhaustive, include `count:all` in your query
+or select this option in the filter panel UI.
+
+![Snippets are in the search side panel](https://storage.googleapis.com/sourcegraph-assets/Docs/search-filters-exhastive.png)
+
+## 4. Move filters to the query
+
+Selected filters are preserved in the URL so you can easily share URl with other Sourcegraph users,
+and they will see selected filters. However, search query is still our first-class entity in Sourcegraph's
+ecosystem (code monitoring, batch changes, code insights). There is a way to convert your selected filters
+into your query by clicking the "Move filters to the query" button.
+
+## 5. Filters are global
+
+`End query = Search Bar's query + Filters Panel UI query`
+
+The Filters panel works in a way that adds search query syntax filter operators to the original query
+in the search bar. This means that selected through filter UI panel filters are global, and  this
+works just fine with simple queries, but if your query has complex parts and contains multiple operands
+and has `AND` and/or `OR` operators, we suggest using filters UI panel with caution since it may produce
+incorrect query and possibly provide zero match results.
+
+For example if your original query is `(test1 repo:sourcegraph/sourcegraph) OR (test2 repo:sourcegraph/about)`
+and you select `sourcegraph/sourcegraph` filter in the filters UI panel this filter will be applied for both
+operands `test1 repo:sourcegraph/sourcegraph` and `test2 repo:sourcegraph/about`
+

--- a/docs/code-search/working/search_filters.mdx
+++ b/docs/code-search/working/search_filters.mdx
@@ -1,6 +1,8 @@
 # Search Filters
 
-This page provides docs about how Search Filters work with Sourcegraph.
+This page provides docs about how Search Filters UI works with Sourcegraph.
+Note: if you're looking for the filters search query syntax documentation you can find it in
+[search query syntax filters section](/code-search/queries#filters-all-searches)
 
 Search Query Syntax might not be that straightforward for new Sourcegraph users. It has a lot of
 query filters and operators, and it isn't easy sometimes to figure out how to use filters

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -98,6 +98,7 @@ export const navigation: NavigationItem[] = [
             title: "Working with Search", href: "/code-search/working/saved_searches",
             subsections: [
               { title: "Saved Search", href: "/code-search/working/saved_searches", },
+              { title: "Search Filters", href: "/code-search/working/search_filters", },
               { title: "Search Snippet", href: "/code-search/working/snippets", },
               { title: "Search Contexts", href: "/code-search/working/search_contexts", },
               { title: "Search Subexpressions", href: "/code-search/working/search_subexpressions", },


### PR DESCRIPTION
This PR adds some short documentation pages for the newly added feature - search filters UI panel. 

Todo 
- [x] Add initial search filters doc page
- [x] Upload images and graphics 
- [ ] Gather more cases about search filters limitations 
- [ ] Grammar and typo review  