### PR TITLE
Update token-limits.mdx

### DIFF
--- a/docs/cody/core-concepts/token-limits.mdx
+++ b/docs/cody/core-concepts/token-limits.mdx
@@ -5,7 +5,17 @@ title: Cody Input and Output Token Limits
 # Input and Output Token Limits
 
 ## Cody's Current Token Limits
-**Currently Cody caps inputs to approximately 7,000 tokens and outputs to approximately 1,000 tokens.**  This balances our needs for context space, retrieval accuracy and latency ([more here](/cody/core-concepts/token-limits#tradeoffs-size-accuracy-latency-and-cost)).  We are actively working to increase these limits, and will update this page when we do.
+**Input Limits (Claude 3 Sonnet and Opus):**
+**30,000 tokens** of user-defined context (user @-mentioned files) 
+**15,000** tokens of continuous context (user messages and context that's sent back to the LLM to help it recall earlier parts of a conversation).  
+
+**Input Limits (all other models):**
+Approximately 7,000 tokens.
+
+**Outputs Limits:**
+Approximately 4,000 tokens.
+
+This balances our needs for context space, retrieval accuracy and latency ([more here](/cody/core-concepts/token-limits#tradeoffs-size-accuracy-latency-and-cost)).  We are actively working to increase these limits, and will update this page when we do.
 
 For more information on how Cody builds context, see our [documentation here](/cody/core-concepts/context.mdx).
 
@@ -22,26 +32,6 @@ Context windows exist due to computational limitations and memory constraints. L
 When a model generates text or code, it does so token by token, predicting the most likely next token based on the input context and its learned patterns. The output limit determines when the model should stop generating further tokens, even if it could potentially continue.
 
 The output limit helps to keep the generated text focused, concise, and manageable by preventing the model from going off-topic or generating excessively long responses, ensuring that the output can be efficiently processed and displayed by downstream applications or user interfaces while managing computational resources.
-
-
-## Current Foundation Model Limits
-
-Here is a table with the context window sizes and ouput limits for each of our [supported models](/cody/capabilities/supported-models.mdx).
-
-| Model | Context Window | Output Limit |
-|-------|----------------|--------------|
-| gpt-3.5-turbo | 16,385 tokens | 4,096 tokens |
-| gpt-4 | 8,192 tokens | 4,096 tokens |
-| gpt-4-turbo | 128,000 tokens | 4,096 tokens |
-| claude instant | 100,000 tokens | 4,096 tokens |
-| claude-2.0 | 100,000 tokens | 4,096 tokens |
-| claude-2.1 | 200,000 tokens | 4,096 tokens |
-| claude-3 Haiku | 200,000 tokens | 4,096 tokens |
-| claude-3 Sonnet | 200,000 tokens | 4,096 tokens |
-| claude-3 Opus | 200,000 tokens | 4,096 tokens |
-| mixtral 8x7b | 32,000 tokens | 4,096 tokens |
-
-
 
 ## Tradeoffs: Size, Accuracy, Latency and Cost
 


### PR DESCRIPTION
Updated information to reflect changes in context token limits, and output limits.

Also removed the following section:

## Current Foundation Model Limits

Here is a table with the context window sizes and output limits for each of our [supported models](/cody/capabilities/supported-models.mdx).

| Model | Context Window | Output Limit |
|-------|----------------|--------------|
| gpt-3.5-turbo | 16,385 tokens | 4,096 tokens |
| gpt-4 | 8,192 tokens | 4,096 tokens |
| gpt-4-turbo | 128,000 tokens | 4,096 tokens |
| claude instant | 100,000 tokens | 4,096 tokens | | claude-2.0 | 100,000 tokens | 4,096 tokens |
| claude-2.1 | 200,000 tokens | 4,096 tokens |
| claude-3 Haiku | 200,000 tokens | 4,096 tokens | | claude-3 Sonnet | 200,000 tokens | 4,096 tokens | | claude-3 Opus | 200,000 tokens | 4,096 tokens |
| mixtral 8x7b | 32,000 tokens | 4,096 tokens |
| mixtral 8x22b | 64,000 tokens | 4,096 tokens |


>>>This section was removed as it was incorrect information with numbers that didn't reflect Codys actual token limits,  which could be seen as either misleading, or at minimum, confusing to end-users.