### PR TITLE
Update messaging on how to resubscribe from a cancelled plan

### DIFF
--- a/docs/cody/usage-and-pricing.mdx
+++ b/docs/cody/usage-and-pricing.mdx
@@ -78,7 +78,7 @@ We currently only support payments through a credit card.
 
 If you do not want to renew Cody Pro, you can cancel your Cody Pro subscription at any time by going to the [accounts page](https://accounts.sourcegraph.com/cody/subscriptions). If you cancel the Pro plan, your Cody Pro will continue until the end of the billing cycle. Once the billing cycle ends, your plan will not renew, and your card will not be charged. This automatically downgrades your plan from Cody Pro to Cody Free.
 
-If you change your mind after canceling your plan and you have a credit card on file, you can click **Resume subscription** from the [accounts page](https://accounts.sourcegraph.com/cody/subscriptions) to re-upgrade to Cody Pro.
+If you change your mind after canceling your plan please contact our Support team at support@sourcegraph.com and we can help you get re-subscribed.
 
 ### Are there any refunds for the Pro subscription?
 


### PR DESCRIPTION
Based on a conversation with @chrsmith. Once the "Resume Subscription" button actually exists we can change this back.