### PR TITLE
Cody: add GPT-4 for enterprise customers

### DIFF
--- a/docs/cody/capabilities/supported-models.mdx
+++ b/docs/cody/capabilities/supported-models.mdx
@@ -7,6 +7,7 @@ Cody supports a variety of cutting edge large language models for use in Chat, a
 | **Provider** | **Model** | **Free** | **Pro** | **Enterprise** |
 |:--|:--|:--|:--|:--|
 | OpenAI | [gpt-3.5 turbo](https://platform.openai.com/docs/models/gpt-3-5-turbo) | - | ✅ | ✅ |
+| OpenAI | [gpt-4](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#:~:text=to%20Apr%202023-,gpt%2D4,-Currently%20points%20to) | - | - | ✅ |
 | OpenAI | [gpt-4 turbo](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#:~:text=TRAINING%20DATA-,gpt%2D4%2D0125%2Dpreview,-New%20GPT%2D4) | - | ✅ | ✅ |
 | Anthropic| [claude Instant](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
 | Anthropic| [claude-2.0](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | ✅ | ✅ | ✅ |


### PR DESCRIPTION
Adds GPT-4 to the list of supported chat models for enterprise customers.

Should be merged after:
- https://github.com/sourcegraph/sourcegraph/pull/61539
 