### PR TITLE
rename 'Enterprise license' to 'Enterprise subscription'

### DIFF
--- a/docs/admin/config/site_config.mdx
+++ b/docs/admin/config/site_config.mdx
@@ -844,7 +844,7 @@ All site configuration options and their default values are shown below.
 // Sourcegraph Enterprise license
 //////////////////////////////////////////////////////////////
 
-	// The license key associated with a Sourcegraph Enterprise license, which is necessary to activate Sourcegraph Enterprise functionality. To obtain this value, contact Sourcegraph to purchase a license. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
+	// The license key associated with a Sourcegraph Enterprise subscription, which is necessary to activate Sourcegraph Enterprise functionality. To obtain this value, contact Sourcegraph to purchase a license. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
 	"licenseKey": null,
 
 //////////////////////////////////////////////////////////////

--- a/docs/admin/pings.mdx
+++ b/docs/admin/pings.mdx
@@ -16,7 +16,7 @@ Sourcegraph aggregates usage and performance metrics for some product features i
 - Sourcegraph version string (e.g. "vX.X.X")
 - Dependency versions (e.g. "6.0.9" for Redis, or "13.0" for Postgres)
 - Deployment type (single Docker image, Docker Compose, Kubernetes cluster, Helm, or pure Docker cluster)
-- License key associated with your Sourcegraph Enterprise license
+- License key associated with your Sourcegraph Enterprise subscription
 - Aggregate count of current monthly users
 - Total count of existing user accounts
 - Aggregated repository statistics

