### PR TITLE
shorter/simpler site description

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
 		template: '%s - Sourcegraph docs',
 		default: 'Sourcegraph docs'
 	},
-	description: 'Delve into Sourcegraph Docs to transform your coding workflow. With features like AI-assisted code comprehension with Cody, robust code search across branches, and code intelligence for navigation and insights, streamline your development process for efficiency and accuracy.',
+	description: 'Documentation for Sourcegraph, the code intelligence platform.',
 	other: {
 		"docsearch:language": "en",
 		"docsearch:version": `v${config.DOCS_LATEST_VERSION}`


### PR DESCRIPTION
- "Delve" is a word that people have recently jokingly started to associate with AI-written content, so I'd like to avoid that word.
- It seems better to simplify the site description instead of using it to pitch Sourcegraph's value prop. The ideal would be to make each page's description and OpenGraph description describe the page rather than the overall site.