### PR TITLE
Add latency section to Cloud FAQ

### DIFF
--- a/docs/cloud/index.mdx
+++ b/docs/cloud/index.mdx
@@ -261,6 +261,22 @@ Sourcegraph Cloud instances have intrusion detection capabilities through [Falco
 
 Sourcegraph Cloud offers a 99.5% uptime guarantee. Learn more from our [SLA](/sla/#sourcegraph-cloud-sla-managed-instance).
 
+### What is the latency of Sourcegraph Cloud?
+
+Sourcegraph measures latency internally for each service, but because of the variability in response times incurred by a search product, these metrics are not meaningful when aggregated into a single "network latency" figure. Because Sourcegraph’s services operate transactionally across several platforms, latency has proven to be too broad a number that averages out many disconnected performance factors to be useful or meaningful for our customers.
+
+The below are for example purposes only:
+
+In the case of things like Code Search, latency is directly correlated with user input / shape of the query, ex. on our public [sourcegraph.com](https://sourcegraph.com/search) instance:
+
+- searching for “squirrel” in the [sourcegraph/sourcegraph](https://sourcegraph.com/github.com/sourcegraph/sourcegraph) repo takes 30ms and returns 163 results
+- searching for “squirrel” in all OSS repos, but only requesting 1000 matches takes 540ms
+- searching for all matches of “squirrel” in all OSS repos returns 1.7million results in 30000ms
+- In the case of other features, latency of Sourcegraph directly depends on latency / uptime / rate-limits of customer managed systems, ex. for:
+- repo syncing (depends on code-host system)
+- user account syncing (depends on Identity Provider)
+- permission syncing (depends on Identity Provider / Code Host / customer calling our Explicit Permissions API)
+
 ### How to connect Sourcegraph Cloud instances to on-prem resources?
 
 Sourcegraph Cloud can securely connect to customer-owned resources on cloud provider platforms or on-prem data centers, such as GitHub Enterprise server in a private network on GCP and Artifact Registry on AWS. Learn more from [Private Connectivity](#private-connectivity).


### PR DESCRIPTION
Per [discussion](https://sourcegraph.slack.com/archives/C022SPMNR0W/p1709661124763989) in #discuss-engineering, aligned on language and examples for discussing why latency is not an effective measure for our cloud services.