### PR TITLE
doc: add entry for perform an entry

### DIFF
--- a/docs/code_navigation/explanations/features.mdx
+++ b/docs/code_navigation/explanations/features.mdx
@@ -194,4 +194,4 @@ Toggling line wrapping on and off helps optimize code readability depending on p
 
 Wrapped lines are visually indicated with a faint vertical line connecting the split sections. Hovering also reveals the full continuous line.
 
-Note: Line wrapping does not modify the actual code contents - it is purely a visual modification. Downloaded files will contain the original non-wrapped lines.
+<Callout type="note">Line wrapping does not modify the actual code contents - it is purely a visual modification. Downloaded files will contain the original non-wrapped lines.</Callout>

--- a/docs/code_navigation/explanations/features.mdx
+++ b/docs/code_navigation/explanations/features.mdx
@@ -90,7 +90,7 @@ When browsing code, you can perform the following actions:
 
 1. Ask Cody
 
-Cody is a free and open-core AI coding assistant that writes, fixes, and maintains your code, and is available on Sourcegraph. It allows you to ask natural language questions about your code and receive intelligent suggestions and explanations.
+Cody is a free and open-core AI coding assistant that writes, fixes, and maintains your code and is available on Sourcegraph. It allows you to ask natural language questions about your code and receive intelligent suggestions and explanations.
 
 When browsing code on Sourcegraph, you can ask Cody a question by clicking the **Ask Cody** button above the file you are viewing. This will open a chat interface where you can have a conversation with Cody about the code you are viewing.
 

--- a/docs/code_navigation/explanations/features.mdx
+++ b/docs/code_navigation/explanations/features.mdx
@@ -79,3 +79,119 @@ Once the symbols service has built an index for a commit, here's the query perfo
 - Path filtering `file:^cmd/` helps narrow the search space
 
 Search-based code navigation uses exact matches `^foo$` and the symbols sidebar uses prefix matches on paths `file:^cmd/` to respond quickly.
