### PR TITLE
Add Sourcegraph Getting Started Guide for Customers

### DIFF
--- a/docs/cody/capabilities/chat.mdx
+++ b/docs/cody/capabilities/chat.mdx
@@ -1,6 +1,6 @@
 # Chat
 
-        <p className="subtitle">Use Cody's chat to get contextually-aware answers to your questions.</p>
+<p className="subtitle">Use Cody's chat to get contextually-aware answers to your questions.</p>
 
 Cody **chat** allows you to ask coding-related questions about your entire codebase or a specific code snippet. You can do it from the **Chat** panel of the supported editor extensions (VS Code, JetBrains, and Neovim) or in the web app.
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -4,13 +4,13 @@
 
 ## Sourcegraph capabilities
 
-- **Search** across all Omniverse code (all code hosts, repos, branches, commits, and diffs)
-- **Navigate** code (go to definition, find references, etc.) with IDE-like precision across all Omniverse repos
-- **Automate** large-scale code changes across repos (update config files, patch vulns, etc.)
+- **Search** across all Omniverse code (code hosts, repos, branches, commits, and diffs)
+- **Navigate** code (go to definition, find references) with IDE-like precision across all Omniverse repos
+- **Automate** large-scale code changes across repos (update config files, and patch vulns)
 - **Track** migrations, adoption/deprecation, versions, etc., by creating customizable, visual dashboards to track what you'd like within Omniverse's codebase
 - **Write and fix** code faster with Cody's AI completions
 - **Ask questions** of Cody to get answers about your codebase
