### PR TITLE
Add default PR template to suggest users get reviews

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+<!-- Explain the changes introduced in your PR -->
+
+## Pull Request approval
+
+Although pull request approval is not enforced for this repository in order to reduce friction, merging without a review will generate a ticket for the docs team to review your changes. So if possible, have your pull request approved before merging.


### PR DESCRIPTION
As part of the discussion about reducing friction when making docs changes, we're proposing removing the requirement for approval before review.

Users creating PRs will still be **prompted** to get approval for changes via this template, but it will not be enforced. Vercel CI passing **will** still be enforced.

* If a user receives approval, the PR is merged as normal.
* If a user doesn't receive approval, the PR will be merged but a ticket will be opened in the [audit trail repo](https://github.com/sourcegraph/sec-pr-audit-trail/issues?q=is:issue) repo which the docs team will be responsible for closing, effectively performing a post-merge review.