+
+### Perform an Action
+
+Code Search allows you to harness the power of Search and quickly find, discover and understand code. However, the end result isn't always to view the results of a search query, Code Search empowers you to perform an action given a set of result.
+
+![Code Search Actions](https://storage.googleapis.com/sourcegraph-assets/Docs/actions/code-search-actions.png)
+
+When browsing code, you can perform the following actions:
+
+1. Ask Cody
+
+Cody is a free and open-core AI coding assistant that writes, fixes, and maintains your code, and is available on Sourcegraph. It allows you to ask natural language questions about your code and receive intelligent suggestions and explanations.
+
+When browsing code on Sourcegraph, you can ask Cody a question by clicking the **Ask Cody** button above the file you are viewing. This will open a chat interface where you can have a conversation with Cody about the code you are viewing.
+
+<video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto' }}>
+    <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/code-search-actions-ask-cody-example.mp4" type="video/mp4" />
+</video>
+
+Having Cody integrated directly into Sourcegraph code search makes it fast and easy to get AI-powered insights as you explore code.
+
+2. Open in Editor
+
+When viewing a file in Sourcegraph, you can open it in your editor of choice to edit the file. This allows you to seamlessly transition from browsing code in Sourcegraph to editing code in your preferred code editor.
+
+When you click the Open in Editor button, Sourcegraph will detect which editor you have configured and open the file in a new tab in that editor.
+
+If you have not configured a default editor, Sourcegraph will prompt you to select an editor before opening the file.
+
+You can read more about this [here](https://sourcegraph.com/docs/integration/open_in_editor).
+
+3. View History
+
+The View History action allows you to see the full commit history for a file directly in Sourcegraph.
+
+When you click this button, a sidebar will open showing every commit that touched the file, ordered chronologically from newest to oldest.
+
+For each commit, you can see:
+
+* The commit message
+* The author
+* The date
+* The commit SHA
+
+![History action](https://storage.googleapis.com/sourcegraph-assets/Docs/actions/history-action.png)
+
+You can click on any commit to view the full diff and see exactly what changed in that particular version of the file.
+
+Exploring the history of a file helps you understand how it evolved over time and why certain changes were made. This additional context can be invaluable when trying to modify or debug code.
+
+The file history integrates tightly with other Sourcegraph navigation features. You can seamlessly transition from browsing history to blaming lines or searching for references.
+
+4. Blame
+
+The Blame action shows annotation on each line of a file indicating the last commit that modified the line and who the author was.
+
+When you click this button on a file, blame information will be displayed inline:
+
+This allows you to easily see the history of every line, without having to explore the full file history. Blame tells you:
+
+* The commit that last modified each line
+* The author who made the change
+* The commit message
+* The timestamp of when it was changed
+
+![Blame action](https://storage.googleapis.com/sourcegraph-assets/Docs/actions/blame-action.png)
+
+Using blame makes it easy to answer questions like:
+
+* Who wrote this line of code originally?
+* When was this method added?
+* What changes were made in this commit?
+
+You can click on any commit in the blame view to explore that snapshot of the file and see the full diff.
+
+Blame data is essential when modifying or debugging existing code in a shared codebase. It helps identify who to talk to when you have questions about particular sections of code.
+
+5. Open in Code host
+
+The Open in CodeHost button allows you to quickly view the file in its native code host.
+
+When you click this button, the file will open in a new browser tab taking you directly to that file on the code host website.
+
+For example, if you are viewing a file from a GitHub repository in Sourcegraph, clicking Open in CodeHost will open `GitHub.com` in a new tab with that file displayed.
+
+6. Copy Link
+
+The Copy Link action allows you to easily copy a permanent link to the exact line range you are viewing in Sourcegraph.
+
+When you click this button, the link is copied to your clipboard. You can then paste the link in any text field or document.
+
+![Copy Link action](https://storage.googleapis.com/sourcegraph-assets/Docs/actions/copy-action.gif)
+
+7. Raw download
+
+The Raw download action allows you to download the raw file contents displayed in Sourcegraph.
+
+When viewing code, click the Raw download button to save the file to your machine.
+
+8. Line Wrapping
+
+The Line Wrap toggle allows you to wrap long lines that extend past the width of the code viewer.
+
+When enabled, any line longer than the window width will wrap to the next line, similar to text in a document.
+
+This makes it easier to read code snippets with very long lines without having to scroll horizontally.
+
+* When disabled (default), long lines will extend past the edge of the window, requiring horizontal scrolling to see the full line.
+
+* When enabled, lines will break to the next line before hitting the window edge.
+
+Toggling line wrapping on and off helps optimize code readability depending on personal preference.
+
+Wrapped lines are visually indicated with a faint vertical line connecting the split sections. Hovering also reveals the full continuous line.
+
+Note: Line wrapping does not modify the actual code contents - it is purely a visual modification. Downloaded files will contain the original non-wrapped lines.

--- a/docs/code_navigation/explanations/features.mdx
+++ b/docs/code_navigation/explanations/features.mdx
@@ -82,7 +82,7 @@ Search-based code navigation uses exact matches `^foo$` and the symbols sidebar 
 
 ### Perform an Action
 
-Code Search allows you to harness the power of Search and quickly find, discover and understand code. However, the end result isn't always to view the results of a search query, Code Search empowers you to perform an action given a set of result.
+Code Search allows you to harness the power of Search and quickly find, discover, and understand code. However, the end result isn't always to view the results of a search query. Code Search empowers you to perform an action given a set of results.
 
 ![Code Search Actions](https://storage.googleapis.com/sourcegraph-assets/Docs/actions/code-search-actions.png)
 

--- a/docs/code_navigation/explanations/index.mdx
+++ b/docs/code_navigation/explanations/index.mdx
@@ -11,6 +11,7 @@
   - [Dependency navigation](/code_navigation/explanations/features#dependency-navigation) (Beta)
   - [Find implementations](/code_navigation/explanations/features#find-implementations)
   - [Symbol search](/code_navigation/explanations/features#symbol-search)
+  - [Perform an Action](/code_navigation/explanations/features#perform-an-action)
 - [Rockskip: faster search-based code navigation](/code_navigation/explanations/rockskip) (Beta)
 - [Writing an indexer](/code_navigation/explanations/writing_an_indexer)
 - [Auto-indexing](/code_navigation/explanations/auto_indexing)


### PR DESCRIPTION
This adds documentation for `Perform an action` project that was implemented earlier.