### PR TITLE
rockskip: document utf-8 limitation

### DIFF
--- a/docs/code-search/code-navigation/rockskip.mdx
+++ b/docs/code-search/code-navigation/rockskip.mdx
@@ -138,3 +138,7 @@ Rockskip indexes the new commits since the previously indexed commit, so if it's
 ## How does it work?
 
 For a deeper dive into the index and query structures, check out the [explanatory RFC](https://docs.google.com/document/d/1sDDpZaWdGtIaiNLNB8QsLwHTvH10fhEKpEa4qcog5vg/edit?usp=sharing).
+
+## Limitations
+
+- Rockskip does not support file paths that are not encoded in UTF-8. Consequently, any symbols in files with non-UTF-8 encoded paths will not be indexed.


### PR DESCRIPTION
This documents a limitation we encountered recently.