### PR TITLE
SGM-6775 - Add rel=canonical tags to /docs

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,6 +25,7 @@ const lexend = localFont({
 });
 
 export const metadata: Metadata = {
+	metadataBase: new URL('https://sourcegraph.com'),
 	title: {
 		template: '%s - Sourcegraph Docs',
 		default: 'Sourcegraph - Docs'
@@ -33,7 +34,9 @@ export const metadata: Metadata = {
 	other: {
 		"docsearch:language": "en",
 		"docsearch:version": `v${config.DOCS_LATEST_VERSION}`
-
+	},
+	alternates: {
+		canonical: '/docs'
 	}
 };
 


### PR DESCRIPTION
### Description
Add rel=canonical tags to /docs

### Ticket
[SG Issue](https://github.com/sourcegraph/about/issues/6775)
[GitStart Ticket](https://clients.gitstart.com/sourcegraph/ticket/SGM-6775)

### Demo
<img width="597" alt="canonical" src="https://github.com/sourcegraph/docs/assets/89894075/4bf718d2-cc23-485a-a636-8b8bf5f08aa0">


### Test plan
- Run the app
- Open browser dev tool
- Verify if the canonical tag is set to `/docs`