### PR TITLE
remove mentions of slash commands

### DIFF
--- a/docs/cody/capabilities/chat.mdx
+++ b/docs/cody/capabilities/chat.mdx
@@ -31,7 +31,7 @@ Let's use Cody VS Code extension's chat interface to answer your first question.
 
 - Click the Cody icon in the sidebar to view the detailed panel
 - Next, click the icon for **New Chat** to open a new chat window
-- Here, you can directly write your question or type slash `/` to select one of the commands and then press **Enter**
+- Write your question or instruction to Cody and then press **Enter**.
 
 For example, ask Cody "What does this file do?"
 

--- a/docs/cody/capabilities/commands.mdx
+++ b/docs/cody/capabilities/commands.mdx
@@ -20,21 +20,16 @@ Support for commands may vary by IDE extension. Read the [feature parity referen
 
 The process of running a command varies from one IDE to another. For example, in VS Code, there are several ways to run a command:
 
-1. Highlight your code and select the command from the sidebar
+1. Select code in the editor and use the Cody commands sidebar to run a command:
 
 ![running-commands](https://storage.googleapis.com/sourcegraph-assets/Docs/using-commands.png)
 
-2. Open up the command palette with `Option+C` `Alt+C`
-3. Right-click on any code element and select **Cody > Choose a command** from the list
-4. Type `/` in the chat bar. Cody will then suggest a list of available commands
-
-  <video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto' }}>
-          <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/commands-working.mp4" type="video/mp4" />
-          </video>
+2. Run **Cody: Commands** in the VS Code command palette.
+3. Right-click in the editor and select a command in the **Cody** submenu.
 
 ## Custom commands
 
-<Callout type="note">Custom Commands are in the Beta stage.</Callout>
+<Callout type="note">Custom Commands are in beta.</Callout>
 
 **Custom Commands** allow you to create and define reusable prompts for Cody tailored to your development workflows. They are defined in `JSON` format and will enable you to call CLI tools, write custom prompts, and select context to be sent to Cody. This provides a flexible way to configure Cody to handle use cases like:
 
@@ -43,16 +38,14 @@ The process of running a command varies from one IDE to another. For example, in
 - Read test command failures to explain and suggest fixes
 - Explain code quality output like linter warnings
 
-<Callout type="note">Cody supports Custom Commands only for VS Code version 0.8 and above.</Callout>
-
 ### Creating a Custom Command
 
 You can create a custom command by editing the configuration JSON file or using the command builder within the VS Code editor. To access the command builder within VS Code:
 
-- Open the Cody commands menu (`⌥C` on Mac or `Alt-C` on Windows/Linux)
+- Open the Cody commands menu (**Cody: Commands** in the command palette)
 - Select **Custom commands > New Custom Command**
-- Type the slash `/` name you want to use, for example, `/my-custom-command`
-- Next, write a suitable description for the command in sentence case. For example, `Compare files in open tabs` or `Explain current directory`
+- Enter the name for your new custom command, such as `my-custom-command`.
+- Next, write a description for the command. For example, `Compare files in open tabs` or `Explain current directory`
 - Provide the relevant instructions for Cody to follow. This is the `prompt` that Cody will use to pass relevant context to the LLM
 - Then, select one or more options for the context Cody should use to generate responses
 - Finally, choose whether to save the command locally or share it with your workspace
@@ -61,11 +54,12 @@ You can create a custom command by editing the configuration JSON file or using 
 
 ### Running Custom Commands
 
-You can invoke custom commands with the same hotkey as predefined commands. Once created, your custom commands will appear with the rest of the predefined commands in the chat and command palette lists. Let's type `/my-custom-command` in the chat window, and it will appear. Now, you can run this new command on your code and get answers to your questions accordingly.
+You can invoke custom commands in 2 ways.
 
-![create-new-custom-command](https://storage.googleapis.com/sourcegraph-assets/Docs/custom-command.png)
+- Run **Cody Command: Custom Commands** in the VS Code command palette.
+- Right-click in the editor and select **Cody > Custom Commands**.
 
-Alternatively, you can right-click the selected code and select **Cody > Custom Commands**.
+Then select the command you want to run. If your custom command expects a code selection, be sure to select code in the editor before running the custom command.
 
 ### Configuring file paths
 
@@ -80,7 +74,7 @@ See the [examples](#examples) and [configuration properties](#configuration-prop
 
 ### Examples
 
-### `/commit-message`
+### `commit-message`
 
 ```json
 {
@@ -95,7 +89,7 @@ See the [examples](#examples) and [configuration properties](#configuration-prop
 }
 ```
 
-### `/compare-tabs`
+### `compare-tabs`
 
 ```json
 {
@@ -110,7 +104,7 @@ See the [examples](#examples) and [configuration properties](#configuration-prop
 }
 ```
 
-### `/current-dir`
+### `current-dir`
 
 ```json
 {
@@ -125,7 +119,7 @@ See the [examples](#examples) and [configuration properties](#configuration-prop
 }
 ```
 
-### `/latest-cody-release`
+### `latest-cody-release`
 
 ```json
 {
@@ -140,7 +134,7 @@ See the [examples](#examples) and [configuration properties](#configuration-prop
 }
 ```
 
-### `/readme`
+### `readme`
 
 ```json
 {
@@ -155,7 +149,7 @@ See the [examples](#examples) and [configuration properties](#configuration-prop
 }
 ```
 
-### `/recent-git-changes`
+### `recent-git-changes`
 
 ```json
 {


### PR DESCRIPTION
Slash commands were removed in v1.2.0 of the VS Code Cody extension (Jan 2024), which makes this documentation incorrect and obsolete. See https://sourcegraph.slack.com/archives/C05MW2TMYAV/p1710314656133489 for context.