### PR TITLE
Remove /slash commands on feature parity page

### DIFF
--- a/docs/cody/clients/feature-reference.mdx
+++ b/docs/cody/clients/feature-reference.mdx
@@ -12,7 +12,6 @@ Here's a feature parity matrix that compares the capabilities of Cody Clients ac
 | Chat history                | ✓           | ✓             | x          | ✓       |
 | Stop chat generating        | ✓           | ✓             | x          | ✓       |
 | Edit sent messages          | ✓           | x             | x          | ✓       |
-| Slash (`/`) commands        | ✓           | x             | x          | x       |
 | Show context files          | ✓           | ✓             | ✓          | ✓       |
 | Custom commands             | ✓           | x             | x          | x       |
 | Clear chat history          | ✓           | ✓             | x          | ✓       |


### PR DESCRIPTION
## Ref:

- https://app.asana.com/0/1205845687915332/1206816088751898/f