### PR TITLE
Tweak performance traces for Cody based on me ignorantly following th…

### DIFF
--- a/docs/cody/troubleshooting.mdx
+++ b/docs/cody/troubleshooting.mdx
@@ -102,10 +102,10 @@ You can get performance traces from the Cody VS Code extension in production wit
 - Start VS Code with a special runtime flag. In macOS, you can do so via the terminal like this:
 
 ```bash
-/Applications/Visual\ Studio\ Code/Contents/MacOS/Electron --inspect-extensions=9333
+/Applications/Visual\ Studio\ Code.app/Contents/MacOS/Electron --inspect-extensions=9333
 ```
-
-- Next, go to Chrome and go to `about://tracing,` which takes you to the following:
+Note that you may need to quit VSCode first, then run that command to re-launch it. It will open all of your windows and tabs again.
+- After VS Code is started, head over to Chrome and go to `chrome://inspect`, which takes you to the following:
 
 ![](https://gist.github.com/assets/458591/0a17881b-5449-48d5-a53e-5556f4f2dedd)
 
@@ -113,11 +113,11 @@ You can get performance traces from the Cody VS Code extension in production wit
 
 ![](https://gist.github.com/assets/458591/972ce113-88f0-482a-99b7-5e51957981ef)
 
-- Now, go back to the `about://tracing` tab, and you should see a new remote target that you can inspect
+- Now head back to the `chrome://inspect` tab, and you should see a new remote target that you can inspect
 
 ![](https://gist.github.com/assets/458591/06b2e293-aea7-42e8-a9cc-592863b6fb07)
 
-- Click this, and you'll see a **DevTools** view. You can go to the **Performance** tab to record a trace from here. And finally, swap tabs to the VS Code window and interact with the extension. Come back later to stop the recording and export it
+- Clicking this will open a (somewhat reduced) DevTools view. Great! We've almost got it. From here you can go to the **Performance** tab to record a trace. And finally, swap tabs to the VS Code window and interact with the extension. Come back later to stop the recording and export it.
 
 ![](https://gist.github.com/assets/458591/d590636b-31e5-4436-8039-ee62b7a8e59f)
 


### PR DESCRIPTION
…e guide.

- Fix the filepath to VSCode
- Add note about quitting VSCode before using the runtime flag
- Change `about://tracing` to `chrome://inspect`