### PR TITLE
Update token-limits of claude 3 sonnet and opus

### DIFF
--- a/docs/cody/core-concepts/token-limits.mdx
+++ b/docs/cody/core-concepts/token-limits.mdx
@@ -15,8 +15,8 @@ Here's a detailed breakdown of the token limits by model:
 | claude-2.0          | 7,000            | shared               | 4,000      |
 | claude-2.1          | 7,000            | shared               | 4,000      |
 | claude-3 Haiku      | 7,000            | shared               | 4,000      |
-| **claude-3 Sonnet** | **200,000**      | **15,000**           | **4,000**  |
-| **claude-3 Opus**   | **200,000**      | **15,000**           | **4,000**  |
+| **claude-3 Sonnet** | **30,000**      | **15,000**           | **4,000**  |
+| **claude-3 Opus**   | **30,000**      | **15,000**           | **4,000**  |
 | mixtral 8x7b        | 7,000            | shared               | 4,000      |
 
 For more information on how Cody builds context, see our [documentation here](/cody/core-concepts/context).


### PR DESCRIPTION
User-defined window for Opus and Sonnet is mentioned in this same doc as 30k but was added as 200k.
The number is mentioned as 30k here too:
https://sourcegraph.com/blog/cody-vscode-1-14-0-release#bigger-and-better-context-windows-to-improve-chat