### PR TITLE
Adding new anthropic claude 3 models family to supported models for enterprise customers

### DIFF
--- a/docs/cody/capabilities/supported-models.mdx
+++ b/docs/cody/capabilities/supported-models.mdx
@@ -12,9 +12,9 @@ Cody supports a variety of cutting edge large language models for use in Chat, a
 | Anthropic| [claude Instant](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
 | Anthropic| [claude-2.0](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
 | Anthropic| [claude-2.1](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
-| Anthropic| [claude-3 Haiku](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | *coming soon* |
-| Anthropic| [claude-3 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | ✅ | ✅ | *coming soon* |
-| Anthropic| [claude-3 Opus](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | *coming soon* |
+| Anthropic| [claude-3 Haiku](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
+| Anthropic| [claude-3 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | ✅ | ✅ | ✅ |
+| Anthropic| [claude-3 Opus](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
 | Mistral| [mixtral 8x7b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best) | - | ✅ | - |
 | Ollama* | [variety](https://ollama.com/) | *experimental*| *experimental* | - |
 ||||||


### PR DESCRIPTION
Adds claude 3 models to the list of supported models for enterprise customers and adds a green tick instead of coming soon. 

To be merged after https://github.com/sourcegraph/sourcegraph/pull/61601 and running the SQL query update

