### PR TITLE
Remove references to smart search

### DIFF
--- a/docs/code-search/features.mdx
+++ b/docs/code-search/features.mdx
@@ -42,29 +42,6 @@ See our [query syntax](/code-search/queries#diff-and-commit-searches-only) docum
 
 Searching for symbols makes it easier to find specific functions, variables, and more. Use the `type:symbol` filter to search for symbol results. Symbol results also appear in typeahead suggestions, so you can jump directly to symbols by name. When on an [indexed](/admin/search#indexed-search) commit, it uses Zoekt. Otherwise it uses the [symbols service](/code_navigation/explanations/features#symbol-search)
 
-## Smart Search
-
-Smart Search helps find search results that are likely to be more useful than showing "no results" by trying slight variations of a user's original query. Smart Search automatically tries alternative queries based on a handful of rules (we know how easy it is to get tripped up by query syntax). When a query alternative finds results, those results are shown immediately. Smart Search is activated by toggling the **lightning bolt** in the search bar, and is on by default. Smart Search is only enabled in the web application and its results view (Search APIs remain the same and are unaffected).
-
-### Example
-
-Take a query like `go buf byte parser`, for example. Normally, Sourcegraph will search for the string "go buf byte parser" with those tokens in that order. If there are **_no_** results, Smart Search attempts variations of the query. One rule applies a `lang:` filter to known languages. For example, `go` may refer to the `Go` language, so we convert this token to a `lang:Go` filter. Another rule relaxes the ordering on remaining tokens so that we search for `buf AND byte AND parser` anywhere in the file. Here's an example of what Smart Search looks like in action:
-
-<img src="https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/2022/smart-search-example.png" alt="Smart Search example"/>
-
-Note that if the original query finds results (which depends on the code it runs on), Smart Search has no effect. Smart Search does not otherwise intervene or interfere with search queries if those queries return results, and Sourcegraph behaves as usual.
-
-### Configuration options
-
-It is sometimes useful to check for the _absence_ of results (we _want_ to see zero matches). In these cases, Smart Search can be disabled temporarily by toggling the lightning button in the search bar. To deactivate Smart Search by default, set `"search.defaultMode": "precise"` in settings.
-
-It is not possible to customize Smart Search rules at this time. So far a small number of rules are enabled based on feedback and utility. They affect the following query properties:
-
-- Separate patterns with `AND` (pattern order doesn't matter)
-- Patterns as filters (e.g., apply `lang:` or `type:symbol`  filters based on keywords)
-- Quotes in queries (run a literal search for quoted patterns)
-- Patterns as Regular Expressions (check patterns for likely regular expression syntax)
-
 ## Saved searches
 
 Saved searches let you save and describe search queries so you can easily monitor the results on an ongoing basis. You can create a saved search for anything, including diffs and commits across all branches of your repositories. Saved searches can be an early warning system for common problems in your code and a way to monitor best practices, the progress of refactors, etc.

--- a/docs/getting-started/github-vs-sourcegraph.mdx
+++ b/docs/getting-started/github-vs-sourcegraph.mdx
@@ -156,8 +156,6 @@ GitHub only returns the first 10 pages of search results. You cannot currently g
 
 Sourcegraph can retrieve all search results. By default, Sourcegraph returns 500 search results, but this number can be increased by increasing the ‘count’ value. Sourcegraph can display a maximum of 1,500 results, but all matches can be fetched using the [src CLI](https://docs.sourcegraph.com/cli/quickstart), the [Stream API](https://docs.sourcegraph.com/api/stream_api), or [GraphQL API](https://docs.sourcegraph.com/api/graphql). You can also export the results via CSV.
 
-Souregraph's Smart Search is a query assistant that activates when a search returns no results. It helps you find search results by trying slight variations of your original query when a search shows "no results," and the alternative results are shown automatically once Smart Search is enabled.
-
 GitHub code search includes suggestions, completions, and the ability to save your searches. Sourcegraph offers suggestions through search query examples and [saved searches](/code-search/working/saved_searches#creating-saved-searches).
 
 GitHub code search returns a list of repositories and files. Sourcegraph results can include repositories, files, diffs, commits, and symbols; however, you must use the ‘type’ filter to return anything outside of repositories and files.


### PR DESCRIPTION
In 5.3 we disabled Smart Search in the UI, so this PR removes references to it
in the current docs (which represent 5.3).

Relates to https://github.com/sourcegraph/sourcegraph/issues/58815