### PR TITLE
Add dedicated "Supported Models" page

### DIFF
--- a/docs/cody/capabilities/supported-models.mdx
+++ b/docs/cody/capabilities/supported-models.mdx
@@ -6,10 +6,9 @@ Cody supports a variety of cutting edge large language models for use in Chat, a
 
 | **Provider** | **Model** | **Free** | **Pro** | **Enterprise** |
 |:--|:--|:--|:--|:--|
-| OpenAI | [gpt-3.5 turbo](https://platform.openai.com/docs/models/gpt-3-5-turbo) | - | ✅ | - |
-| OpenAI | [gpt-4 turbo](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#:~:text=TRAINING%20DATA-,gpt%2D4%2D0125%2Dpreview,-New%20GPT%2D4) | - | ✅ | - |
-| OpenAI | [gpt-4](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo) | - | - | ✅ |
-| Anthropic| [claude Instant](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | - |
+| OpenAI | [gpt-3.5 turbo](https://platform.openai.com/docs/models/gpt-3-5-turbo) | - | ✅ | ✅ |
+| OpenAI | [gpt-4 turbo](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#:~:text=TRAINING%20DATA-,gpt%2D4%2D0125%2Dpreview,-New%20GPT%2D4) | - | ✅ | ✅ |
+| Anthropic| [claude Instant](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
 | Anthropic| [claude-2.0](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | ✅ | ✅ | ✅ |
 | Anthropic| [claude-2.1](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
 | Anthropic| [claude-3 Haiku](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | *coming soon* |

--- a/docs/cody/capabilities/supported-models.mdx
+++ b/docs/cody/capabilities/supported-models.mdx
@@ -15,8 +15,8 @@ Cody supports a variety of cutting edge large language models for use in Chat, a
 | Anthropic| [claude-3 Haiku](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | *coming soon* |
 | Anthropic| [claude-3 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | *coming soon* |
 | Anthropic| [claude-3 Opus](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | *coming soon* |
-| Mistral| [Mixtral 8x7b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best) | - | ✅ | - |
-| Ollama* | [*Variety*](https://ollama.com/) | *experimental*| *experimental* | - |
+| Mistral| [mixtral 8x7b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best) | - | ✅ | - |
+| Ollama* | [variety](https://ollama.com/) | *experimental*| *experimental* | - |
 ||||||
 
 ## Autocomplete
@@ -27,7 +27,7 @@ Cody uses a set of models for autocomplete which are suited for the low latency 
 |:--|:--|:--|:--|:--|
 | Fireworks.ai | [StarCoder](https://arxiv.org/abs/2305.06161) | ✅ | ✅ | ✅ |
 | Anthropic| [claude Instant](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | - | ✅ |
-| Ollama* | [*Multiple*](https://ollama.com/) | *experimental*| *experimental* | - |
+| Ollama* | [variety](https://ollama.com/) | *experimental*| *experimental* | - |
 ||||||
 
 

--- a/docs/cody/capabilities/supported-models.mdx
+++ b/docs/cody/capabilities/supported-models.mdx
@@ -1,0 +1,32 @@
+# Supported Large Language Models
+
+## Chat
+
+Cody supports a variety of cutting edge large language models for use in Chat, allowing you to select the best model for your use case.  Free users are defaulted to Claude 2.0 model from Anthropic, while Pro users have access to select any supported model.
+
+| **Provider** | **Model** | **Free** | **Pro** | **Enterprise** |
+|:--|:--|:--|:--|:--|
+| OpenAI | [gpt-3.5 turbo](https://platform.openai.com/docs/models/gpt-3-5-turbo) | - | ✅ | - |
+| OpenAI | [gpt-4 turbo](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#:~:text=TRAINING%20DATA-,gpt%2D4%2D0125%2Dpreview,-New%20GPT%2D4) | - | ✅ | - |
+| OpenAI | [gpt-4](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo) | - | - | ✅ |
+| Anthropic| [claude Instant](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | - |
+| Anthropic| [claude-2.0](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | ✅ | ✅ | ✅ |
+| Anthropic| [claude-2.1](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
+| Anthropic| [claude-3 Haiku](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | *coming soon* |
+| Anthropic| [claude-3 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | *coming soon* |
+| Anthropic| [claude-3 Opus](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | *coming soon* |
+| Mistral| [Mixtral 8x7b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best) | - | ✅ | - |
+| Ollama* | [*Variety*](https://ollama.com/) | *experimental*| *experimental* | - |
+
+## Autocomplete
+
+Cody uses a set of models for autocomplete which are suited for the low latency use case. 
+
+| **Provider** | **Model** | **Free** | **Pro** | **Enterprise** |
+|:--|:--|:--|:--|:--|
+| Fireworks.ai | [StarCoder](https://arxiv.org/abs/2305.06161) | ✅ | ✅ | ✅ |
+| Anthropic| [claude Instant](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | - | ✅ |
+| Ollama* | [*Multiple*](https://ollama.com/) | *experimental*| *experimental* | - |
+
+
+*[*See here for Ollama setup instructions*](https://sourcegraph.com/docs/cody/clients/install-vscode#supported-local-ollama-models-with-cody)

--- a/docs/cody/capabilities/supported-models.mdx
+++ b/docs/cody/capabilities/supported-models.mdx
@@ -17,6 +17,7 @@ Cody supports a variety of cutting edge large language models for use in Chat, a
 | Anthropic| [claude-3 Opus](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | *coming soon* |
 | Mistral| [Mixtral 8x7b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best) | - | ✅ | - |
 | Ollama* | [*Variety*](https://ollama.com/) | *experimental*| *experimental* | - |
+||||||
 
 ## Autocomplete
 
@@ -27,6 +28,8 @@ Cody uses a set of models for autocomplete which are suited for the low latency 
 | Fireworks.ai | [StarCoder](https://arxiv.org/abs/2305.06161) | ✅ | ✅ | ✅ |
 | Anthropic| [claude Instant](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | - | ✅ |
 | Ollama* | [*Multiple*](https://ollama.com/) | *experimental*| *experimental* | - |
+||||||
 
 
-*[*See here for Ollama setup instructions*](https://sourcegraph.com/docs/cody/clients/install-vscode#supported-local-ollama-models-with-cody)
+
+<Callout type="note">[See here for Ollama setup instructions](https://sourcegraph.com/docs/cody/clients/install-vscode#supported-local-ollama-models-with-cody)</Callout>

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -49,6 +49,7 @@ export const navigation: NavigationItem[] = [
               { title: "Commands", href: "/cody/capabilities/commands", },
               { title: "Debug Code", href: "/cody/capabilities/debug-code", },
               { title: "Cody Ignore", href: "/cody/capabilities/ignore-context", },
+              { title: "Supported Models", href: "/cody/capabilities/supported-models", },
             ]
           },
           {


### PR DESCRIPTION
Adds a dedicated page under `Cody > Capabilities > supported-models`

Gives a clear layout of which LLMs are supported for chat and completions and for which account types (Free, Pro, Enterprise)