### PR TITLE
Docs for VS Code release April 3rd

### DIFF
--- a/docs/cody/capabilities/supported-models.mdx
+++ b/docs/cody/capabilities/supported-models.mdx
@@ -12,8 +12,8 @@ Cody supports a variety of cutting edge large language models for use in Chat, a
 | Anthropic| [claude-2.0](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
 | Anthropic| [claude-2.1](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
 | Anthropic| [claude-3 Haiku](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | *coming soon* |
-| Anthropic| [claude-3 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | ✅ | ✅ | ✅ |
-| Anthropic| [claude-3 Opus](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
+| Anthropic| [claude-3 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | ✅ | ✅ | *coming soon* |
+| Anthropic| [claude-3 Opus](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | *coming soon* |
 | Mistral| [mixtral 8x7b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best) | - | ✅ | - |
 | Ollama* | [variety](https://ollama.com/) | *experimental*| *experimental* | - |
 ||||||

--- a/docs/cody/capabilities/supported-models.mdx
+++ b/docs/cody/capabilities/supported-models.mdx
@@ -9,18 +9,18 @@ Cody supports a variety of cutting edge large language models for use in Chat, a
 | OpenAI | [gpt-3.5 turbo](https://platform.openai.com/docs/models/gpt-3-5-turbo) | - | ✅ | ✅ |
 | OpenAI | [gpt-4 turbo](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#:~:text=TRAINING%20DATA-,gpt%2D4%2D0125%2Dpreview,-New%20GPT%2D4) | - | ✅ | ✅ |
 | Anthropic| [claude Instant](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
-| Anthropic| [claude-2.0](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | ✅ | ✅ | ✅ |
+| Anthropic| [claude-2.0](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
 | Anthropic| [claude-2.1](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
 | Anthropic| [claude-3 Haiku](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | *coming soon* |
-| Anthropic| [claude-3 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | *coming soon* |
-| Anthropic| [claude-3 Opus](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | *coming soon* |
+| Anthropic| [claude-3 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | ✅ | ✅ | ✅ |
+| Anthropic| [claude-3 Opus](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
 | Mistral| [mixtral 8x7b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best) | - | ✅ | - |
 | Ollama* | [variety](https://ollama.com/) | *experimental*| *experimental* | - |
 ||||||
 
 ## Autocomplete
 
-Cody uses a set of models for autocomplete which are suited for the low latency use case. 
+Cody uses a set of models for autocomplete which are suited for the low latency use case.
 
 | **Provider** | **Model** | **Free** | **Pro** | **Enterprise** |
 |:--|:--|:--|:--|:--|

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -137,6 +137,8 @@ Cody's chat allows you to add files and symbols as context in your messages.
 
 The `@-file` also supports line numbers. You can specify line numbers when you `@-mention` files in chat by appending `:line-range` after the file name. This allows you to `@-mention` parts of large files and clarifies what Cody commands you refer to.
 
+The `@-files` lookup time for the list of fuzzy-matching files is quite fast (approx. 100ms). This ability to match context is even more prominent when working in large workspaces. Moreover, if your file size is too large, warning messages will appear in the `@-file` selection list, along with guided instructions about typing `@#` symbols for more refined results.
+
 ![Specifying line numbers in @-mentions in Cody for VS Code](https://storage.googleapis.com/sourcegraph-assets/blog/cody-vscode-1.8.0/@file-line-numbers.gif)
 
 ## Context fetching mechanism
@@ -212,11 +214,11 @@ Cody also works with Cursor, Gitpod, IDX, and other similar VS Code forks. To ac
 
 ## Supported LLM models
 
-Cody offers a native support for Anthropic and Starcoder for Chat, Commands on the **Free** tier. Users on Cody **Pro** have the ability to choose from a list of supported LLM models for Chat, Commands, and Autocomplete. These LLMs are Claude Instant, Claude 2.0, Claude 2.1, Claude 3 (Haiku, Opus and Sonnet), ChatGPT 3.5 Turbo, ChatGPT 4 Turbo Preview, and Mixtral.
+Claude 3 Sonnet is the default LLM model for Cody Free users for Chat and Commands. Users on Cody **Pro** can choose from a list of supported LLM models for Chat, Commands, and Autocomplete. These LLMs are Claude Instant, Claude 2.0, Claude 2.1, Claude 3 (Haiku, Opus and Sonnet), ChatGPT 3.5 Turbo, ChatGPT 4 Turbo Preview, and Mixtral.
 
 ![llm-selection-cody-pro](https://storage.googleapis.com/sourcegraph-assets/blog/cody-vscode-1.8.0/claude3-2.png)
 
-Cody Enterprise users get additional capabilities like BYOLLM (Bring Your Own LLM) key. Your site administrator determines the LLM, and cannot be changed within the editor. However, Cody Enterprise users when using Cody Gateway have the ability to [configure custom models](/cody/core-concepts/cody-gateway#configuring-custom-models) Anthropic (like Claude 2.0 and Claude Instant) and OpenAI (GPT 3.5 and GPT 4).
+Cody Enterprise users get Claude 3 (Opus and Sonnet) as the default LLM models without extra cost. In addition, Enterprise users also get capabilities like BYOLLM (Bring Your Own LLM) key. Your site administrator determines the LLM; you cannot change it from the editor. However, when using Cody Gateway, you can [configure custom models](/cody/core-concepts/cody-gateway#configuring-custom-models) Anthropic (like Claude 2.0 and Claude Instant) and OpenAI (GPT 3.5 and GPT 4).
 
 ## Supported local Ollama models with Cody
 

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -220,7 +220,7 @@ Claude 3 Sonnet is the default LLM model for Cody Free users for Chat and Comman
 
 ![llm-selection-cody-pro](https://storage.googleapis.com/sourcegraph-assets/blog/cody-vscode-1.8.0/claude3-2.png)
 
-Cody Enterprise users get Claude 3 (Opus and Sonnet) as the default LLM models without extra cost. In addition, Enterprise users also get capabilities like BYOLLM (Bring Your Own LLM) key. Your site administrator determines the LLM; you cannot change it from the editor. However, when using Cody Gateway, you can [configure custom models](/cody/core-concepts/cody-gateway#configuring-custom-models) Anthropic (like Claude 2.0 and Claude Instant) and OpenAI (GPT 3.5 and GPT 4).
+Cody Enterprise users get Claude 2 as the default LLM model without extra cost. In addition, Enterprise users also get capabilities like BYOLLM (Bring Your Own LLM) key. Your site administrator determines the LLM; you cannot change it from the editor. However, when using Cody Gateway, you can [configure custom models](/cody/core-concepts/cody-gateway#configuring-custom-models) Anthropic (like Claude 2.0 and Claude Instant) and OpenAI (GPT 3.5 and GPT 4).
 
 ## Supported local Ollama models with Cody
 

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -128,16 +128,18 @@ The chat interface is designed intuitively, which makes it easier to edit chat m
   <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/Chat_%20Redesigned%20chat%20editing.mp4" type="video/mp4" />
 </video>
 
-### Selecting Context
+### Selecting Context with @-mentions
 
 Cody's chat allows you to add files and symbols as context in your messages.
 
 - Type `@-file` and then a filename to include a file as context
 - Type `@#` and then a symbol name to include the symbol's definition as context. Functions, methods, classes, types, etc., are all symbols
 
-The `@-file` also supports line numbers. You can specify line numbers when you `@-mention` files in chat by appending `:line-range` after the file name. This allows you to `@-mention` parts of large files and clarifies what Cody commands you refer to.
+The `@-file` also supports line numbers to query the context of large files. You can add ranges of large files to your context by @-mentioning a large file and appending a number range to the filename, for example, `@filepath/filename:1-10`.
 
-The `@-files` lookup time for the list of fuzzy-matching files is quite fast (approx. 100ms). This ability to match context is even more prominent when working in large workspaces. Moreover, if your file size is too large, warning messages will appear in the `@-file` selection list, along with guided instructions about typing `@#` symbols for more refined results.
+When you `@-mention` files to add to Cody’s context window, the file lookup takes `files.exclude`, `search.exclude`, and `.gitgnore` files into account. This makes the file search faster as a result up to 100ms.
+
+Moreover, when you `@-mention` files, Cody will track the number of characters in those files against the context window limit of the selected chat model. As you `@-mention` multiple files, Cody will calculate how many tokens of the context window remain. When the remaining context window size becomes too small, you get **File too large** errors for further more `@-mention` files.
 
 ![Specifying line numbers in @-mentions in Cody for VS Code](https://storage.googleapis.com/sourcegraph-assets/blog/cody-vscode-1.8.0/@file-line-numbers.gif)
 

--- a/docs/cody/usage-and-pricing.mdx
+++ b/docs/cody/usage-and-pricing.mdx
@@ -86,7 +86,7 @@ We don't offer refunds, but if you have any queries regarding the Cody Pro plan,
 
 ## Enterprise
 
-Cody Enterprise is designed for enterprises prioritizing security and administrative controls. We offer either seat-based or token based pricing models, depending on what makes most sense for your organization. You get Claude 3 (Opus and Sonnet) as the default LLM models without extra cost. You also get additional capabilities like BYOLLM (Bring Your Own LLM), supporting Single-Tenant and Self Hosted setups for flexible coding environments.
+Cody Enterprise is designed for enterprises prioritizing security and administrative controls. We offer either seat-based or token based pricing models, depending on what makes most sense for your organization. You get Claude 2 as the default LLM model without extra cost. You also get additional capabilities like BYOLLM (Bring Your Own LLM), supporting Single-Tenant and Self Hosted setups for flexible coding environments.
 
 Security features include SAML/SSO for enhanced authentication and guardrails to enforce coding standards. Cody Enterprise supports advanced Code Graph context and multi-code host context for a deeper understanding of codebases, especially in complex projects. With 24/5 enhanced support, Cody Enterprise ensures timely assistance.
 
@@ -102,7 +102,7 @@ The following table shows a high-level comparison of the three plans available o
 | **Embeddings (public code)**      | Supported                                                  | Supported                                                                                   | Supported                             |
 | **Keyword Context (local code)**  | Supported                                                  | Supported                                                                                   | Supported                             |
 | **Developer Limitations**         | 1 developer                                                | Up to 50 devs                                                                               | Scalable, consumption-based pricing   |
-| **LLM Support**                   | Anthropic + StarCoder for Chat, Commands, and Autocomplete | Choice of LLMs for Chat and Commands (VS Code and JetBrains only), StarCoder and Autocomplete | Claude 3 and Bring Your Own LLM Key (experimental) |
+| **LLM Support**                   | Anthropic + StarCoder for Chat, Commands, and Autocomplete | Choice of LLMs for Chat and Commands (VS Code and JetBrains only), StarCoder and Autocomplete | Claude 2 and Bring Your Own LLM Key (experimental) |
 | **Code Editor Support**           | VS Code, JetBrains IDEs, and Neovim                        | VS Code, JetBrains IDEs, and Neovim                                                         | VS Code, JetBrains IDEs, and Neovim   |
 | **Single-Tenant and Self Hosted** | N/A                                                        | N/A                                                                                         | Yes                                   |
 | **SAML/SSO**                      | N/A                                                        | N/A                                                                                         | Yes                                   |

--- a/docs/cody/usage-and-pricing.mdx
+++ b/docs/cody/usage-and-pricing.mdx
@@ -10,7 +10,7 @@ The free plan is designed for individuals to get started with Cody. It comes wit
 
 The free plan provides access to local context with keyword search and embeddings on open-source code via Sourcegraph.com. You get **200 MB** of embeddings over your lifetime and can manage these from the user settings in VS Code, with JetBrains IDE support coming soon. If you embed 150 MB of code, you can only embed another 50 MB of code. If you delete that 150 MB of code embedding, the original 200 MB of code embeddings will be available again.
 
-The free plan ensures local context utilization and allows you to seamlessly integrate Cody into your preferred client, whether it's VSCode, JetBrains, or Neovim. Finally, you'll have default support with Anthropic and StarCoder as the officially supported LLMs.
+The free plan ensures local context utilization and allows you to seamlessly integrate Cody into your preferred client, whether it's VSCode, JetBrains, or Neovim. Finally, you'll have default support with Anthropic (Claude 3 for Chat and Commands) and StarCoder as the officially supported LLMs.
 
 ### Billing cycle
 
@@ -86,7 +86,7 @@ We don't offer refunds, but if you have any queries regarding the Cody Pro plan,
 
 ## Enterprise
 
-Cody Enterprise is designed for enterprises prioritizing security and administrative controls. We offer either seat-based or token based pricing models, depending on what makes most sense for your organization. You get additional capabilities like BYOLLM (Bring Your Own LLM), supporting Single-Tenant and Self Hosted setups for flexible coding environments.
+Cody Enterprise is designed for enterprises prioritizing security and administrative controls. We offer either seat-based or token based pricing models, depending on what makes most sense for your organization. You get Claude 3 (Opus and Sonnet) as the default LLM models without extra cost. You also get additional capabilities like BYOLLM (Bring Your Own LLM), supporting Single-Tenant and Self Hosted setups for flexible coding environments.
 
 Security features include SAML/SSO for enhanced authentication and guardrails to enforce coding standards. Cody Enterprise supports advanced Code Graph context and multi-code host context for a deeper understanding of codebases, especially in complex projects. With 24/5 enhanced support, Cody Enterprise ensures timely assistance.
 
@@ -102,7 +102,7 @@ The following table shows a high-level comparison of the three plans available o
 | **Embeddings (public code)**      | Supported                                                  | Supported                                                                                   | Supported                             |
 | **Keyword Context (local code)**  | Supported                                                  | Supported                                                                                   | Supported                             |
 | **Developer Limitations**         | 1 developer                                                | Up to 50 devs                                                                               | Scalable, consumption-based pricing   |
-| **LLM Support**                   | Anthropic + StarCoder for Chat, Commands, and Autocomplete | Choice of LLMs for Chat and Commands (VS Code and JetBrains only), StarCoder and Autocomplete | Bring Your Own LLM Key (experimental) |
+| **LLM Support**                   | Anthropic + StarCoder for Chat, Commands, and Autocomplete | Choice of LLMs for Chat and Commands (VS Code and JetBrains only), StarCoder and Autocomplete | Claude 3 and Bring Your Own LLM Key (experimental) |
 | **Code Editor Support**           | VS Code, JetBrains IDEs, and Neovim                        | VS Code, JetBrains IDEs, and Neovim                                                         | VS Code, JetBrains IDEs, and Neovim   |
 | **Single-Tenant and Self Hosted** | N/A                                                        | N/A                                                                                         | Yes                                   |
 | **SAML/SSO**                      | N/A                                                        | N/A                                                                                         | Yes                                   |


### PR DESCRIPTION
This PR adds docs changes for the VS Code release on April 3rd. 

- Mentions about Cluade 3 Sonnet as the default LLM model for Cody Free
- Update Supported LLMs docs page
- Update pricing page 
- Mention updates to @-file file handling and fast look up times 