### PR TITLE
Add dig for SG cloud-hosted deployment

### DIFF
--- a/docs/cody/clients/enable-cody-enterprise.mdx
+++ b/docs/cody/clients/enable-cody-enterprise.mdx
@@ -119,6 +119,12 @@ Cody is now fully enabled on your self-hosted Sourcegraph enterprise instance!
 
 [Learn more about running Cody on Sourcegraph Cloud](/cloud/#cody).
 
+### Sourcegraph Enterprise Cloud hosted Cody Deployment
+
+Here's a detailed breakdown of the architecture for a Cody Enterprise Cloud-hosted Cody deployment.
+
+![](https://storage.googleapis.com/sourcegraph-assets/Docs/Sourcegraph%20Enterprise%20Cloud-hosted%20Cody%20Deployment.jpg)
+
 ## Enabling codebase-aware answers
 
 <Callout type="note"> To enable codebase-aware answers for Cody, you must first [configure the code graph context](/cody/core-concepts/code-graph).</Callout>


### PR DESCRIPTION
Here's a detailed breakdown of the architecture for a Cody Enterprise Cloud-hosted Cody deployment.