### PR TITLE
Add a redirector script for routing old docs versions to subdomain

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -19,6 +19,18 @@ const nextConfig = {
 				source: `/v/${config.DOCS_LATEST_VERSION}/:slug*`,
 				destination: '/:slug*',
 				permanent: false
+			},
+			{
+				source: '/docs/v/5.3/:slug',
+				destination: 'https://5.3.sourcegraph.com/docs/:slug', // Static transformation as example
+				permanent: false,
+				basePath: false
+			},
+			{
+				source: '/docs/v/5.2/:slug',
+				destination: 'https://5.2.sourcegraph.com/docs/:slug', // Static transformation as example
+				permanent: false,
+				basePath: false
 			}
 		];
 	}


### PR DESCRIPTION
This PR adds a redirect script that routes any `sourcegraph.com/docs/v/x.x` to `x.x.sourcegraph.com` subdomains. The root for legacy versions live at: https://github.com/sourcegraph/docs-legacy-versions 
