### PR TITLE
Added content tabs component for sub-sections

### DIFF
--- a/src/components/ContentTabs.jsx
+++ b/src/components/ContentTabs.jsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { getMDXComponent } from 'next-contentlayer/hooks';
+import clsx from 'clsx';
+import { useParams, useRouter } from 'next/navigation';
+import { allPosts } from 'contentlayer/generated';
+import MdxComponents from '@/components/MdxComponents';
+
+export function ContentTabs({ children, name }) {
+  const params = useParams();
+  const router = useRouter();
+  const [onTab, setOnTab] = useState(true)
+  const [selectedTab, setSelectedTab] = useState(null);
+  const [postContent, setPostContent] = useState(null);
+
+  useEffect(() => {
+    updateTabFromURL();
+  }, []);
+
+  const updateTabFromURL = () => {
+
+    const path = `/${params.slug.join('/')}`;
+    const allPaths = children.map(child => child.props.href)
+
+    if (!allPaths.includes(path)) {
+      setSelectedTab(allPaths[0])
+      const selectedPost = allPosts.find(post => `/${post._raw.flattenedPath}` === allPaths[0] && name == 'main');
+
+      if (selectedPost) {
+        const Content = getMDXComponent(selectedPost.body.code);
+        setPostContent(<Content components={MdxComponents()} />);
+        setOnTab(false)
+        
+        const url = new URL(window.location.href);
+        url.pathname = allPaths[0];
+        window.history.replaceState(null, null, url.toString());
+        console.log('allPaths__', allPaths[0])
+      }
+    } else setSelectedTab(path)
+  };
+
+  if (!onTab) return <div>{postContent}</div>
+
+  return (
+    <div>
+      <div className="flex flex-wrap border-b overflow-auto">
+        {children.map((child, index) => (
+          <button
+            key={index}
+            className={clsx(
+              'py-2 px-3 mr-4 text-sm transition-colors duration-300 whitespace-nowrap',
+              selectedTab === child.props.href ? 'font-semibold border-b-2 border-[#3098AA] text-[#3098AA]' : 'hover:border-b-2 hover:border-gray-300 text-gray-500 dark:text-white'
+            )}
+            onClick={() => router.push(child.props.href)}
+          >
+            {child.props.title}
+          </button>
+        ))}
+      </div>
+      <div className="mt-4">{postContent}</div>
+    </div>
+  );
+}
+
+export function ContentTab({ title, href, selected }) {
+  return null;
+}

--- a/src/components/MdxComponents.tsx
+++ b/src/components/MdxComponents.tsx
@@ -9,12 +9,15 @@ import { QuickLink, QuickLinks } from './mdx/QuickLinks';
 import { Tab, Tabs } from './mdx/Tabs';
 import ResourceEstimator from './resource-estimator/ResourceEstimator';
 import { PreCodeBlock } from './PreCodeBlock';
+import { ContentTabs, ContentTab } from './ContentTabs';
 
 const MdxComponents = (version?: string) => {
 	return {
 		ResourceEstimator,
 		AWSOneClickLaunchForm,
 		Accordion,
+		ContentTabs: (props: any) => <ContentTabs {...props} />,
+    ContentTab: (props: any) => <ContentTab {...props} />,
 		Tabs: (props: any) => <Tabs {...props} />,
 		Tab: (props: any) => <Tab {...props} />,
 		QuickLinks,


### PR DESCRIPTION
This PR introduces the ContentTabs component for creating tabbed content in MDX files. The component handles tab switching and URL updates seamlessly without nesting issues.

# Usage Instructions

### Example Directory Structure
```
.
├── docs
│   └── cody
│       └── clients
│           ├── index.mdx
│           ├── install-vscode.mdx
│           ├── install-jetbrains.mdx
│           ├── install-neovim.mdx
│           ├── cody-with-sourcegraph.mdx
│           └── enable-cody-enterprise.mdx
```
### Main Tab Set (index.mdx)
- For the main tab set, typically in your index file (e.g., code/clients/index.mdx), use the ContentTabs component with the name prop set to 'main'.
- **Example: docs/cody/clients/index.mdx**
``` mdx
<ContentTabs name='main'>
  <ContentTab title="VS Code" href="/cody/clients/install-vscode" />
  <ContentTab title="JetBrains (beta)" href="/cody/clients/install-jetbrains" />
  <ContentTab title="Neovim (experimental)" href="/cody/clients/install-neovim" />
  <ContentTab title="Web" href="/cody/clients/cody-with-sourcegraph" />
  <ContentTab title="Cody Enterprise" href="/cody/clients/enable-cody-enterprise" />
</ContentTabs>
```

### Other MDX Files
- For other MDX files, use the ContentTabs component without the name prop.
- **Example: docs/cody//clients/install-vscode.mdx**
``` mdx
<ContentTabs>
  <ContentTab title="VS Code" href="/cody/clients/install-vscode" />
  <ContentTab title="JetBrains (beta)" href="/cody/clients/install-jetbrains" />
  <ContentTab title="Neovim (experimental)" href="/cody/clients/install-neovim" />
  <ContentTab title="Web" href="/cody/clients/cody-with-sourcegraph" />
  <ContentTab title="Cody Enterprise" href="/cody/clients/enable-cody-enterprise" />
</ContentTabs>
```

