### PR TITLE
JetBrains April release

### DIFF
--- a/docs/cody/capabilities/supported-models.mdx
+++ b/docs/cody/capabilities/supported-models.mdx
@@ -1,8 +1,8 @@
 # Supported Large Language Models
 
-## Chat
+## Chat and Commands
 
-Cody supports a variety of cutting edge large language models for use in Chat, allowing you to select the best model for your use case.  Free users are defaulted to the Claude 3 Sonnet model from Anthropic, while Pro users have access to select any supported model.
+Cody supports a variety of cutting edge large language models for use in Chat and Commands, allowing you to select the best model for your use case.  Free users are defaulted to the Claude 3 Sonnet model from Anthropic, while Pro users have access to select any supported model.
 
 | **Provider** | **Model** | **Free** | **Pro** | **Enterprise** |
 |:--|:--|:--|:--|:--|
@@ -10,7 +10,7 @@ Cody supports a variety of cutting edge large language models for use in Chat, a
 | OpenAI | [gpt-4](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#:~:text=to%20Apr%202023-,gpt%2D4,-Currently%20points%20to) | - | - | ✅ |
 | OpenAI | [gpt-4 turbo](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#:~:text=TRAINING%20DATA-,gpt%2D4%2D0125%2Dpreview,-New%20GPT%2D4) | - | ✅ | ✅ |
 | Anthropic| [claude Instant](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
-| Anthropic| [claude-2.0](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
+| Anthropic| [claude-2.0](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | - |
 | Anthropic| [claude-2.1](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
 | Anthropic| [claude-3 Haiku](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | - | ✅ | ✅ |
 | Anthropic| [claude-3 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison) | ✅ | ✅ | ✅ |
@@ -18,6 +18,8 @@ Cody supports a variety of cutting edge large language models for use in Chat, a
 | Mistral| [mixtral 8x7b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best) | - | ✅ | - |
 | Ollama* | [variety](https://ollama.com/) | *experimental*| *experimental* | - |
 ||||||
+
+<Callout type="note">To use Claude 3 (Opus and Sonnets) models with Cody Enterprise, make sure you've upgraded your Sourcegraph instance to the latest version.</Callout>
 
 ## Autocomplete
 

--- a/docs/cody/clients/install-jetbrains.mdx
+++ b/docs/cody/clients/install-jetbrains.mdx
@@ -107,15 +107,17 @@ Cody with JetBrains offers quick, ready-to-use Commands for common actions to wr
 
 ## Supported LLM models
 
-Cody offers a native support for Claude 2.0 for Chat, Commands, and Autocomplete on the **Free** tier. Users on Cody **Pro** have the ability to choose from a list of supported LLM models for Chat, Commands, and Autocomplete. These LLMs are Claude Instant, Claude 2.0, Claude 2.1, Claude 3 (Opus and Sonnet), ChatGPT 3.5 Turbo, ChatGPT 4 Turbo Preview, and Mixtral.
+For Cody Free users, Claude 3 Sonnet is the default LLM model for Chat and Commands. Users on Cody **Pro** have the ability to choose from a list of supported LLM models for Chat and Commands. These LLMs are Claude Instant, Claude 2.0, Claude 2.1, Claude 3 (Opus and Sonnet), ChatGPT 3.5 Turbo, ChatGPT 4 Turbo Preview, and Mixtral.
 
 ![llm-selection-cody-pro](https://storage.googleapis.com/sourcegraph-assets/Docs/llm-select-jb.png)
 
-Cody Enterprise users get additional capabilities like BYOLLM (Bring Your Own LLM) key. Your site administrator determines the LLM, and cannot be changed within the editor. However, Cody Enterprise users when using Cody Gateway have the ability to [configure custom models](/cody/core-concepts/cody-gateway#configuring-custom-models) Anthropic (like Claude 2.0 and Claude Instant) and OpenAI (GPT 3.5 and GPT 4).
+Enterprise users get Claude 3 (Opus and Sonnet) as the default LLM models without extra cost. You also get additional capabilities like BYOLLM (Bring Your Own LLM), supporting Single-Tenant and Self Hosted setups for flexible coding environments. Your site administrator determines the LLM, and cannot be changed within the editor. However, Cody Enterprise users when using Cody Gateway have the ability to [configure custom models](/cody/core-concepts/cody-gateway#configuring-custom-models) Anthropic (like Claude 2.0 and Claude Instant) and OpenAI (GPT 3.5 and GPT 4).
+
+<Callout type="note">To use Claude 3 (Opus and Sonnets) models with Cody Enterprise, make sure you've upgraded your Sourcegraph instance to the latest version.</Callout>
 
 ## Chat history
 
-Next to the chat tab, there is a chat history tab that displays all the previous chat interactions with Cody. You can revisit any of the previous chat interactions to get the context of the conversation.
+Next to the **Chat** tab is **Chat History**, which displays Cody's previous chat interactions. You can revisit any previous chat interactions to get the context of the conversation. You can export your chat history as JSON files for later use.
 
 ## Context fetching mechanism
 

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -220,7 +220,9 @@ Claude 3 Sonnet is the default LLM model for Cody Free users for Chat and Comman
 
 ![llm-selection-cody-pro](https://storage.googleapis.com/sourcegraph-assets/blog/cody-vscode-1.8.0/claude3-2.png)
 
-Cody Enterprise users get Claude 2 as the default LLM model without extra cost. In addition, Enterprise users also get capabilities like BYOLLM (Bring Your Own LLM) key. Your site administrator determines the LLM; you cannot change it from the editor. However, when using Cody Gateway, you can [configure custom models](/cody/core-concepts/cody-gateway#configuring-custom-models) Anthropic (like Claude 2.0 and Claude Instant) and OpenAI (GPT 3.5 and GPT 4).
+Cody Enterprise users get Claude 3 (Opus and Sonnet) as the default LLM models without extra cost. In addition, Enterprise users also get capabilities like BYOLLM (Bring Your Own LLM) key. Your site administrator determines the LLM; you cannot change it from the editor. However, when using Cody Gateway, you can [configure custom models](/cody/core-concepts/cody-gateway#configuring-custom-models) Anthropic (like Claude 2.0 and Claude Instant) and OpenAI (GPT 3.5 and GPT 4).
+
+<Callout type="note">To use Claude 3 (Opus and Sonnets) models with Cody Enterprise, make sure you've upgraded your Sourcegraph instance to the latest version.</Callout>
 
 ## Supported local Ollama models with Cody
 

--- a/docs/cody/usage-and-pricing.mdx
+++ b/docs/cody/usage-and-pricing.mdx
@@ -10,7 +10,7 @@ The free plan is designed for individuals to get started with Cody. It comes wit
 
 The free plan provides access to local context with keyword search and embeddings on open-source code via Sourcegraph.com. You get **200 MB** of embeddings over your lifetime and can manage these from the user settings in VS Code, with JetBrains IDE support coming soon. If you embed 150 MB of code, you can only embed another 50 MB of code. If you delete that 150 MB of code embedding, the original 200 MB of code embeddings will be available again.
 
-The free plan ensures local context utilization and allows you to seamlessly integrate Cody into your preferred client, whether it's VSCode, JetBrains, or Neovim. Finally, you'll have default support with Anthropic (Claude 3 for Chat and Commands) and StarCoder as the officially supported LLMs.
+The free plan ensures local context utilization and allows you to seamlessly integrate Cody into your preferred client, whether it's VSCode, JetBrains, or Neovim. Finally, you'll have default support with Anthropic (Claude 3 Sonnet for Chat and Commands) and StarCoder as the officially supported LLMs.
 
 ### Billing cycle
 
@@ -86,7 +86,7 @@ We don't offer refunds, but if you have any queries regarding the Cody Pro plan,
 
 ## Enterprise
 
-Cody Enterprise is designed for enterprises prioritizing security and administrative controls. We offer either seat-based or token based pricing models, depending on what makes most sense for your organization. You get Claude 2 as the default LLM model without extra cost. You also get additional capabilities like BYOLLM (Bring Your Own LLM), supporting Single-Tenant and Self Hosted setups for flexible coding environments.
+Cody Enterprise is designed for enterprises prioritizing security and administrative controls. We offer either seat-based or token based pricing models, depending on what makes most sense for your organization. You get Claude 3 (Opus and Sonnet) as the default LLM models without extra cost. You also get additional capabilities like BYOLLM (Bring Your Own LLM), supporting Single-Tenant and Self Hosted setups for flexible coding environments.
 
 Security features include SAML/SSO for enhanced authentication and guardrails to enforce coding standards. Cody Enterprise supports advanced Code Graph context and multi-code host context for a deeper understanding of codebases, especially in complex projects. With 24/5 enhanced support, Cody Enterprise ensures timely assistance.
 
@@ -102,7 +102,7 @@ The following table shows a high-level comparison of the three plans available o
 | **Embeddings (public code)**      | Supported                                                  | Supported                                                                                   | Supported                             |
 | **Keyword Context (local code)**  | Supported                                                  | Supported                                                                                   | Supported                             |
 | **Developer Limitations**         | 1 developer                                                | Up to 50 devs                                                                               | Scalable, consumption-based pricing   |
-| **LLM Support**                   | Anthropic + StarCoder for Chat, Commands, and Autocomplete | Choice of LLMs for Chat and Commands (VS Code and JetBrains only), StarCoder and Autocomplete | Claude 2 and Bring Your Own LLM Key (experimental) |
+| **LLM Support**                   | Anthropic + StarCoder for Chat, Commands, and Autocomplete | Choice of LLMs for Chat and Commands (VS Code and JetBrains only), StarCoder and Autocomplete | Claude 3 and Bring Your Own LLM Key (experimental) |
 | **Code Editor Support**           | VS Code, JetBrains IDEs, and Neovim                        | VS Code, JetBrains IDEs, and Neovim                                                         | VS Code, JetBrains IDEs, and Neovim   |
 | **Single-Tenant and Self Hosted** | N/A                                                        | N/A                                                                                         | Yes                                   |
 | **SAML/SSO**                      | N/A                                                        | N/A                                                                                         | Yes                                   |


### PR DESCRIPTION
This PR adds docs changes for the JetBrains release on April 9th.

- Mentions about Cluade 3 Sonnet as the default LLM model for Cody Free
- Mentions about the functionality to export Chat history as JSON data
- Update Supported LLMs docs page
- Update pricing page