### PR TITLE
repo metadata is GA as of 5.1.0

### DIFF
--- a/docs/code-search/queries/language.mdx
+++ b/docs/code-search/queries/language.mdx
@@ -265,7 +265,7 @@ Set whether the pattern should run a literal search, regular expression search, 
 
 ### Repo has meta
 
-Tagging repositories with key-value pairs is GA as of 5.1.0, but can be disabled if desired by creating the feature flag `repository-metadata` and setting it to `false`. Add metadata by [following the instructions](/admin/repo/metadata).
+Tagging repositories with key-value pairs is GA as of 5.1.0, but can be disabled by creating the feature flag `repository-metadata` and setting it to `false`. Add metadata by [following the instructions](/admin/repo/metadata).
 
 ![repo-has-meta](https://storage.googleapis.com/sourcegraph-assets/Docs/CS-LANG/repo-has-meta.png)
 

--- a/docs/code-search/queries/language.mdx
+++ b/docs/code-search/queries/language.mdx
@@ -255,7 +255,7 @@ For example,
 
 ### Pattern type
 
-![patter-type](https://storage.googleapis.com/sourcegraph-assets/Docs/CS-LANG/pattern-type.png)
+![pattern-type](https://storage.googleapis.com/sourcegraph-assets/Docs/CS-LANG/pattern-type.png)
 
 Set whether the pattern should run a literal search, regular expression search, or structural search. This parameter is available as a command-line and accessibility option and is synonymous with the visual [search pattern](#search-pattern) toggles.
 
@@ -265,9 +265,7 @@ Set whether the pattern should run a literal search, regular expression search, 
 
 ### Repo has meta
 
-<Callout type="note">Tagging repositories with key-value pairs is available is Experimental stage in Sourcegraph 4.0.</Callout>
-
-Tagging repositories with key-value pairs is a **preview** of functionality we're currently exploring to make searching large numbers of repositories easier. To enable this feature, enable the `repository-metadata` feature flag for your org.
+Tagging repositories with key-value pairs is GA as of 5.1.0, but can be disabled if desired by creating the feature flag `repository-metadata` and setting it to `false`. Add metadata by [following the instructions](/admin/repo/metadata).
 
 ![repo-has-meta](https://storage.googleapis.com/sourcegraph-assets/Docs/CS-LANG/repo-has-meta.png)
 


### PR DESCRIPTION
update language to reflect that and add a link
to instructions from the language page