### PR TITLE
Add Managing access tokens page

### DIFF
--- a/docs/cli/how-tos/index.mdx
+++ b/docs/cli/how-tos/index.mdx
@@ -4,3 +4,4 @@ The following how-tos apply to the `src` command line interface to Sourcegraph:
 
 - [Creating an access token](/cli/how-tos/creating_an_access_token)
 - [Revoking an access token](/cli/how-tos/revoking_an_access_token)
+- [Managing access tokens](managing_access_tokens.mdx)

--- a/docs/cli/how-tos/index.mdx
+++ b/docs/cli/how-tos/index.mdx
@@ -4,4 +4,4 @@ The following how-tos apply to the `src` command line interface to Sourcegraph:
 
 - [Creating an access token](/cli/how-tos/creating_an_access_token)
 - [Revoking an access token](/cli/how-tos/revoking_an_access_token)
-- [Managing access tokens](managing_access_tokens.mdx)
+- [Managing access tokens](/cli/how-tos/managing_access_tokens)

--- a/docs/cli/how-tos/managing_access_tokens.mdx
+++ b/docs/cli/how-tos/managing_access_tokens.mdx
@@ -10,6 +10,8 @@ The `auth.accessTokens.allow` configuration field permits or restricts the creat
 - `all-users-create` Allows users to create their own token.
 - `site-admin-create` Allows site admins to create tokens for users.
 
+`auth.accessTokens.maxTokensPerUser` - This config field determines the maximum number of active access tokens a user can have. The default maximum is 25 tokens.
+
 ## Access token expiration
 
 Admins can set expiration policies for access tokens. After this specified period, tokens will automatically lose their access. Note that tokens created before version 5.3 do not expire; this policy only applies to **new** tokens.
@@ -19,5 +21,3 @@ Admins can set expiration policies for access tokens. After this specified perio
 `auth.accessTokens.expirationOptionDays` - This represents the options users are presented with for the token expiration period. The default options are [7, 14, 30, 60, 90].
 
 `auth.accessTokens.defaultExpirationDays` - This sets the default duration selection when creating a new access token. The default is 90 days.
-
-`auth.accessTokens.maxTokensPerUser` - This config field determines the maximum number of active access tokens a user can have. The default maximum is 25 tokens.

--- a/docs/cli/how-tos/managing_access_tokens.mdx
+++ b/docs/cli/how-tos/managing_access_tokens.mdx
@@ -1,0 +1,23 @@
+# Managing access tokens
+
+The `auth.accessTokens` setting in Sourcegraph's site configuration allows admins to fine-tune parameters related to access tokens. 
+
+## Access token creation
+
+The `auth.accessTokens.allow` configuration field permits or restricts the creation of access tokens. It can be assigned one of three values: "none," "all-users-create" (which is the default option), or "site-admin-create.”
+
+- `none` Disables the creation of access tokens.
+- `all-users-create` Allows users to create their own token.
+- `site-admin-create` Allows site admins to create tokens for users.
+
+## Access token expiration
+
+Admins can set expiration policies for access tokens. After this specified period, tokens will automatically lose their access. Note that tokens created before version 5.3 do not expire; this policy only applies to **new** tokens.
+
+`auth.accessTokens.allowNoExpiration` - This controls whether tokens can be created with no expiration date. The default setting is false.
+
+`auth.accessTokens.expirationOptionDays` - This represents the options users are presented with for the token expiration period. The default options are [7, 14, 30, 60, 90].
+
+`auth.accessTokens.defaultExpirationDays` - This sets the default duration selection when creating a new access token. The default is 90 days.
+
+`auth.accessTokens.maxTokensPerUser` - This config field determines the maximum number of active access tokens a user can have. The default maximum is 25 tokens.


### PR DESCRIPTION
Added a new link to the "Managing access tokens" page in the how-tos directory since there are a couple of access token-related pages here. There may be a better place for this page.