### PR TITLE
Remove content layout shifts (CLS) from Cody for VS Code install page

### DIFF
--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -22,7 +22,11 @@ Follow these steps to install the Cody AI extension for VS Code:
 - Type **Cody AI** in the search bar and click the **Install** button
 - After installing, you may be prompted to reload VS Code to activate the extension
 
-![install-vscode-extension](https://storage.googleapis.com/sourcegraph-assets/Docs/install-cody-vscode.png)
+<img
+  src="https://storage.googleapis.com/sourcegraph-assets/Docs/install-cody-vscode.png"
+  alt="Screenshot of Cody for VS Code marketplace install page"
+  style={{ aspectRatio: '2630 / 802' }}
+/>
 
 Alternatively, you can also [download and install the extension from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai) directly.
 
@@ -34,7 +38,11 @@ After a successful installation, the Cody icon appears in the [Activity sidebar]
 
 Cody Free and Cody Pro users can sign in to their Sourcegraph.com accounts through GitHub, GitLab, or Google.
 
-![cody-sign-flow](https://storage.googleapis.com/sourcegraph-assets/Docs/cody-new-ui.png)
+<img
+  src="https://storage.googleapis.com/sourcegraph-assets/Docs/cody-new-ui.png"
+  alt="Cody for VS Code sign in flow"
+  style={{ aspectRatio: '1296 / 671' }}
+/>
 
 ### Sourcegraph Enterprise Cody Users
 
@@ -44,41 +52,77 @@ Sourcegraph Enterprise users should connect Cody to their Enterprise instance by
 
 You'll be prompted to choose how to sign-in, select **Sign In to Sourcegraph Instances v5.1 and above**.
 
-![sign-in-option](https://storage.googleapis.com/sourcegraph-assets/Docs/927fb401aa80af47f4384a854309b0ed5ac58da34507ed4c0dfd72da61e1edfb.png)
+<img
+  src="https://storage.googleapis.com/sourcegraph-assets/Docs/927fb401aa80af47f4384a854309b0ed5ac58da34507ed4c0dfd72da61e1edfb.png"
+  alt="Sign in options"
+  style={{ aspectRatio: '1212 / 282' }}
+/>
 
 Enter the URL of your Enterprise instance. If you are unsure, please contact your administrator.
 
-![instance-url](https://storage.googleapis.com/sourcegraph-assets/Docs/c8fc65594ac718cfc6e6d67e76af8dd8989c8dd6300725f5afd872210f76e786.png)
+<img
+  src="https://storage.googleapis.com/sourcegraph-assets/Docs/c8fc65594ac718cfc6e6d67e76af8dd8989c8dd6300725f5afd872210f76e786.png"
+  alt="Instance URL"
+  style={{ aspectRatio: '1210 / 150' }}
+/>
 
 A pop-up will ask if you want to Open the URL in a new window. Click **Open** to open the URL in a new window.
 
-![](https://storage.googleapis.com/sourcegraph-assets/Docs/0c72d6a8e48a28bb6543d5dd333187ae130743937e584b67bd3a42b810e9ec69.png)
+<img
+	src="https://storage.googleapis.com/sourcegraph-assets/Docs/0c72d6a8e48a28bb6543d5dd333187ae130743937e584b67bd3a42b810e9ec69.png"
+	alt="Cody for VS Code sign in permissions dialog"
+	style={{ aspectRatio: '536 / 712' }}
+	/>
 
 Sign in to your instance. If you do not yet have a login, please contact your administrator.
 
-![](https://storage.googleapis.com/sourcegraph-assets/Docs/3b66de59129d19d8e71ed4d07b1e369ac956b7e3177cb8d3af60765559842431.png)
+<img
+	src="https://storage.googleapis.com/sourcegraph-assets/Docs/3b66de59129d19d8e71ed4d07b1e369ac956b7e3177cb8d3af60765559842431.png"
+	alt="Sign in"
+	style={{ aspectRatio: '784 / 806' }}
+	/>
 
 Create an access token from Account Settings - Access Tokens. Click **+ Generate new token**
 
-![create-token](https://storage.googleapis.com/sourcegraph-assets/Docs/a88d828e082067ac6c57f8c32d67de3bf093732689578a4aa29c5b2f67fd53ba.png)
+<img
+	src="https://storage.googleapis.com/sourcegraph-assets/Docs/a88d828e082067ac6c57f8c32d67de3bf093732689578a4aa29c5b2f67fd53ba.png"
+	alt="Creating an access token"
+	style={{ aspectRatio: '2252 / 448' }}
+	/>
 
 Name the token and click **+ Generate token**.
 
-![name-generate-token](https://storage.googleapis.com/sourcegraph-assets/Docs/6e2255ea122a5b1840d0ce7c032e26742540b7a2a610ab95d47e969b9f94e3f4.png)
+<img
+	src="https://storage.googleapis.com/sourcegraph-assets/Docs/6e2255ea122a5b1840d0ce7c032e26742540b7a2a610ab95d47e969b9f94e3f4.png"
+	alt="Token name"
+	style={{ aspectRatio: '1808 / 638' }}
+	/>
 
 Copy the token and return to VSCode.
 
-![copy-token](https://storage.googleapis.com/sourcegraph-assets/Docs/707e642d4cf84aba4134cb83d2bdc0c1280f847d0909c144aaf43e004de3a945.png)
+<img
+	src="https://storage.googleapis.com/sourcegraph-assets/Docs/707e642d4cf84aba4134cb83d2bdc0c1280f847d0909c144aaf43e004de3a945.png"
+	alt="Copying the token"
+	style={{ aspectRatio: '1816 / 926' }}
+	/>
 
 Again, click **Sign In to Your Enterprise Instance** and choose **Sign In to Sourcegraph Instances v5.1 and above**. Enter the URL of your instance.
 
 You should now be prompted to authorize Sourcegraph to connect to your VSCode extension using the token you created. Click **Authorize**.
 
-![](https://storage.googleapis.com/sourcegraph-assets/Docs/78651f94c061ba7a63041893a73705b5b5568587830831f68b3afee1f02ca744.png)
+<img
+	src="https://storage.googleapis.com/sourcegraph-assets/Docs/78651f94c061ba7a63041893a73705b5b5568587830831f68b3afee1f02ca744.png"
+	alt="Authorization permission dialog"
+	style={{ aspectRatio: '780 / 1086' }}
+	/>
 
 Finally, you will be asked to allow the extension access. CLick **Open**.
 
-![](https://storage.googleapis.com/sourcegraph-assets/Docs/946384c3bbce7790dc119ecec2d1540fcb3e50dc007eee4472c0bcac8b14c251.png)
+<img
+	src="https://storage.googleapis.com/sourcegraph-assets/Docs/946384c3bbce7790dc119ecec2d1540fcb3e50dc007eee4472c0bcac8b14c251.png"
+	alt="VS Code allow permissions dialog"
+	style={{ aspectRatio: '572 / 630' }}
+	/>
 
 VSCode should now display the Cody panel and you're ready to go.
 
@@ -86,7 +130,11 @@ VSCode should now display the Cody panel and you're ready to go.
 
 Once connected, click the Cody icon from the sidebar again. The Cody extension will open in a configurable side panel.
 
-![code-panel](https://storage.googleapis.com/sourcegraph-assets/Docs/NLS-Beta.png)
+<img
+	src="https://storage.googleapis.com/sourcegraph-assets/Docs/NLS-Beta.png"
+	alt="Cody for VS Code"
+	style={{ aspectRatio: '1306 / 1940' }}
+	/>
 
 Let's create an autocomplete suggestion to verify that the Cody extension has been successfully installed and is working as expected.
 
@@ -104,7 +152,7 @@ function bubbleSort(array){
 - As you start typing, Cody will automatically provide suggestions and context-aware completions based on your coding patterns and the code context
 - These autocomplete suggestions appear as grayed text. To accept the suggestion, press the `Tab` key
 
-    <video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto' }}>
+    <video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto', aspectRatio: '1920 / 1080' }}>
           <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/cody-in-action.mp4" type="video/mp4" />
           </video>
 
@@ -118,13 +166,17 @@ All previous and existing chats are stored under the chats panel on the left. Yo
 
 There is a **Chat History** button at the top of your chat tabs, so you can navigate between chats (and search chats) without opening the Cody sidebar.
 
-![view-chat-history](https://storage.googleapis.com/sourcegraph-assets/blog/vscode-v1-2-0-blog/image-002.png)
+<img
+	src="https://storage.googleapis.com/sourcegraph-assets/blog/vscode-v1-2-0-blog/image-002.png"
+	alt="Cody command menu"
+	style={{ aspectRatio: '1942 / 1086' }}
+	/>
 
 ### Chat interface
 
 The chat interface is designed intuitively, which makes it easier to edit chat messages or start a new chat quickly. You can hit **Enter** to edit your message immediately without waiting for the stream to finish. This allows for quicker experimentation and iteration and less dependence on sending follow-up messages to clarify your question (which can also fill up your chat's context window).
 
-<video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto' }}>
+<video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto', aspectRatio: '1920 / 1080' }}>
   <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/Chat_%20Redesigned%20chat%20editing.mp4" type="video/mp4" />
 </video>
 
@@ -141,7 +193,11 @@ When you `@-mention` files to add to Cody’s context window, the file lookup ta
 
 Moreover, when you `@-mention` files, Cody will track the number of characters in those files against the context window limit of the selected chat model. As you `@-mention` multiple files, Cody will calculate how many tokens of the context window remain. When the remaining context window size becomes too small, you get **File too large** errors for further more `@-mention` files.
 
-![Specifying line numbers in @-mentions in Cody for VS Code](https://storage.googleapis.com/sourcegraph-assets/blog/cody-vscode-1.8.0/@file-line-numbers.gif)
+<img
+	src="https://storage.googleapis.com/sourcegraph-assets/blog/cody-vscode-1.8.0/@file-line-numbers.gif"
+	alt="Cody chat interface @'ing a file"
+	style={{ aspectRatio: '782 / 580' }}
+	/>
 
 ## Context fetching mechanism
 
@@ -161,7 +217,11 @@ Cody's Enhanced Context enables Cody to leverage search and embeddings-based con
 
 <Callout type="note">Enhanced context selector offers single-repo support for Cody Free and Pro while multi-repo support for Cody Enterprise.</Callout>
 
-![enhanced-context-selector](https://storage.googleapis.com/sourcegraph-assets/Docs/enhanced-context-imp.png)
+<img
+	src="https://storage.googleapis.com/sourcegraph-assets/Docs/enhanced-context-imp.png"
+	alt="Enhanced context popover"
+	style={{ aspectRatio: '1320 / 546' }}
+	/>
 
 The following tables shows what happens when Enhanced Context Selection is enabled or disabled.
 
@@ -184,7 +244,7 @@ Cody offers quick, ready-to-use [Commands](/cody/capabilities/commands) for comm
 
 Let's understand how the `/doc` command generates code documentation for a function.
 
-<video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto' }}>
+<video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto', aspectRatio: '1920 / 1080' }}>
   <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/code-comments-cody.mp4" type="video/mp4" />
 </video>
 
@@ -194,7 +254,11 @@ Let's understand how the `/doc` command generates code documentation for a funct
 
 For customization and advanced use cases, you can create **Custom Commands** tailored to your requirements. You can also bind keyboard shortcuts to run your custom commands quickly. To bind a keyboard shortcut, open the Keyboard Shortcuts editor and search for `cody.command.custom.` to see the list of your custom commands.
 
-![keybinding-custom-command](https://storage.googleapis.com/sourcegraph-assets/blog/cody-vscode-1.8.0/keybindings.png)
+<img
+	src="https://storage.googleapis.com/sourcegraph-assets/blog/cody-vscode-1.8.0/keybindings.png"
+	alt="Settings"
+	style={{ aspectRatio: '1059 / 228' }}
+	/>
 
 <Callout type="info">Learn more about Custom Commands [here](/cody/capabilities/commands#custom-commands)</Callout>
 
@@ -218,7 +282,11 @@ Cody also works with Cursor, Gitpod, IDX, and other similar VS Code forks. To ac
 
 Claude 3 Sonnet is the default LLM model for Cody Free users for Chat and Commands. Users on Cody **Pro** can choose from a list of supported LLM models for Chat, Commands, and Autocomplete. These LLMs are Claude Instant, Claude 2.0, Claude 2.1, Claude 3 (Haiku, Opus and Sonnet), ChatGPT 3.5 Turbo, ChatGPT 4 Turbo Preview, and Mixtral.
 
-![llm-selection-cody-pro](https://storage.googleapis.com/sourcegraph-assets/blog/cody-vscode-1.8.0/claude3-2.png)
+<img
+	src="https://storage.googleapis.com/sourcegraph-assets/blog/cody-vscode-1.8.0/claude3-2.png"
+	alt="Choosing an chat model"
+	style={{ aspectRatio: '1330 / 624' }}
+	/>
 
 Cody Enterprise users get Claude 3 (Opus and Sonnet) as the default LLM models without extra cost. In addition, Enterprise users also get capabilities like BYOLLM (Bring Your Own LLM) key. Your site administrator determines the LLM; you cannot change it from the editor. However, when using Cody Gateway, you can [configure custom models](/cody/core-concepts/cody-gateway#configuring-custom-models) Anthropic (like Claude 2.0 and Claude Instant) and OpenAI (GPT 3.5 and GPT 4).
 
@@ -253,7 +321,11 @@ To generate autocomplete suggestions with Ollama locally, follow these steps:
 
 #### Cody Chat and Commands with Ollama
 
-![ollama-cody](https://storage.googleapis.com/sourcegraph-assets/blog/cody-vscode-1.8.0/localollama.png)
+<img
+	src="https://storage.googleapis.com/sourcegraph-assets/blog/cody-vscode-1.8.0/localollama.png"
+	alt="Chat model selector"
+	style={{ aspectRatio: '1110 / 443' }}
+	/>
 
 To generate chat and commands with Ollama locally, follow these steps:
 


### PR DESCRIPTION
Adds aspect ratios to the image and videos to prevent [CLS](https://web.dev/articles/optimize-cls), so we can reliably link to a section of the page without it scrolling away from it as elements load.

To generate the image tags I used:

```zsh
images=(
	https://storage.googleapis.com/abc.png
	https://storage.googleapis.com/def.png
);

for image in "${images[@]}"; do
	curl -O $image
	filename=$image:t
	aspect_ratio=$(file "$filename" | grep -Eo "[[:digit:]]+ *x *[[:digit:]]+" | sed -e 's/ x / \/ /')

	echo "<img"
	echo "	src=\"$image\""
	echo "	alt=\"\""
	echo "	style={{ aspectRatio: '$aspect_ratio' }}"
	echo "	/>"
done
```