### PR TITLE
Explain `internal` repositoryQuery

### DIFF
--- a/docs/admin/external_service/github.mdx
+++ b/docs/admin/external_service/github.mdx
@@ -494,6 +494,8 @@ GitHub connections support the following configuration options, which are specif
 	//
 	// - `public` mirrors all public repositories for GitHub Enterprise and is the equivalent of `none` for GitHub
 	//
+	// - `internal` mirrors all internal repositories for GitHub Enterprise and is the equivalent of `none` for GitHub
+	//
 	// - `affiliated` mirrors all repositories affiliated with the configured token's user:
 	// 	- Private repositories with read access
 	// 	- Public repositories owned by the user or their orgs

--- a/docs/admin/external_service/github.mdx
+++ b/docs/admin/external_service/github.mdx
@@ -538,7 +538,7 @@ Sourcegraph displays search results from the default branch of a repository when
 ## Troubleshooting
 
 ### Hitting GitHub Search API rate limit with repositoryQuery
-When Sourcegraph syncs repositories configured  via `repositoryQuery`, it consumes GitHub API search rate limit, which is lower than the normal rate limit. The `affiliated`, `public` and `none` special values, however, trigger normal API requests instead of search API requests.
+When Sourcegraph syncs repositories configured  via `repositoryQuery`, it consumes GitHub API search rate limit, which is lower than the normal rate limit. The `affiliated`, `public`, and `none` special values, however, trigger normal API requests instead of search API requests. `internal` is also a special value that uses the GitHub Search API to list all internal repositories.
 
 When the search rate limit quota is exhausted, an error like `failed to list GitHub repositories for search: page=..., searchString=\"...\"` can be found in logs. To work around this try reducing the frequency with which repository syncing happens by setting a higher value (in minutes) of `repoListUpdateInterval` in your Sourcegraph [site config](https://docs.sourcegraph.com/admin/config/site_config).
 


### PR DESCRIPTION
Doc update for https://github.com/sourcegraph/sourcegraph/pull/62266