### PR TITLE
small fix for some json files - remove dangling commas

### DIFF
--- a/docs/dev/background-information/scim_postman_collection.json
+++ b/docs/dev/background-information/scim_postman_collection.json
@@ -453,7 +453,7 @@
 		},
 		{
 			"key": "token",
-			"value": "TODO paste random token here",
+			"value": "TODO paste random token here"
 		},
 		{
 			"key": "user_id",

--- a/docs/versioned/5.2/dev/background-information/scim_postman_collection.json
+++ b/docs/versioned/5.2/dev/background-information/scim_postman_collection.json
@@ -453,7 +453,7 @@
 		},
 		{
 			"key": "token",
-			"value": "TODO paste random token here",
+			"value": "TODO paste random token here"
 		},
 		{
 			"key": "user_id",


### PR DESCRIPTION
A couple of json files that are used for reference had dangling commas in them.