### PR TITLE
chore: Remove hint about Sourcegraph 2.13

### DIFF
--- a/docs/admin/deploy/docker-single-container/google_cloud.mdx
+++ b/docs/admin/deploy/docker-single-container/google_cloud.mdx
@@ -28,7 +28,7 @@ This tutorial shows you how to deploy [single-container Sourcegraph with Docker]
 
 - Create your VM, then navigate to its public IP address.
 
-- If you have configured a DNS entry for the IP, configure `externalURL` to reflect that. (Note: `externalURL` was called `appURL` in Sourcegraph 2.13 and earlier.)
+- If you have configured a DNS entry for the IP, configure `externalURL` to reflect that.
 
 ---
 

--- a/docs/admin/url.mdx
+++ b/docs/admin/url.mdx
@@ -11,5 +11,3 @@ When that is done, update your DNS records to point to your gateway's external I
   // ...
 }
 ```
-
-> NOTE: `externalURL` was called `appURL` in Sourcegraph 2.13 and earlier.


### PR DESCRIPTION
This version is half a decade old, and no one is using it. Cleaning up to avoid confusion.