-- **Get alerts** for code changes (reintroduction of anti-patterns, etc.)
+- **Get alerts** for code changes (reintroduction of anti-patterns)
 - **Document** your code with live and persistent Notebooks that are shareable with your organization
 
 ## Getting started

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,0 +1,120 @@
+# Sourcegraph Getting Started Guide
+
+<p className= "subtitle">Sourcegraph is your Code Search and AI Coding Assistant tool. These docs will help you get onboarded with the Sourcegraph platform and our products.</p>
+
+## Sourcegraph capabilities
+
+- **Search** across all Omniverse code (all code hosts, repos, branches, commits, and diffs)
+- **Navigate** code (go to definition, find references, etc.) with IDE-like precision across all Omniverse repos
+- **Automate** large-scale code changes across repos (update config files, patch vulns, etc.)
+- **Track** migrations, adoption/deprecation, versions, etc., by creating customizable, visual dashboards to track what you'd like within Omniverse's codebase
+- **Write and fix** code faster with Cody's AI completions
+- **Ask questions** of Cody to get answers about your codebase
+- **Get alerts** for code changes (reintroduction of anti-patterns, etc.)
+- **Document** your code with live and persistent Notebooks that are shareable with your organization
+
+## Getting started
+
+- Visit [`your-account.sourcegraphcloud.com`](https://freenome.sourcegraphcloud.com/sign-in)
+- Login with GitLab
+- Set up the [VS Code editor extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai) ([read instructions](https://github.com/sourcegraph/customer-training/blob/main/collateral/cody/vscode-sourcegraph-sign-in.md)) or [JetBrains editor extension](https://plugins.jetbrains.com/plugin/9682-sourcegraph-cody--code-search) ([read instructions](https://github.com/sourcegraph/customer-training/blob/main/collateral/cody/jetbrains-sourcegraph-sign-in.md))
+- Use Sourcegraph Code Search, Navigation, Batch Changes, Code Insights, and Code Monitoring from the Sourcegraph web app
+- Use Sourcegraph Cody from your editor and the Sourcegraph web app!
+
+## Getting help and learning more
+
+- See the docs and videos below
+- Ask questions/how-tos and share feedback in [#sourcegraph-support-XXX](https://freenome.slack.com/archives/C0698SYMP3P) with the XXX and Sourcegraph teams
+
+## Documentation and videos
+
+## Cody
+
+Your AI coding assistant for code generation, code completions, and chat.
+
+- [Quickstart](https://sourcegraph.com/docs/cody/quickstart)
+- [Installation](https://sourcegraph.com/docs/cody/clients)
+  - [VS Code](https://sourcegraph.com/docs/cody/clients/install-vscode)
+  - [JetBrains](https://sourcegraph.com/docs/cody/clients/install-jetbrains)
+  - [Neovim](https://sourcegraph.com/docs/cody/clients/install-neovim)
+  - [Cody for Web](https://sourcegraph.com/docs/cody/clients/cody-with-sourcegraph)
+  - [Cody for Enterprise](https://sourcegraph.com/docs/cody/clients/enable-cody-enterprise)
+- [Capabilities](https://sourcegraph.com/docs/cody/capabilities)
+- [Core Concepts](https://sourcegraph.com/docs/cody/core-concepts/context)
+- [Use Cases](https://sourcegraph.com/docs/cody/use-cases/generate-unit-tests)
+- [Usage and Pricing](https://sourcegraph.com/docs/cody/usage-and-pricing)
+- [Troubleshooting](https://sourcegraph.com/docs/cody/troubleshooting)
+- [FAQ](https://sourcegraph.com/docs/cody/faq)
+
+## Code Search
+
+Search and navigate across all repos, branches, code hosts, commits, diffs, and a lot more.
+
+- [Code Search Overview Video](https://www.youtube.com/watch?v=dnfh5Q01UFA)
+- [Code Search Capabilities](https://sourcegraph.com/docs/code-search/features)
+- [Code Search Types](https://sourcegraph.com/docs/code-search/types/exhaustive)
+- [Working With Search](https://sourcegraph.com/docs/code-search/working/saved_searches)
+- [Search Query Syntax](https://sourcegraph.com/docs/code-search/queries)
+- [Code Navigation Introduction](https://sourcegraph.com/docs/code_navigation/explanations/introduction_to_code_navigation) & [Overview](https://sourcegraph.com/docs/code_navigation)
+- [Search cheat sheet](https://about.sourcegraph.com/blog/how-to-search-cheat-sheet)
+- [Search examples](https://sourcegraph.com/docs/code-search/examples)
+- [Search query syntax](https://sourcegraph.com/docs/code-search/queries)
+- [Search features](https://docs.sourcegraph.com/code_search/explanations/features)
+- [FAQs](https://sourcegraph.com/docs/code-search/faq)
+- [Sourcegraph 101 YouTube playlist](https://www.youtube.com/playlist?list=PL6zLuuRVa1_hAu1mBPeWLqIxoipI3rj17)
+
+## Code Navigation
+
+Code navigation helps you quickly explore code, dependencies, and symbols within the Sourcegraph file view. Code navigation consists of several features that make it easier to move through your codebase without getting lost.
+
+- [How to Guides](https://sourcegraph.com/docs/code_navigation/how-to)
+- [Explanations](https://sourcegraph.com/docs/code_navigation/explanations)
+- [References](https://sourcegraph.com/docs/code_navigation/references)
+
+## Code Monitoring
+
+Watch your code with code monitors and trigger actions to run automatically in response to events.
+
+- [Quickstart](https://sourcegraph.com/docs/code_monitoring/quickstart)
+- [How to Guides](https://sourcegraph.com/docs/code_monitoring/how-tos)
+- [Explanations](https://sourcegraph.com/docs/code_monitoring/explanations)
+
+## Batch Changes
+
+Automate large-scale code changes across repos (update config files, patch vulns, etc.)
+
+- [Quickstart](https://sourcegraph.com/docs/batch_changes/quickstart)
+- [Explanations](https://sourcegraph.com/docs/batch_changes/explanations)
+- [Tutorials](https://sourcegraph.com/docs/batch_changes/tutorials)
+- [How to Guides](https://sourcegraph.com/docs/batch_changes/how-tos)
+- [References](https://sourcegraph.com/docs/batch_changes/references)
+- [3-minute demo](https://youtu.be/GKyHYqH6ggY)
+- [Common use cases and recipes](https://github.com/sourcegraph/batch-change-examples)
+
+## Code Insights
+
+Create customizable, visual dashboards to track what you'd like within our codebase (track migrations, adoption/deprecation, versions, etc.)
+
+- [Quickstart](https://sourcegraph.com/docs/code_insights/quickstart)
+- [Explanation](https://sourcegraph.com/docs/code_insights/explanations)
+- [How To](https://sourcegraph.com/docs/code_insights/how-tos)
+- [References](https://sourcegraph.com/docs/code_insights/references)
+- [3-minute demo](https://youtu.be/fMCUJQHfbUA)
+- [Common use cases and recipes](https://sourcegraph.com/docs/code_insights/references/common_use_cases)
+
+## Notebooks
+
+Notebooks enable powerful live–and persistent–documentation, shareable with your organization or the world.
+
+- [Quickstart](https://sourcegraph.com/docs/notebooks/quickstart)
+
+## CLI and API
+
+Interact with Sourcegraph in the command line.
+
+- [Quickstart](https://sourcegraph.com/docs/cli/quickstart)
+- [Explanations](https://sourcegraph.com/docs/cli/explanations)
+- [How To](https://sourcegraph.com/docs/cli/how-tos)
+- [References](https://sourcegraph.com/docs/cli/references)
+- [Sourcegraph GraphQL API](https://sourcegraph.com/docs/api/graphql)
+- [Sourcegraph Stream API](https://sourcegraph.com/docs/api/stream_api)


### PR DESCRIPTION
This PR adds docs for Customer Onboarding. The docs remain in stealth mode and can only be accessed via the exact URL.

## Reference

@toddherskovitz from Sales reached out and he wanted these docs for onboarding.


## Preview

- [Link](https://sourcegraph-docs-v2-git-add-customer-docs-sourcegraph-f8c71130.vercel.app/docs/quickstart)