### PR TITLE
Remove semantic versioning references from update page

### DIFF
--- a/docs/admin/updates/index.mdx
+++ b/docs/admin/updates/index.mdx
@@ -15,7 +15,7 @@ A new Sourcegraph release consists of updated images that incorporate code chang
 When upgrading Sourcegraph, it is necessary to update and apply the deployment manifests. However, in addition to the manifest updates, it is crucial to ensure that all underlying database schemas of Sourcegraph are also updated.
 
 ### Release Schedule and versioning
-Sourcegraph releases use semantic versioning, for example: `v5.0.3`
+Sourcegraph releases have three digits, for example: `v5.0.3`
 | Description   | Version |
 |---------------|---------|
 | major         | `5`     |


### PR DESCRIPTION
<!-- Explain the changes introduced in your PR -->
Sourcegraph releases do not follow semantic versioning. I'm removing a reference that says we do

## Pull Request approval

Although pull request approval is not enforced for this repository in order to reduce friction, merging without a review will generate a ticket for the docs team to review your changes. So if possible, have your pull request approved before merging.
