### PR TITLE
Add Resource Estimator and AWS OneClick docs in version 5.2

### DIFF
--- a/docs/versioned/5.2/admin/deploy/machine-images/aws-oneclick.mdx
+++ b/docs/versioned/5.2/admin/deploy/machine-images/aws-oneclick.mdx
@@ -1,0 +1,114 @@
+# AWS One-Click Installation for Sourcegraph
+
+This page describes how to launch a verified and pre-configured Sourcegraph instance in just ~10 minutes using our one-click CloudFormation template and standard AMIs.
+
+Prefer manually installing on AWS yourself? See our [AMI](/admin/deploy/machine-images/aws-ami) installation options or our [script-install](/admin/deploy/single-node/script) installation options.
+
+## Prerequisites
+
+* An AWS account (most regions are supported, see our [Launcher](#deploy-sourcegraph) below for a complete list)
+* General familiarity with AWS
+* An [EC2 keypair](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-key-pairs.html) for SSH access
+* (optional) A Sourcegraph license to unlock features ([view plans](https://sourcegraph.com/pricing) or [learn how licenses work](/admin/subscriptions/index))
+
+## What will be created
+
+Using our wizard, a single EC2 instance will be created with the following:
+
+- EBS root volume: 50GB
+- EBS data volume: 500GB - your Sourcegraph data (code and search indices.)
+- AWS Network Security Group
+- The latest version of Sourcegraph
+- (optional) DNS and TLS via AWS Load Balancer and AWS Certificate Manager
+
+<Callout type="note">The instance will launch in the default VPC. If your AWS user does not have a default VPC, or the option `Auto-assign public IPv4 address` is not enabled for a subnet within that VPC, please see our [Manual AMI](/admin/deploy/machine-images/aws-ami) instructions instead.</Callout>
+
+![aws-oneclick](https://storage.googleapis.com/sourcegraph-assets/Docs/aws-oneclick-diagram.png)
+
+## Determine your instance size
+
+The number of users and repositories you will use with Sourcegraph determines your instance size. If you fall between two sizes, choose the larger of the two.
+
+Example: With 8,000 users with 80,000 repositories, your instance size would be **L**. If you have 1,000 users with 80,000 repositories, then size **M**.
+
+|                      |   **XS**    |    **S**    |    **M**    |    **L**     |    **XL**    |
+| -------------------- | ----------- | ----------- | ----------- | ------------ | ------------ |
+| **Users**            | `<= 500`    | `<= 1,000`  | `<= 5,000`  | `<= 10,000`  | `<= 20,000`  |
+| **Repositories**     | `<= 5,000`  | `<= 10,000` | `<= 50,000` | `<= 100,000` | `<= 250,000` |
+| **Recommended Type** | m6a.2xlarge | m6a.4xlarge | m6a.8xlarge | m6a.12xlarge | m6a.24xlarge |
+| **Minimum Type**     | m6a.2xlarge | m6a.2xlarge | m6a.4xlarge | m6a.8xlarge  | m6a.12xlarge |
+
+## Deploy Sourcegraph 🎉
+
+<Callout type="note">For security, please follow [Amazon best practices](https://docs.aws.amazon.com/accounts/latest/reference/best-practices-root-user.html) and _do not deploy Sourcegraph using your AWS account root user.</Callout>
+
+<Callout type="note">By default the CloudFormation template will create standard EBS volumes. If you have special EBS volume encryption requirements, please see the [AWS EBS Encryption guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html) and install Sourcegraph using our [Manual AMI](/admin/deploy/machine-images/aws-ami) instructions instead.</Callout>
+
+Choose an AWS Region in the launcher below and click **Launch Stack**. When prompted, choose your **SSH Keypair** and **Sourcegraph Instance Size** per the chart above, then **Create Stack**.
+
+<AWSOneClickLaunchForm />
+
+If you're running into any problem, see our [Troubleshooting guide](/admin/troubleshooting).
+
+### Confirm you can access Sourcegraph
+
+Find the URL of your Sourcegraph instance in the **Outputs** section of the AWS Stack. On first launch, Sourcegraph may take ~5 minutes to start and may display a `404 not found` page temporarily.
+
+### Executors
+
+Executors are supported using [native kubernetes executors](/admin/executors/deploy_executors_kubernetes).
+
+Executors support [auto-indexing](/code-search/code-navigation/auto_indexing) and [server-side batch changes](/batch_changes/explanations/server_side).
+
+To enable executors you must do the following:
+
+1. Connect to the AMI instance using `ssh`
+2. Run `cd /home/ec2-user/deploy/install/`
+3. Replace the placeholder `executor.frontendPassword` in `override.yaml`
+4. Run the following command to update the executor
+
+```curl
+helm upgrade -i -f ./override.yaml --version "$(cat /home/ec2-user/.sourcegraph-version)" executor sourcegraph/sourcegraph-executor-k8s
+```
+
+1. Adding the following to the site-admin config using the password you chose previously
+
+```curl
+"executors.accessToken": "<exector.frontendPassword>",
+"executors.frontendURL": "http://sourcegraph-frontend:30080",
+"codeIntelAutoIndexing.enabled": true
+```
+
+1. Check `Site-Admin > Executors > Instances` to verify the executor connected successfully. If it does not appear try reboot the instance
+
+To use server-side batch changes you will need to enable the `native-ssbc-execution` [feature flag](/admin/executors/native_execution#enable).
+
+### Secure your instance
+
+By default Sourcegraph will be available over HTTP on the public internet. To secure it you should now perform the following:
+
+1. [Configure DNS and HTTPS/TLS](/admin/deploy/machine-images/aws-ami#networking) using an AWS Load Balancer and AWS Certificate Manager.
+2. [Configure user authentication](/admin/auth/) (SSO, SAML, OpenID Connect, etc.)
+3. [Review the new Network Security Group](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html) to prevent access from the public internet and follow the principle of least privilege.
+
+## Managing Sourcegraph
+
+### Backup and restore
+
+We strongly recommend you taking [snapshots of the entire Sourcegraph data EBS volume](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-creating-snapshot.html) on an [automatic, scheduled basis](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snapshot-lifecycle.html). Only the Sourcegraph data volume (500G) needs to be backed up.
+
+To restore from a backup, simply follow our [upgrade instructions](/admin/deploy/machine-images/aws-ami#upgrade) and skip directly to **Step 2: Launch a new instance** - choosing your desired Sourcegraph version and your backed up data volume.
+
+### Upgrading your Sourcegraph instance
+
+Updates are released every month, and upgrading is a simple process: backup your instance, detach the Sourcegraph data volume, and start a new instance using the latest AMI with your data volume attached. For step-by-step instructions [see here](/admin/deploy/machine-images/aws-ami#upgrade).
+
+### Monitoring & alerting
+
+Sourcegraph comes with extensive built-in monitoring dashboards & the ability to configure alerts. Please see our [monitoring guide](/admin/how-to/monitoring-guide) for more information.
+
+### Get Support
+
+Feel free to reach out to `support@sourcegraph.com` if you have any questions.
+
+Business support, training, Slack support, SLAs, and dedicated Technical Advisors are all available through [Business and Enterprise plans](https://sourcegraph.com/pricing).

--- a/docs/versioned/5.2/admin/deploy/resource_estimator.mdx
+++ b/docs/versioned/5.2/admin/deploy/resource_estimator.mdx
@@ -1,0 +1,35 @@
+# Sourcegraph Resource Estimator
+
+Updating the form below will recalculate an estimate for the resources you can use to configure your Sourcegraph deployment.
+
+<ResourceEstimator />
+
+<Callout type="info">For any questions or issues [get help from an engineer](mailto:support@sourcegraph.com).</Callout>
+
+## Additional information
+
+### Limitations
+
+- The estimator does not support instances with more than **50,000 users or 5,000,000 repositories**.
+
+### How to update a resource in your deployment?
+
+- For docker-compose deployments, edit your [docker-compose.yml file](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) and set `cpus` and `mem_limit` to the limits shown above
+- For Helm deployments, create an [override file](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/examples/common-modifications/override.yaml) (or update your existing override file) with the new values shown above
+- For non-Helm Kubernetes deployments, we recommend using Kustomize to generate manifests with the values shown above. Please refer to our [Kustomize overlay for resources update](https://github.com/sourcegraph/deploy-sourcegraph/tree/master/overlays/resources-update) for detail
+
+### What is engagement rate?
+
+(*Deprecated*) Engagement rate refers to the percentage of users who use Sourcegraph regularly. It is generally used for existing deployments to estimate resources.
+
+### If you plan to enforce repository permissions on Sourcegraph
+
+Repository permissions on Sourcegraph can have a noticeable impact on search performance if you have a large number of users and/or repositories on your code host. We suggest setting your authorization ttl values as high as you are comfortable setting it in order to reduce the chance of this (e.g. to 72h) in the repository permission configuration.
+
+### What kind of data can be regenerated without backup?
+
+See our docs on [Persistent data backup in Kubernetes](/admin/deploy/migrate-backup#persistent-data-backup-in-kubernetes) for more detail.
+
+#### How does Sourcegraph scale?
+
+[Click here to learn more about how each Sourcegraph service scales.](/admin/deploy/scale)


### PR DESCRIPTION
The PR adds missing resource estimator and awsoneclick docs in version 5.2 folder.
