### PR TITLE
remove unreleased changelog entry

### DIFF
--- a/docs/CHANGELOG.mdx
+++ b/docs/CHANGELOG.mdx
@@ -16,7 +16,6 @@ All notable changes to Sourcegraph are documented in this file.
 - Added support for the `gitURLType` setting for Gerrit, Sourcegraph now supports cloning from Gerrit via SSH. Note: Not on Cloud yet, like for all code hosts. [#61537](https://github.com/sourcegraph/sourcegraph/pull/61537)
 - Support for OpenAI chat models for enterprise customers. [#61539](https://github.com/sourcegraph/sourcegraph/pull/61539)
 - Added support for explicitly enumerating repositories to sync from Bitbucket Cloud. Previously, Sourcegraph would automatically sync all repositories from a Bitbucket Cloud workspace. [#61536](https://github.com/sourcegraph/sourcegraph/pull/61536)
-- New `rev:at.time()` search filter that allows you to search a branch at a point in time. [#61513](https://github.com/sourcegraph/sourcegraph/pull/61513)
 
 ### Changed
 


### PR DESCRIPTION
removing a changelog entry for a feature that didn't go out in 5.3.9104

[Context](https://sourcegraph.slack.com/archives/C05D629GWJK/p1713262306198269)