--- a/docs/admin/subscriptions/index.mdx
+++ b/docs/admin/subscriptions/index.mdx
@@ -1,4 +1,4 @@
-# Paid licenses for Sourcegraph Enterprise
+# Paid Sourcegraph Enterprise subscriptions
 
 > NOTE: Pricing documentation below applies to [Sourcegraph Enterprise](https://about.sourcegraph.com/pricing).
 

--- a/docs/cody/clients/enable-cody-enterprise.mdx
+++ b/docs/cody/clients/enable-cody-enterprise.mdx
@@ -85,7 +85,7 @@ You can set up Cody for your Enterprise instance in one of the following ways:
 ### Prerequisites
 
 - You have Sourcegraph version 5.1.0 or above
-- A Sourcegraph Enterprise license with [Cody Gateway access](/cody/core-concepts/cody-gateway) or [an account with a third-party LLM provider](#using-a-third-party-llm-provider)
+- A Sourcegraph Enterprise subscription with [Cody Gateway access](/cody/core-concepts/cody-gateway) or [an account with a third-party LLM provider](#using-a-third-party-llm-provider)
 
 ### Enable Cody on your Sourcegraph instance
 

--- a/docs/cody/core-concepts/cody-gateway.mdx
+++ b/docs/cody/core-concepts/cody-gateway.mdx
@@ -4,7 +4,7 @@
 
 <Callout type="note" title="Note">Cody Gateway is supported for Sourcegraph Enterprise customers on v5.1 or more.</Callout>
 
-Sourcegraph Cody Gateway powers the default `"provider": "sourcegraph"` and Cody completions for Sourcegraph Enterprise users. It supports a variety of upstream LLM providers, such as [Anthropic](https://www.anthropic.com/) and [OpenAI](https://openai.com/), with rate limits, quotas, and model availability tied to your Sourcegraph Enterprise license.
+Sourcegraph Cody Gateway powers the default `"provider": "sourcegraph"` and Cody completions for Sourcegraph Enterprise users. It supports a variety of upstream LLM providers, such as [Anthropic](https://www.anthropic.com/) and [OpenAI](https://openai.com/), with rate limits, quotas, and model availability tied to your Sourcegraph Enterprise subscription.
 
 ## Using Cody Gateway in Sourcegraph Enterprise
 
@@ -25,7 +25,7 @@ For more details about configuring Cody, read the following resources:
 
 Cody Gateway is hosted at `cody-gateway.sourcegraph.com`. To use Cody Gateway, your Sourcegraph instance must be connected to the service in this domain.
 
-<Callout type="warning">Sourcegraph Cody Gateway access must be included in your Sourcegraph Enterprise license. You can verify it by checking it with your account manager. If you are a [Sourcegraph Cloud](/cloud/) user, Cody is enabled by default on your instance starting with Sourcegraph 5.1.</Callout>
+<Callout type="warning">Sourcegraph Cody Gateway access must be included in your Sourcegraph Enterprise subscription. You can verify it by checking it with your account manager. If you are a [Sourcegraph Cloud](/cloud/) user, Cody is enabled by default on your instance starting with Sourcegraph 5.1.</Callout>
 
 ## Configuring custom models
 
@@ -42,7 +42,7 @@ The currently supported upstream providers for models are:
 - [`anthropic/`](https://www.anthropic.com/)
 - [`openai/`](https://openai.com/)
 
-For Sourcegraph Enterprise customers, model availability depends on your Sourcegraph Enterprise license.
+For Sourcegraph Enterprise customers, model availability depends on your Sourcegraph Enterprise subscription.
 
 <Callout type="warning">When using OpenAI models for completions, only chat completions will work - code completions are currently unsupported.</Callout>
 

--- a/docs/dev/how-to/cody_gateway.mdx
+++ b/docs/dev/how-to/cody_gateway.mdx
@@ -32,7 +32,7 @@ To use this locally running Cody Gateway from your local Sourcegraph instance, c
     "endpoint": "http://localhost:9992",
     "chatModel": "anthropic/claude-2",
     "completionModel": "anthropic/claude-instant-1",
-    // Create an Enterprise license key:
+    // Create an Enterprise subscription and license key:
     // https://sourcegraph.test:3443/site-admin/dotcom/product/subscriptions
     // Under "Cody services", ensure access is enabled and get the access token
     // to use here.
@@ -87,7 +87,7 @@ commands:
       CODY_GATEWAY_BIGQUERY_PROJECT_ID: cody-gateway-dev
 ```
 
-Then to view events statistics on the Enterprise licenses page, add the following section in the site configuration, and run the `sg start dotcom` stack:
+Then to view events statistics on the Enterprise subscriptions page, add the following section in the site configuration, and run the `sg start dotcom` stack:
 
 ```json
 {

--- a/docs/dev/security/secret_formats.mdx
+++ b/docs/dev/security/secret_formats.mdx
@@ -9,7 +9,7 @@ Sourcegraph uses a number of secret formats to store authentication tokens and k
 | Sourcegraph Access Token (v1, deprecated)    | Token used to access the Sourcegraph GraphQL API                                 | User-generated             | `[a-fA-F0-9]{40}`         |                         |
 | Sourcegraph Dotcom User Gateway Access Token | Token used to grant sourcegraph.com users access to Cody                         | Backend (not user-visible) | `sgd_[a-fA-F0-9]{64}`     |                         |
 | Sourcegraph License Key Token                | Token used for product subscriptions, derived from a Sourcegraph license key     | Backend (not user-visible) | `slk_[a-fA-F0-9]{64}`     |                         |
-| Sourcegraph Enterprise license (aka "product subscription") Token       | Token used for product subscriptions, not derived from a Sourcegraph license key | Backend (not user-visible) | `sgs_[a-fA-F0-9]{64}`     |                         |
+| Sourcegraph Enterprise subscription (aka "product subscription") Token       | Token used for Enterprise subscriptions, derived from a Sourcegraph license key | Backend (not user-visible) | `sgs_[a-fA-F0-9]{64}`     |                         |
 
 For further information about Sourcegraph Access Tokens, see:
 - [Creating an access token](/cli/how-tos/creating_an_access_token)

--- a/docs/versioned/5.2/admin/pings.mdx
+++ b/docs/versioned/5.2/admin/pings.mdx
@@ -16,7 +16,7 @@ Sourcegraph aggregates usage and performance metrics for some product features i
 - Sourcegraph version string (e.g. "vX.X.X")
 - Dependency versions (e.g. "6.0.9" for Redis, or "13.0" for Postgres)
 - Deployment type (single Docker image, Docker Compose, Kubernetes cluster, Helm, or pure Docker cluster)
-- License key associated with your Sourcegraph subscription
+- License key associated with your Sourcegraph Enterprise subscription
 - Aggregate count of current monthly users
 - Total count of existing user accounts
 - Aggregated repository statistics


### PR DESCRIPTION
Partially revert https://github.com/sourcegraph/docs/pull/125 - see https://github.com/sourcegraph/sourcegraph/pull/61049. In particular #125 introduced some errors about how Cody Gateway properties are evaluated, notably very few Cody Gateway access properties are evaluated from license keys.

While here I also found another error - there's a table indicating the product subscription token is `not derived from a Sourcegraph license key`, but it _is_ derived from the license key, which is how the zero-config Cody mechanism works. I've fixed this in this PR