### PR TITLE
more docs updates for initial context

### DIFF
--- a/docs/cody/capabilities/chat.mdx
+++ b/docs/cody/capabilities/chat.mdx
@@ -4,7 +4,7 @@
 
 Cody **chat** allows you to ask coding-related questions about any part of your codebase or specific code snippets. You can do it from the **Chat** panel of the supported editor extensions (VS Code, JetBrains, and Neovim) or in the web app.
 
-Key functionalities in the VS Code extension include support for multiple simultaneous chats, enhanced chat context configurability through `@` commands, detailed visibility into the code that Cody read before providing a response, and more.
+Key functionalities in the VS Code extension include support for multiple simultaneous chats, enhanced chat context configurability through @-mentions, detailed visibility into the code that Cody read before providing a response, and more.
 
 You can learn more about the IDE support for these functionalities in the [feature parity reference](/cody/clients/feature-reference#chat).
 
@@ -63,6 +63,8 @@ Cody's chat allows you to add files and symbols as context in your messages.
 
 - Type `@` and then a filename to include a file as context
 - Type `@#` and then a symbol name to include the symbol's definition as context. Functions, methods, classes, types, etc., are all symbols
+
+Cody's experimental [OpenCtx](https://openctx.org) support adds even more context sources, including Jira, Linear, Google Docs, Notion, and more.
 
 ### Chat vs Commands
 

--- a/docs/cody/clients/enable-cody-enterprise.mdx
+++ b/docs/cody/clients/enable-cody-enterprise.mdx
@@ -58,22 +58,14 @@ To enable Cody Analytics:
 - Users without a Sourcegraph.com account, please get in touch with one of our teammates. They can help with both the account setup and assigning instances to specific users
 - Map your user account to a Sourcegraph instance, and this gives you access to Cody's analytics
 
-### Multi-repo context
+### Multi-repository context
 
-<Callout type= "info">Multi-repo context for Sourcegraph Enterprise is supported with VS Code and JetBrains IDEs extensions.</Callout>
+<Callout type= "info">Multi-repo context for Sourcegraph Enterprise is supported with VS Code and JetBrains editor extensions.</Callout>
 
-Cody Enterprise allows up to 10 repos to support multi-repo context for users on IDE extensions. These can be added from the enhanced context selector window. Multi-repo context can search and retrieve context from multiple repositories responding to user questions, opening up more complex use cases. Enterprise users can ask questions requiring broader knowledge from across a codebase.
+Cody Enterprise supports searching up to 10 repositories to find relevant context in chat.
 
-### Enhanced context selector
-
-<Callout>Enhanced context selector is currently supported on VS Code and JetBrains IDE extensions.</Callout>
-
-The **Enhanced context selector** panel allows Cody Enterprise users to add up to **10 repos** to search across multiple repositories. This will enable users to ask questions requiring broader knowledge from across a codebase.
-
-Create a new chat in VS Code and click the **Enhanced Context** icon in the chat type field. Click the **Choose Repositories...** button and select up to 10 repositories from the list.
-
-![enhanced-context-enterprise](https://storage.googleapis.com/sourcegraph-assets/Docs/enhanced-context-enterprise.png)
-
+* In VS Code, open a new Cody chat, type `@`, and select `Remote Repositories` to search other repositories for context.
+* In JetBrains, use the enhanced context selector.
 
 ## Setting up Cody Enterprise
 

--- a/docs/cody/clients/feature-reference.mdx
+++ b/docs/cody/clients/feature-reference.mdx
@@ -26,10 +26,8 @@
 |              **Feature**              | **VS Code** | **JetBrains** | **Neovim** | **Web** |
 | ------------------------------------- | ----------- | ------------- | ---------- | ------- |
 | Single-repo context                   | ✅           | ✅             | ✅          | ✅       |
-| Enhanced context selection            | ✅           | ✅             | ❌          | ❌       |
-| File-based Cody Ignore (experimental) | ✅           | ❌             | ❌          | ❌       |
+| Multi-repo context                    | ✅           | ❌             | ❌          | ✅       |
 | Local context                         | ✅           | ✅             | ❌          | ❌       |
-| Embeddings                            | ✅           | ❌             | ✅          | ❌       |
 | Expanded Context Window for Claude 3  | ✅           | ✅             | ❌          | ❌       |
 
 ## Code Autocomplete
@@ -84,17 +82,14 @@
 | @-symbol                      | ✅           | ❌             | ❌          | ❌       |
 | LLM selection                 | ✅           | ✅             | ❌          | ❌       |
 | Ollama support (experimental) | ✅           | ❌             | ❌          | ❌       |
-| LLM Selection                 | ✅           | ✅             | ❌          | ❌       |
 
 ### Context Selection
 
 |              **Feature**              | **VS Code** | **JetBrains** | **Neovim** | **Web** |
 | ------------------------------------- | ----------- | ------------- | ---------- | ------- |
 | Single-repo context                   | ✅           | ✅             | ✅          | ✅       |
-| Enhanced context selection            | ✅           | ✅             | ❌          | ❌       |
-| File-based Cody Ignore (experimental) | ✅           | ❌             | ❌          | ❌       |
+| Multi-repo context                    | ✅           | ✅             | ❌          | ❌       |
 | Local context                         | ✅           | ✅             | ❌          | ❌       |
-| Embeddings                            | ✅           | ❌             | ✅          | ❌       |
 | Expanded Context Window for Claude 3  | ✅           | ✅             | ❌          | ❌       |
 
 ## Code Autocomplete
@@ -156,8 +151,6 @@
 | ------------------------------------- | ----------- | ------------- | ---------- | ------- |
 | Single-repo context                   | ✅           | ✅             | ✅          | ✅       |
 | Multi-repo context                    | ✅           | ✅             | ❌          | ✅       |
-| Enhanced context selection            | ✅           | ✅             | ❌          | ❌       |
-| File-based Cody Ignore (experimental) | ✅           | ❌             | ❌          | ❌       |
 | Local context                         | ✅           | ✅             | ❌          | ❌       |
 | Embeddings                            | ❌           | ❌             | ❌          | ❌       |
 | Expanded Context Window for Claude 3  | ❌           | ❌             | ❌          | ❌       |

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -202,11 +202,11 @@ When you have both a repository and files @-mentioned, Cody will search the repo
 
 ### Rerun prompts with different context
 
-If Cody chat doesn’t provide you with a correct answer on the first attempt, you can re-run a prompt with slight changes to your context. There are buttons that help you re-run and retry prompts with different contexts:
+If Cody's answer isn't helpful, you can try asking again with different context:
 
-- Public knowledge only: Cody will not use context; it’ll only use knowledge from the base model
-- Current file only: Re-run the prompt again using just the current file as context
-- Add context: Provides @-mention context options to improve the response. Could be files, symbols, remote repositories, or even web URLs
+- Public knowledge only: Cody will not use your own code files as context; it’ll only use knowledge trained into the base model.
+- Current file only: Re-run the prompt again using just the current file as context.
+- Add context: Provides @-mention context options to improve the response by explicitly including files, symbols, remote repositories, or even web pages (by URL).
 
 <video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto', aspectRatio: '1920 / 1080' }}>
   <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/rerun-context-0624.mp4" />
@@ -220,38 +220,12 @@ Enterprise users can leverage the full power of the Sourcegraph search engine as
 
 <Callout type="info"> Read more about [Context fetching mechanism](/cody/core-concepts/context/#context-fetching-mechanism) in detail.</Callout>
 
-## Context scope
 
-VS Code users on the Free or Pro plan get single-repo support and can use one repo for context fetching. Enterprise users get multi-repo support and can explicitly specify **up to 10 additional repos** they would like Cody to use for context.
+## Context sources
 
-### Enhanced Context Selector
+You can @-mention files, symbols, and web pages in Cody. Cody Enterprise also supports @-mentioning repositories to search for context in a broader scope. Cody's experimental [OpenCtx](https://openctx.org) support adds even more context sources, including Jira, Linear, Google Docs, Notion, and more.
 
-Cody's Enhanced Context enables Cody to leverage search and embeddings-based context. Community users can generate local embeddings for their projects by clicking the icon next to the chat input. Users can also disable Enhanced Context or configure more granular control of Cody’s context by including `@-files` or `@#-symbols` in the chat input. This feature only supports local files and paths relative to your workspace. Start typing `@`, and Cody will suggest files for you to include.
-
-<Callout type="note">Cody Free and Pro offers single-repo context, and Cody Enterprise supports multi-repo context.</Callout>
-
-<img
-  src="https://storage.googleapis.com/sourcegraph-assets/Docs/enhanced-context-imp.png"
-  alt="Enhanced context popover"
-  style={{ aspectRatio: '1320 / 546' }}
- />
-
-The following tables shows what happens when Enhanced Context Selection is enabled or disabled.
-
-|                           | Opened Files | Highlighted Code | Embeddings (If available) | Search (as backup) |     |
-| ------------------------- | ------------ | ---------------- | ------------------------- | ------------------ | --- |
-| Enhanced Context Enabled  | ✅            | ✅                | ✅                         | ✅                  |     |
-| Enhanced Context Disabled | ❌            | ❌                | ❌                         | ❌                  |     |
-
-### Add files as context from the file tree
-
-You can add files as context to the Cody chat directly from the folder hierarchy. To do so, right-click any file from the folder and click the **Add File to Cody Chat** option. The selected file path will populate as an `@-mention` entry in the chat window to fetch context.
-
-If your Cody chat window is not open, this option will appear as **New Chat with File** when you right-click any file.
-
-<video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto' }}>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/vscode-context-file-tree.mp4" type="video/mp4" />
-</video>
+<Callout type="note">Cody Free and Pro offer single-repo context, and Cody Enterprise supports multi-repo context.</Callout>
 
 ## Commands
 

--- a/docs/cody/core-concepts/embeddings.mdx
+++ b/docs/cody/core-concepts/embeddings.mdx
@@ -10,15 +10,5 @@ Embeddings are a semantic representation of text that allows you to create a sea
 
 <Callout type= "info">As of Sourcegraph version 5.3, embeddings are only available to Cody Free and Cody Pro users on the VS Code extension.</Callout>
 
-Cody Free and Pro users can leverage local embeddings for context fetching. Local embeddings are indexed from the **Enhanced Context** panel. Once indexed, Cody will use these embeddings to provide context to your search queries.
+Cody Free and Pro users can leverage local embeddings for context fetching. Embeddings are created automatically and are used to provide context to Cody in chat, edits, and more.
 
-## Enable embeddings
-
-To enable embeddings in VS Code IDE:
-
-- Open a repository in your workspace
-- Next, create a new Cody chat
-- Inside the chat window, open the **Enhanced Context Selector** window and select **Enable Embeddings**
-- This uploads the repository's context to OpenAI's Embeddings API and gets stored locally
-
-<Callout type="note">Embeddings are no longer supported for Cody Enterprise and JetBrains IDE extension. You can learn more about Cody's [context fetching mechanism](/cody/core-concepts/context#context-fetching-mechanism).</Callout>

--- a/docs/cody/troubleshooting.mdx
+++ b/docs/cody/troubleshooting.mdx
@@ -51,11 +51,13 @@ If you find yourself being automatically signed out of Cody every time you resta
 
 ### No context files were included by Cody
 
-If Cody is not responding with answers relevant to your codebase, it might be missing context files. To make sure that context files are included, follow these steps:
+If Cody's answers don't seem accurate, it may be because Cody is unable to find the right relevant files to use as context. You can see which files Cody used in the **Context** row right below your message.
 
-- From your Cody chat window enable the checkbox for **[Enhanced Context](/cody/clients/install-vscode#enhanced-context-selector)** panel
-- Next, go to the **Output** log panel in VS Code and select **Cody by Sourcegraph** from the dropdown menu
-- Finally, copy the output log. We're specifically looking for log messages like these:
+To troubleshoot further:
+
+1. Enable the `cody.debug.verbose` setting in your VS Code user settings.
+1. Open the **Cody by Sourcegraph** output channel in VS Code.
+1. Look for log messages such as the following:
 
 ```bash
 █ SimpleChatPanelProvider: getEnhancedContext > embeddings (start)

--- a/docs/cody/use-cases/vsc-tutorial.mdx
+++ b/docs/cody/use-cases/vsc-tutorial.mdx
@@ -12,7 +12,7 @@ Start writing code and Cody will complete the line (or the entire function) for 
 
 - Autocomplete uses the surrounding code and context to inform the suggestions, so if you need to guide it you can add a comment above the line you're editing.
 - You can hover over the grey suggestion to see a toolbar of alternative suggestions, as well as other options such as accepting a single word at a time.
-- You can use the "Trigger Autocomplete at Cursor" command to trigger a code suggestion at any time, using the default keyboard shortcut of `Option` `\` on macOS and `Alt` `\` on Windows & Linux.
+- You can use the "Trigger Autocomplete at Cursor" command to trigger a code suggestion at any time, using the default keyboard shortcut of `Opt+L`/`Alt+L`.
 
 ## Chat
 
@@ -20,13 +20,12 @@ Start writing code and Cody will complete the line (or the entire function) for 
 
 Answer questions about general programming topics, or specific to your codebase, with Cody chat. You can choose between LLMs, @-mentions files and symbols, and enable enhanced repository-wide code context.
 
-You can start a chat at any time using the default keyboard shortcut of `Option` `/` on macOS and `Alt` `/` on Windows & Linux.
+You can start a chat at any time using the default keyboard shortcut of `Opt+L`/`Alt+L`.
 
 **✨ Pro-tips for using Cody chat**
 
-- Enabling “Enhanced Context”, and tagging specific files and symbols, gives the selected LLM more context to help answer your questions more accurately.
-- If you want to chat directly with the LLM without any additional context adding, disable "Enhanced Context".
-- You can increase the quality of your chat responses by enabling "Search Context (Beta)" in your [Cody Settings](command:cody.status-bar.interacted).
+- Tagging specific files and symbols gives the selected LLM more context to help answer your questions more accurately.
+- If you want to chat directly with the LLM without any additional context adding, delete the @-mentions that are automatically inserted in each new Cody chat and just ask a plain question.
 
 ## Cody Commands
 
@@ -36,7 +35,7 @@ Cody has a range of commands for explaining code, generating unit tests, adding 
 
 To get started: select code in your editor, right click, and choose a command from the "Cody" menu.
 
-You can also use the [Cody: Commands Menu](command:cody.menu.commands) which has the default keyboard shortcut of `Option` `C` on macOS and `Alt` `C` on Windows & Linux.
+You can also use the [Cody: Commands Menu](command:cody.menu.commands) which has the default keyboard shortcut of `Opt+C`/`Alt+C`.
 
 **✨ Pro-tips for using Cody commands**
 
@@ -48,12 +47,12 @@ You can ask Cody to perform code edits using the Edit Code command. This will ed
 
 To get started: select code in your editor, right click, and choose "Cody → Edit Code".
 
-You can also use the default keyboard shortcut of `Option` `K` on macOS and `Alt` `K` on Windows & Linux.
+You can also use the default keyboard shortcut of `Opt+K`/`Alt+K`.
 
 **✨ Pro-tips for code editing with Cody**
 
 - You can open the 💡 menu, with an "Cody: Edit Code" option, by selecting any line of code and using the keyboard short `Command` `.` on macOS or `Crtl` `.` on Windows & Linux.
-- If you start an empty line and open the 💡 menu (using the keyboard short `Command` `.` on macOS or `Crtl` `.` on Windows & Linux) you can use "Cody: Generate Code" to generate new lines of code based on instructions.
+- If you start an empty line and open the 💡 menu (using the keyboard short `Command` `.` on macOS or `Ctrl` `.` on Windows & Linux) you can use "Cody: Generate Code" to generate new lines of code based on instructions.
 - You define your own custom code editing commands using [Custom Commands (Beta)](https://sourcegraph.com/docs/cody/custom-commands), by setting the [`commands.<id>.mode` property](https://sourcegraph.com/docs/cody/capabilities/commands#commands-id-mode).
 
 ## Explain Code
@@ -69,7 +68,7 @@ Use Cody to get an in-depth explanation of any piece of code in any programming 
 
 To get started, select code in your editor, right-click, and choose "Cody > Explain Code".
 
-You can also run this command from the [Cody: Commands Menu](command:cody.menu.commands), which has the default keyboard shortcut of `Option` `C` on macOS and `Alt` `C` on Windows & Linux.
+You can also run this command from the [Cody: Commands Menu](command:cody.menu.commands), which has the default keyboard shortcut of `Opt+C`/`Alt+C`.
 
 **✨ Pro-tips for understanding code with Cody**
 


### PR DESCRIPTION
Removes mentions of the enhanced context popover on VS Code, which was removed in v1.20: https://sourcegraph.com/blog/cody-vscode-1-20-0-release.