### PR TITLE
Support initiating search from hash url

### DIFF
--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -8,7 +8,7 @@ import './docsearch/docsearch.css';
 const getInitialQuery = () => {
 	if (typeof window !== 'undefined' && window?.location?.href) {
 		const url = new URL(window.location.href);
-		const [_, hashQuery] = url.hash?.split('#');
+		const hashQuery = url.hash?.slice(1);
 		const params = new URLSearchParams(hashQuery);
 		const query = params.get('q');
 		return query ?? undefined;

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -5,6 +5,16 @@ import './docsearch/docsearch.css';
 
 // import '@docsearch/css';
 
+const getInitialQuery = () => {
+	if (typeof window !== 'undefined' && window?.location?.href) {
+		const url = new URL(window.location.href);
+		const [_, hashQuery] = url.hash?.split('#');
+		const params = new URLSearchParams(hashQuery);
+		const query = params.get('q');
+		return query ?? undefined;
+	}
+}
+
 export const Search = () => {
 	let [modifierKey, setModifierKey] = useState<string>();
 
@@ -13,11 +23,13 @@ export const Search = () => {
 		setModifierKey(isMac ? '⌘' : 'Ctrl');
 	}, []);
 
+	const initialQuery = getInitialQuery();
 	return (
 		<DocSearch
 			appId="0EBA2NRQU3"
 			indexName="sourcegraph"
 			apiKey="1b6e51c1d4ef24bef0a5f1ab00dad80a"
+			initialQuery={initialQuery}
 		/>
 	);
 };

--- a/src/components/search/docsearch/DocSearch.tsx
+++ b/src/components/search/docsearch/DocSearch.tsx
@@ -50,10 +50,10 @@ export interface DocSearchProps {
 
 export function DocSearch(props: DocSearchProps) {
     const searchButtonRef = React.useRef<HTMLButtonElement>(null);
-    const [isOpen, setIsOpen] = React.useState(false);
     const [initialQuery, setInitialQuery] = React.useState<string | undefined>(
         props?.initialQuery || undefined
     );
+    const [isOpen, setIsOpen] = React.useState(!!initialQuery);
 
     const onOpen = React.useCallback(() => {
         setIsOpen(true);
@@ -61,6 +61,7 @@ export function DocSearch(props: DocSearchProps) {
 
     const onClose = React.useCallback(() => {
         setIsOpen(false);
+        setInitialQuery(undefined);
     }, [setIsOpen]);
 
     const onInput = React.useCallback(


### PR DESCRIPTION
I like to create browser shortcuts to quickly search sites. For the handbook you can do that with this url 
```
https://handbook.sourcegraph.com/#stq=test
```

However, for the docs site, it does not support this (as far as I can tell). But with this change you can do this
```
http://localhost:3000/#q=test
```

This PR adds support for this by having it look for the `#q=` hash param and using that to set the initial query. 

To support this I had to make a couple changes

1. In Search.tsx I extract the hash param if it is present and set the `initialQuery` prop in the `<DocSearch>` component (which was not passed in before)
2. I updated `<DocSearch>`  to automatically open the search dialog if the initialQuery prop is present and I clear the query when the dialog is closed. 



![image](https://github.com/sourcegraph/docs/assets/304410/857c7a80-72f7-4086-a629-018fa297a034)
