### PR TITLE
Add note about access token instance identifiers

### DIFF
--- a/docs/dev/security/secret_formats.mdx
+++ b/docs/dev/security/secret_formats.mdx
@@ -16,3 +16,16 @@ For further information about Sourcegraph Access Tokens, see:
 - [Revoking an access token](/cli/how-tos/revoking_an_access_token)
 
 Sourcegraph is in the process of rolling out a new Sourcegraph Access Token format. When generating an access token you may receive a token in v2 or v3 format depending on your Sourcegraph instance's version. Newer instances are fully backwards-compatible with all older formats.
+
+
+### Sourcegraph Access Token (v3) Instance Identifier
+The Sourcegraph Access Token (v3) includes an *instance identifier* which can be used by Sourcegraph to securely identify which instance the token was generated for. In the event of a token leak, this allows us to inform the relevant customer.
+
+```
+sgp _ <instance identifier> _ <token value>
+```
+
+The *instance identifier* is intentionally **not** verified when a token is used, so tokens will remain valid if it is modified. For example, the following tokens are equivalent as they both have the same *token value*:
+
+* `sgp_foobar_abcdef0123456789`
+* `sgp_bazbar_abcdef0123456789`


### PR DESCRIPTION
Explain the purpose of the instance identifier, and that the fact it can be modified is not a security concern.