### PR TITLE
Docs for JetBrains release April 9th

### DIFF
--- a/docs/cody/capabilities/supported-models.mdx
+++ b/docs/cody/capabilities/supported-models.mdx
@@ -1,33 +1,33 @@
 # Supported Large Language Models
 
-## Chat
+## Chat and Commands
 
-Cody supports a variety of cutting edge large language models for use in Chat, allowing you to select the best model for your use case.  Free users are defaulted to Claude 2.0 model from Anthropic, while Pro users have access to select any supported model.
+Cody supports a variety of cutting edge large language models for use in Chat and Commands, allowing you to select the best model for your use case. Free users get Claude 3 Sonnet as the default LLM model from Anthropic, while Pro users have access to select any supported model.
 
-| **Provider** | **Model** | **Free** | **Pro** | **Enterprise** |
-|:--|:--|:--|:--|:--|
-| OpenAI | [gpt-3.5 turbo](https://platform.openai.com/docs/models/gpt-3-5-turbo) | - | ✅ | ✅ |
-| OpenAI | [gpt-4 turbo](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#:~:text=TRAINING%20DATA-,gpt%2D4%2D0125%2Dpreview,-New%20GPT%2D4) | - | ✅ | ✅ |
-| Anthropic| [claude Instant](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
-| Anthropic| [claude-2.0](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | ✅ | ✅ | ✅ |
-| Anthropic| [claude-2.1](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
-| Anthropic| [claude-3 Haiku](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | *coming soon* |
-| Anthropic| [claude-3 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | *coming soon* |
-| Anthropic| [claude-3 Opus](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | *coming soon* |
-| Mistral| [mixtral 8x7b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best) | - | ✅ | - |
-| Ollama* | [variety](https://ollama.com/) | *experimental*| *experimental* | - |
-||||||
+| **Provider** |                                                                   **Model**                                                                   |    **Free**    |    **Pro**     | **Enterprise** |
+| :----------- | :-------------------------------------------------------------------------------------------------------------------------------------------- | :------------- | :------------- | :------------- |
+| OpenAI       | [gpt-3.5 turbo](https://platform.openai.com/docs/models/gpt-3-5-turbo)                                                                        | -              | ✅              | ✅              |
+| OpenAI       | [gpt-4 turbo](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#:~:text=TRAINING%20DATA-,gpt%2D4%2D0125%2Dpreview,-New%20GPT%2D4) | -              | ✅              | ✅              |
+| Anthropic    | [claude Instant](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                     | -              | ✅              | ✅              |
+| Anthropic    | [claude-2.0](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                         | -              | ✅              | ✅              |
+| Anthropic    | [claude-2.1](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                         | -              | ✅              | ✅              |
+| Anthropic    | [claude-3 Haiku](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                     | -              | ✅              | *coming soon*  |
+| Anthropic    | [claude-3 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                    | ✅              | ✅              | *coming soon*  |
+| Anthropic    | [claude-3 Opus](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                      | -              | ✅              | *coming soon*  |
+| Mistral      | [mixtral 8x7b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best)                        | -              | ✅              | -              |
+| Ollama*      | [variety](https://ollama.com/)                                                                                                                | *experimental* | *experimental* | -              |
+|              |                                                                                                                                               |                |                |                |
 
 ## Autocomplete
 
-Cody uses a set of models for autocomplete which are suited for the low latency use case. 
+Cody uses a set of models for autocomplete which are suited for the low latency use case.
 
-| **Provider** | **Model** | **Free** | **Pro** | **Enterprise** |
-|:--|:--|:--|:--|:--|
-| Fireworks.ai | [StarCoder](https://arxiv.org/abs/2305.06161) | ✅ | ✅ | ✅ |
-| Anthropic| [claude Instant](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | - | ✅ |
-| Ollama* | [variety](https://ollama.com/) | *experimental*| *experimental* | - |
-||||||
+| **Provider** |                                         **Model**                                         |    **Free**    |    **Pro**     | **Enterprise** |
+| :----------- | :---------------------------------------------------------------------------------------- | :------------- | :------------- | :------------- |
+| Fireworks.ai | [StarCoder](https://arxiv.org/abs/2305.06161)                                             | ✅              | ✅              | ✅              |
+| Anthropic    | [claude Instant](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | -              | -              | ✅              |
+| Ollama*      | [variety](https://ollama.com/)                                                            | *experimental* | *experimental* | -              |
+|              |                                                                                           |                |                |                |
 
 
 

--- a/docs/cody/clients/install-jetbrains.mdx
+++ b/docs/cody/clients/install-jetbrains.mdx
@@ -107,7 +107,7 @@ Cody with JetBrains offers quick, ready-to-use Commands for common actions to wr
 
 ## Supported LLM models
 
-Cody offers a native support for Claude 2.0 for Chat, Commands, and Autocomplete on the **Free** tier. Users on Cody **Pro** have the ability to choose from a list of supported LLM models for Chat, Commands, and Autocomplete. These LLMs are Claude Instant, Claude 2.0, Claude 2.1, Claude 3 (Opus and Sonnet), ChatGPT 3.5 Turbo, ChatGPT 4 Turbo Preview, and Mixtral.
+For Cody Free users, Claude 3 Sonnet is the default LLM model for Chat and Commands. Users on Cody **Pro** have the ability to choose from a list of supported LLM models for Chat and Commands. These LLMs are Claude Instant, Claude 2.0, Claude 2.1, Claude 3 (Opus and Sonnet), ChatGPT 3.5 Turbo, ChatGPT 4 Turbo Preview, and Mixtral.
 
 ![llm-selection-cody-pro](https://storage.googleapis.com/sourcegraph-assets/Docs/llm-select-jb.png)
 
@@ -115,7 +115,7 @@ Cody Enterprise users get additional capabilities like BYOLLM (Bring Your Own LL
 
 ## Chat history
 
-Next to the chat tab, there is a chat history tab that displays all the previous chat interactions with Cody. You can revisit any of the previous chat interactions to get the context of the conversation.
+Next to the **Chat** tab is **Chat History**, which displays Cody's previous chat interactions. You can revisit any previous chat interactions to get the context of the conversation. You can export your chat history as JSON files for later use.
 
 ## Context fetching mechanism
 

--- a/docs/cody/usage-and-pricing.mdx
+++ b/docs/cody/usage-and-pricing.mdx
@@ -10,7 +10,7 @@ The free plan is designed for individuals to get started with Cody. It comes wit
 
 The free plan provides access to local context with keyword search and embeddings on open-source code via Sourcegraph.com. You get **200 MB** of embeddings over your lifetime and can manage these from the user settings in VS Code, with JetBrains IDE support coming soon. If you embed 150 MB of code, you can only embed another 50 MB of code. If you delete that 150 MB of code embedding, the original 200 MB of code embeddings will be available again.
 
-The free plan ensures local context utilization and allows you to seamlessly integrate Cody into your preferred client, whether it's VSCode, JetBrains, or Neovim. Finally, you'll have default support with Anthropic and StarCoder as the officially supported LLMs.
+The free plan ensures local context utilization and allows you to seamlessly integrate Cody into your preferred client, whether it's VSCode, JetBrains, or Neovim. Finally, you'll have default support with Anthropic (Claude 3 Sonnet for Chat and Commands) and StarCoder as the officially supported LLMs.
 
 ### Billing cycle
 


### PR DESCRIPTION
This PR adds docs changes for the JetBrains release on April 9th. 

- Mentions about Cluade 3 Sonnet as the default LLM model for Cody Free
- Mentions about the functionality to export Chat history as JSON data
- Update Supported LLMs docs page
- Update pricing page 