### PR TITLE
Add note that HTTP clones need to be enabled for Gerrit

### DIFF
--- a/docs/admin/external_service/gerrit.mdx
+++ b/docs/admin/external_service/gerrit.mdx
@@ -31,6 +31,7 @@ A Gerrit instance can be connected to Sourcegraph as follows:
 }
 ```
 4. The provided `username` and `password` must be the HTTP credentials of an admin account on Gerrit. See [the Gerrit HTTP documentation](https://gerrit-documentation.storage.googleapis.com/Documentation/2.14.2/user-upload.html#http) for details on how to generate HTTP credentials.
+<Callout type="note">The Gerrit instance has to have HTTPS clones enabled (the default). [`download.scheme=http`](https://gerrit-review.googlesource.com/Documentation/config-gerrit.html#download). Sourcegraph cannot clone Gerrit repos via SSH.</Callout>
 5. Select **Add Repositories** to create the connection. Sourcegraph will start mirroring the specified projects.
 
 If you added the `"authorization": {}` option to the configuration, and this is the first Gerrit code host connection you have created for this Gerrit instance, you might see a warning like this:


### PR DESCRIPTION
A customer had this option disabled which causes Sourcegraph to fail cloning the repos. Until we support SSH cloning as well, this setting is required for connecting to Gerrit.

![Screenshot 2024-03-26 at 22 11 09@2x](https://github.com/sourcegraph/docs/assets/19534377/e46af28a-c5cd-48c9-b117-c5e416373dc4)
