### PR TITLE
Fix Table of Contents errors

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -21,8 +21,13 @@ export const Post = defineDocumentType(() => ({
             type: "json",
             resolve: async (doc) => {
                 const regXHeader = /^ *(?<flag>#{1,6})\s+(?<content>.+)/gm;
+                const regXCodeBlock = /```[\s\S]*?```/g;
                 const slugger = new GithubSlugger();
-                const headings = Array.from(doc.body.raw.matchAll(regXHeader)).map(
+
+                // Ignore content within code blocks – No headings there
+                const bodyWithoutCodeBlocks = doc.body.raw.replace(regXCodeBlock, '');
+
+                const headings = Array.from(bodyWithoutCodeBlocks.matchAll(regXHeader)).map(
                     ({ groups }) => {
                         const flag = groups?.flag;
                         // Handles headings with links eg:


### PR DESCRIPTION
This PR fixes TOC errors. They were caused by false headings being generated because of `#` inside code blocks. We are now ignoring all content inside code blocks while generating headings for TOC.

@MaedahBatool Please test if this solves the issues.