### PR TITLE
Design Guide template

### DIFF
--- a/docs/demo-design.mdx
+++ b/docs/demo-design.mdx
@@ -1,0 +1,47 @@
+# Design Library
+
+This is a design guide for all the elemenets we need for our Changelog page.
+
+## This is a H2
+
+### This is a H3
+
+#### This is a H4
+
+This is plain text.
+
+## Callouts
+
+**Note**
+
+<br />
+<Callout type="note">This is a note.</Callout>
+
+**Tip**
+<br />
+
+<Callout type="tip">This is a tip.</Callout>
+
+**Info**
+<br />
+
+<Callout type="info">This is an info.</Callout>
+
+**Warning**
+<br />
+
+<Callout type="warning">This is an warning.</Callout>
+
+**Image**
+<br />
+
+![running-commands](https://storage.googleapis.com/sourcegraph-assets/Docs/using-commands-0624.png)
+
+
+**Video/GIF**
+<br />
+
+
+<video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto' }}>
+  <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/cody-in-action.mp4" type="video/mp4"/>
+</video>

--- a/docs/demo-design.mdx
+++ b/docs/demo-design.mdx
@@ -2,11 +2,11 @@
 
 This is a design guide for all the elemenets we need for our Changelog page.
 
-## This is a H2
+## Heading 2
 
-### This is a H3
+### Heading 3
 
-#### This is a H4
+#### Heading 4
 
 This is plain text.
 

--- a/docs/demo-design.mdx
+++ b/docs/demo-design.mdx
@@ -30,7 +30,7 @@ This is plain text.
 **Warning**
 <br />
 
-<Callout type="warning">This is an warning.</Callout>
+<Callout type="warning">This is a warning.</Callout>
 
 **Image**
 <br />


### PR DESCRIPTION
@traceyljohnson I have created this demo page as a guide to view how our docs components look in light and dark modes. This will help you with the Changelog design part. 

- **Page Preview Link**: https://sourcegraph-docs-git-demo-design-template-sourcegraph-f8c71130.vercel.app/demo-design

On this page, we can see the following components:

- H1
- H2
- H3
- H4
- Paragraph (Text)
- Callouts for note, info, tip and warning
- Image
- Video/GIFs

Let me know if you need more and I'll add it to it.