### PR TITLE
Fix typo in keyword search docs

### DIFF
--- a/docs/code-search/queries/index.mdx
+++ b/docs/code-search/queries/index.mdx
@@ -15,7 +15,7 @@ This section documents the available search pattern syntax and interpretation in
 
 ### Keyword search (default)
 
-<Callout type="note" title="Beta">New in version 5.3: Keyword search is in the Beta stage and enabled by default. Toggle the "Search language update" switch to off to enable Standard search. Site administrators can disable Keyword search globally by setting `experimentalFeatures.keywordSearch: false` in site settings. Users can override the setting in their user settings. </Callout>
+<Callout type="note" title="Beta">New in version 5.3: Keyword search is in the Beta stage and enabled by default. Toggle the "Keyword Search" switch to off to enable Standard search. Site administrators can disable Keyword search globally by setting `experimentalFeatures.keywordSearch: false` in site settings. Users can override the setting in their user settings. </Callout>
 
 Keyword search matches individual terms anywhere in the document or the filename. Use `"..."` to match phrases exactly. Specify regular expressions inside `/.../`.
 

--- a/docs/versioned/5.2/code-search/queries/index.mdx
+++ b/docs/versioned/5.2/code-search/queries/index.mdx
@@ -15,7 +15,7 @@ This section documents the available search pattern syntax and interpretation in
 
 ### Keyword search (default)
 
-<Callout type="note" title="Beta">New in version 5.3: Keyword search is in the Beta stage and enabled by default. Toggle the "Search language update" switch to off to enable Standard search. Site administrators can disable Keyword search globally by setting `experimentalFeatures.keywordSearch: false` in site settings. Users can override the setting in their user settings. </Callout>
+<Callout type="note" title="Beta">New in version 5.3: Keyword search is in the Beta stage and enabled by default. Toggle the "Keyword Search" switch to off to enable Standard search. Site administrators can disable Keyword search globally by setting `experimentalFeatures.keywordSearch: false` in site settings. Users can override the setting in their user settings. </Callout>
 
 Keyword search matches individual terms anywhere in the document or the filename. Use `"..."` to match phrases exactly. Specify regular expressions inside `/.../`.
 


### PR DESCRIPTION
We updated the naming on the toggle to "Keyword Search" before releasing.