### PR TITLE
update documentation for permissions (RBAC and Repository)

### DIFF
--- a/docs/admin/access_control/index.mdx
+++ b/docs/admin/access_control/index.mdx
@@ -36,8 +36,6 @@ You can read about the specific permission types available for each RBAC-enabled
 - [Batch Changes](/admin/access_control/batch_changes)
 - [Ownership](/admin/access_control/ownership)
 
-> NOTE: While Batch Changes is the only RBAC-enabled product area today, we will be working on migrating other product areas in future releases of Sourcegraph. Please reach out to our [support team](mailto:support@sourcegraph.com) if you have further questions.
-
 ### Deleting a role
 
 > NOTE: Built-in system roles cannot be deleted.

--- a/docs/dev/how-to/add_permissions.mdx
+++ b/docs/dev/how-to/add_permissions.mdx
@@ -1,4 +1,4 @@
-# Permissions
+# RBAC Permissions
 
 This doc is for engineers who want to add permissions for features they want to protect using the Access Control System. The permission referred to in this context differs from repository permissions; the latter concerns permissions from code hosts relating to repositories.
 
@@ -22,7 +22,7 @@ To add permissions for a new feature, follow these steps:
 
 1. Add the namespace and action to [`schema.yaml`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/rbac/schema.yaml). Namespace string must be unique.
 
-2. Generate the access control constants with the command `sg gen`. This will generate access control constants for [Typescript](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb/-/blob/client/web/src/rbac/constants.ts) and [Go](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb4374d1449c918f695c21d2c933c5a1d15/-/blob/internal/rbac/constants.go).
+2. Generate the access control constants with the command `bazel run //`. This will generate access control constants for [Typescript](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb/-/blob/client/web/src/rbac/constants.ts) and [Go](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb4374d1449c918f695c21d2c933c5a1d15/-/blob/internal/rbac/constants.go).
     - Additionally modify [schema.graphql](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@2badaeb3ccb0d9bf660234e8b5eddb4cba6598bb/-/blob/cmd/frontend/graphqlbackend/schema.graphql?L9729) by adding a new namespace enum
 
 3. Once these constants have been generated, you can protect any resource using the access control system. 

--- a/docs/dev/how-to/add_permissions.mdx
+++ b/docs/dev/how-to/add_permissions.mdx
@@ -22,7 +22,7 @@ To add permissions for a new feature, follow these steps:
 
 1. Add the namespace and action to [`schema.yaml`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/rbac/schema.yaml). Namespace string must be unique.
 
-2. Generate the access control constants with the command `bazel run //`. This will generate access control constants for [Typescript](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb/-/blob/client/web/src/rbac/constants.ts) and [Go](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb4374d1449c918f695c21d2c933c5a1d15/-/blob/internal/rbac/constants.go).
+2. Generate the access control constants with the command `bazel run //dev:write_all_generated`. This will generate access control constants for [Typescript](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb/-/blob/client/web/src/rbac/constants.ts) and [Go](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@8b4e1cb4374d1449c918f695c21d2c933c5a1d15/-/blob/internal/rbac/constants.go).
     - Additionally modify [schema.graphql](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@2badaeb3ccb0d9bf660234e8b5eddb4cba6598bb/-/blob/cmd/frontend/graphqlbackend/schema.graphql?L9729) by adding a new namespace enum
 
 3. Once these constants have been generated, you can protect any resource using the access control system. 

--- a/docs/dev/how-to/debug_permissions.mdx
+++ b/docs/dev/how-to/debug_permissions.mdx
@@ -1,4 +1,4 @@
-# Debugging Permissions
+# Debugging Repository Permissions
 
 This document provides a list of options to try when debugging permissions issues.
 

--- a/docs/dev/how-to/index.mdx
+++ b/docs/dev/how-to/index.mdx
@@ -61,8 +61,11 @@
 
 ## Access Control
 
-- [Adding permissions](/dev/how-to/add_permissions)
-- [Debugging permissions](/dev/how-to/debug_permissions)
+- [Adding RBAC permissions](/dev/how-to/add_permissions)
+
+## Repository Permissions
+
+- [Debugging Repository permissions](/dev/how-to/debug_permissions)
 
 ## Wolfi
 


### PR DESCRIPTION
I noticed in the grouping for `dev/how-tos`, we group content for Access Control and Repository permissions together, this PR separates that.

Also @bobheadxi suggested renaming the title of the Access Control docs for adding permissions so it's clear it's about RBAC permissions and not repository permissions.