### PR TITLE
docs: code host connections: add "Sourcegraph can't connect to your code host" section to troubleshooting page

### DIFF
--- a/docs/admin/repo/add.mdx
+++ b/docs/admin/repo/add.mdx
@@ -17,12 +17,42 @@
 
 ## Troubleshooting
 
+### Repositories not showing up
+
 If your repositories are not showing up, check the site admin **Repositories** page on Sourcegraph (and ensure you're logged in as an admin).
 If nothing informative is visible there, check for error messages related to communication with your code host's API in the logs from:
 
 - [Docker Compose](/admin/deploy/docker-compose/) and [Kubernetes](/admin/deploy/kubernetes/): the logs from the `repo-updater` container/pod
 - [Single-container](/admin/deploy/docker-single-container/): the `sourcegraph/server` Docker container
 
+### Repository not cloning or updating
+
 If your repositories are showing up but are not cloning or updating from the original Git repository:
 
 - Follow the instructions for [troubleshooting a repository that is not being updated](/admin/how-to/repo-not-updated)
+
+### Sourcegraph can't connect to your code host
+
+If Sourcegraph displays errors when syncing repositories from your code host, please click the "Test connection" button on the code host configuration page.
+
+If the connection test fails with errors like:
+
+> Connection check failed: request failed: context deadline exceeded
+>
+> This error might indicate that the code host is not reachable from your Sourcegraph instance.
+
+or:
+
+> Connection check failed: request failed: Get "https://nonexistenturl.com/api/v3/user": dial tcp: lookup nonexistenturl.com: no such host
+>
+> This error might indicate that the code host is not reachable from your Sourcegraph instance.
+
+These errors suggest that your code host is not reachable over the network from your Sourcegraph instance, which is required for Sourcegraph to sync repositories from your code host. In order to resolve this network issue, some fixes might include any / all of:
+
+- Making your code host accessible over the public internet
+- Configuring your Sourcegraph instance's network to allow outbound connections to your code host
+- Tweaking the firewall configuration to allow inbound connections to your code host from your Sourcegraph instance
+- Tweaking the DNS configuration of your Sourcegraph instance to resolve your code host's domain name to the IP address of your code host
+- etc.
+
+The specific configuration steps depend on your network setup. If you need assistance, please contact your network administrator or customer support.


### PR DESCRIPTION
Part of https://linear.app/sourcegraph/issue/SRC-359/

This PR adds a new section the code host connection troubleshooting page. It clarifies that a code host needs to be accessible over the network in order to sync repositories with it. 