### PR TITLE
docs: move displayLimit field description from admin site config to user settings docs page

### DIFF
--- a/docs/admin/config/settings.mdx
+++ b/docs/admin/config/settings.mdx
@@ -112,6 +112,9 @@ Settings options and their default values are shown below.
 	// The default pattern type that search queries will be intepreted as. `lucky` is an experimental mode that will interpret the query in multiple ways.
 	"search.defaultPatternType": null,
 
+	// The number of results we send down during a search. Note: this is different to the count: in the query. The search will continue once we hit displayLimit and updated filters and statistics will continue to stream down. Defaults to 1500.
+	"search.displayLimit": 1500,
+
 	// Disable search suggestions below the search bar when constructing queries. Defaults to false.
 	"search.hideSuggestions": false,
 

--- a/docs/admin/config/site_config.mdx
+++ b/docs/admin/config/site_config.mdx
@@ -803,7 +803,6 @@ All site configuration options and their default values are shown below.
 	// - {
 	//     "commitDiffMaxRepos": 50,
 	//     "commitDiffWithTimeFilterMaxRepos": 5000,
-	//     "displayLimit": 1500,
 	//     "maxRepos": 200,
 	//     "maxTimeoutSeconds": 60
 	//   }


### PR DESCRIPTION
## Description

- Changes to the documentation based on:
	- Issue: https://github.com/sourcegraph/sourcegraph/issues/36691
	- PR: https://github.com/sourcegraph/sourcegraph/pull/60761