### PR TITLE
Update site config discrepancy (address vs addresses)

### DIFF
--- a/docs/admin/config/site_config.mdx
+++ b/docs/admin/config/site_config.mdx
@@ -226,9 +226,7 @@ All site configuration options and their default values are shown below.
 	// - {
 	//     "level": "warning",
 	//     "notifier": {
-	//       "addresses": [
-	//         "alerts@example.com"
-	//       ],
+	//       "addresses": "alerts@example.com",
 	//       "type": "email"
 	//     }
 	//   }

--- a/docs/versioned/5.2/admin/config/site_config.mdx
+++ b/docs/versioned/5.2/admin/config/site_config.mdx
@@ -226,9 +226,7 @@ All site configuration options and their default values are shown below.
 	// - {
 	//     "level": "warning",
 	//     "notifier": {
-	//       "addresses": [
-	//         "alerts@example.com"
-	//       ],
+	//       "addresses": "alerts@example.com",
 	//       "type": "email"
 	//     }
 	//   }


### PR DESCRIPTION
A discrepancy exists for observability alerting on these 2 pages:
https://sourcegraph.com/docs/admin/config/site_config
https://sourcegraph.com/docs/admin/observability/alerting#alerting

Updated link 1 to match link 2(which is correct)