### PR TITLE
Add Cody Ignore pings

### DIFF
--- a/docs/admin/pings.mdx
+++ b/docs/admin/pings.mdx
@@ -198,6 +198,14 @@ Sourcegraph aggregates usage and performance metrics for some product features i
     - Displaying ownership panel in file view.
 - Histogram of cloned repository sizes
 - Aggregate daily, weekly, monthly repository metadata usage statistics
+- Cody providers data
+  - Completions
+    - Provider name
+    - Chat, fast chat, and completion model names (only for "sourcegraph" provider)
+  - Embeddings
+    - Provider name
+    - Model name (only for "sourcegraph" provider)
+- Whether Cody context filters are configured in the site config (true/false)
 
 ## Allowlist IPs / CIDR Ranges for Sourcegraph
 


### PR DESCRIPTION
1. Docs update on new pings data:
- RFC
- https://github.com/sourcegraph/sourcegraph/pull/62080

2. Add missing data on Cody providers pings. It existed on the old docs site, data is still reported via pings, so it should probably be mentioned on the pings page. Feel free to push back on this if we intentionally removed this data.