### PR TITLE
remove mentions of to-be-removed separate Cody natural-language search quickpick UI (prefer using it via chat instead)

### DIFF
--- a/docs/cody/clients/feature-reference.mdx
+++ b/docs/cody/clients/feature-reference.mdx
@@ -61,12 +61,6 @@
 | Improve variable names         | ❌           | ❌             | ❌          | ✅       |
 | Ollama support (experimental)  | ✅           | ❌             | ❌          | ❌       |
 
-## Natural Language Search
-
-|       **Feature**       | **VS Code** | **JetBrains** | **Neovim** | **Web** |
-| ----------------------- | ----------- | ------------- | ---------- | ------- |
-| Natural language search | ✅           | ❌             | ❌          | ❌       |
-
   </Tab>
   <Tab title="Pro">
 
@@ -123,12 +117,6 @@
 | Reset chat                     | ✅           | ❌             | ❌          | ❌       |
 | Improve variable names         | ❌           | ❌             | ❌          | ✅       |
 | Ollama support (experimental)  | ✅           | ❌             | ❌          | ❌       |
-
-## Natural Language Search
-
-|       **Feature**       | **VS Code** | **JetBrains** | **Neovim** | **Web** |
-| ----------------------- | ----------- | ------------- | ---------- | ------- |
-| Natural language search | ✅           | ❌             | ❌          | ❌       |
 
   </Tab>
     <Tab title="Enterprise">
@@ -195,12 +183,6 @@
 | Ollama support (experimental)  | ✅           | ❌             | ❌          | ❌       |
 | Admin LLM selection            | ✅           | ✅             | ✅          | ✅       |
 
-
-## Natural Language Search
-
-|       **Feature**       | **VS Code** | **JetBrains** | **Neovim** | **Web** |
-| ----------------------- | ----------- | ------------- | ---------- | ------- |
-| Natural language search | ✅           | ❌             | ❌          | ❌       |
 
   </Tab>
 </Tabs>

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -302,14 +302,6 @@ For customization and advanced use cases, you can create **Custom Commands** tai
 
 <Callout type="info">Learn more about Custom Commands [here](/cody/capabilities/commands#custom-commands)</Callout>
 
-## Cody Natural Language Search
-
-<Callout type="note">Cody Natural Language Search is currently available in Beta for all users on VS Code extension.</Callout>
-
-Cody's **Natural Language Search** is an AI-powered code search that allows users to input a natural language search query and look for it within their project. For example, "password hashing" or "connection retries".
-
-In the left-hand panel, type your queries in the **Search** field, and the search results are displayed. You can select one of the search results and verify that the correct file opens in a new tab. Natural Language Search works for all Cody users with the ability to search across your entire local codebase from within the IDE.
-
 ## Updating the extension
 
 VS Code will typically notify you when updates are available for installed extensions. Follow the prompts to update the Cody AI extension to the latest version.

--- a/docs/cody/use-cases/vsc-tutorial.mdx
+++ b/docs/cody/use-cases/vsc-tutorial.mdx
@@ -105,14 +105,3 @@ To get started:
 **✨ Pro-tips for assigning keyboard shortcuts for Cody**
 
 - You can assign key bindings (keyboard shortcuts) to individual custom commands.
-
-## Natural Language Search
-
-![](https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-natural-language.gif)
-
-Cody builds a Search index of your local files to make it easier to find what you’re looking for. Use a natural language query like “password hashing” or "connection retries" to quickly find and open the files that match your search.
-
-**✨ Pro-tips for using Cody’s Natural Language Search**
-
-- Increase the quality of your chat responses by enabling "Search Context (Beta)" in your [Cody Settings](command:cody.status-bar.interacted). This enables chat to use the natural language search index as a context source.
-- You can search file and symbol names too, not just natural language queries.


### PR DESCRIPTION
See https://github.com/sourcegraph/cody/pull/4506.

This capability is NOT being removed, but it's very rarely used (and only by non-enterprise users) separately. It is almost always used as part of Cody chat, which performs a natural-language search and shows the results in every chat in the context row.