### PR TITLE
Add tutorials page to navigation list

### DIFF
--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -263,6 +263,10 @@ export const navigation: NavigationItem[] = [
         href: "/sla",
       },
       {
+        title: "Tutorials",
+        href: "/tutorials",
+      },
+      {
         title: "Sourcegraph Accounts",
         href: "/sourcegraph-accounts"
       },


### PR DESCRIPTION
This adds the tutorials page to the navigation list under "Help & Support"