### PR TITLE
Fix docs for bitbucket server webhooks

### DIFF
--- a/docs/admin/config/webhooks/incoming.mdx
+++ b/docs/admin/config/webhooks/incoming.mdx
@@ -129,7 +129,7 @@ Done! Sourcegraph will now receive webhook events from Bitbucket Server / Bitbuc
 
 #### Code push
 
-Follow the same steps as above, but ensure you tick the `Push` option. If asked for a specific event, use `repo:refs_changed`.
+Follow the same steps as above, but include `repo:refs_changed` in the **Events** field.
 
 ### Bitbucket cloud
 


### PR DESCRIPTION
The instructions talk abotu some Push tickbox, which doesn't exist. This PR clarifies what actually needs to be done.

Closes SRC-387

Test plan:

Review.