### PR TITLE
Document content-based lang detection

### DIFF
--- a/docs/code-search/queries/language.mdx
+++ b/docs/code-search/queries/language.mdx
@@ -105,6 +105,15 @@ For example,
 
 - [`lang:typescript encoding`](https://sourcegraph.com/search?q=lang:typescript+encoding&patternType=regexp)
 
+#### Content-based language detection
+<span class="badge badge-beta">Beta</span>
+Language filters work by checking the file name and extension. They can behave unexpectedly
+when a language's extension is ambiguous: for example `lang:Objective-C` may also match Matlab files, since both
+languages use the `.m` extension.
+
+If this is an issue, you can enable the feature flag `search-content-based-lang-detection`. When enabled, Sourcegraph
+more accurately detects a file's language by checking the file contents in addition to the name and extension.
+
 ### Content
 
 ![content](https://storage.googleapis.com/sourcegraph-assets/Docs/CS-LANG/content.png)

--- a/docs/code-search/queries/language.mdx
+++ b/docs/code-search/queries/language.mdx
@@ -105,8 +105,7 @@ For example,
 
 - [`lang:typescript encoding`](https://sourcegraph.com/search?q=lang:typescript+encoding&patternType=regexp)
 
-#### Content-based language detection
-<span class="badge badge-beta">Beta</span>
+#### Content-based language detection (Beta)
 Language filters work by checking the file name and extension. They can behave unexpectedly
 when a language's extension is ambiguous: for example `lang:Objective-C` may also match Matlab files, since both
 languages use the `.m` extension.


### PR DESCRIPTION
Add a note about `search-content-based-lang-detection`, which was missing from
the docs. It's presented as a "beta" feature because we still have a few
follow-ups to bring it to GA
(https://github.com/sourcegraph/sourcegraph/issues/60676).