### PR TITLE
Add docs changes for VS Code release June 12th

### DIFF
--- a/docs/cody/capabilities/supported-models.mdx
+++ b/docs/cody/capabilities/supported-models.mdx
@@ -15,7 +15,9 @@ Cody supports a variety of cutting edge large language models for use in Chat an
 | Anthropic    | [claude-3 Opus](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                      | -              | ✅              | ✅              |
 | Mistral      | [mixtral 8x7b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best)                        | -              | ✅              | -              |
 | Mistral      | [mixtral 8x22b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best)                       | -              | ✅              | -              |
-| Ollama*      | [variety](https://ollama.com/)                                                                                                                | *experimental* | *experimental* | -              |
+| Ollama      | [variety](https://ollama.com/)                                                                                                                | experimental | experimental | -              |
+| Google Gemini      | [1.5 Pro](https://deepmind.google/technologies/gemini/pro/)                                                                                                                | - | ✅ | -              |
+| Google Gemini       | [1.5 Flash](https://deepmind.google/technologies/gemini/flash/)                                                                                                                | - | ✅ | -              |
 |              |                                                                                                                                               |                |                |                |
 
 <Callout type="note">To use Claude 3 (Opus and Sonnets) models with Cody Enterprise, make sure you've upgraded your Sourcegraph instance to the latest version.</Callout>

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -249,7 +249,6 @@ Enterprise users can leverage the full power of the Sourcegraph search engine as
 
 <Callout type="info"> Read more about [Context fetching mechanism](/cody/core-concepts/context/#context-fetching-mechanism) in detail.</Callout>
 
-
 ## Context sources
 
 You can @-mention files, symbols, and web pages in Cody. Cody Enterprise also supports @-mentioning repositories to search for context in a broader scope. Cody's experimental [OpenCtx](https://openctx.org) support adds even more context sources, including Jira, Linear, Google Docs, Notion, and more.
@@ -312,15 +311,11 @@ Cody also works with Cursor, Gitpod, IDX, and other similar VS Code forks. To ac
 
 ## Supported LLM models
 
-Claude 3 Sonnet is the default LLM model for Cody Free users for Chat and Commands. Users on Cody **Pro** can choose from a list of supported LLM models for Chat, Commands, and Autocomplete. These LLMs are Claude Instant, Claude 2.0, Claude 2.1, Claude 3 (Haiku, Opus and Sonnet), ChatGPT 3.5 Turbo, ChatGPT 4 Turbo Preview, GPT-4o and Mixtral.
+Claude 3 Sonnet is the default LLM model for Cody Free users for Chat and Commands. Users on Cody **Pro** can choose from a list of supported LLM models for Chat, Commands, and Autocomplete. These LLMs are Claude Instant, Claude 2.0, Claude 2.1, Claude 3 (Haiku, Opus and Sonnet), ChatGPT 3.5 Turbo, ChatGPT 4 Turbo Preview, GPT-4o, Mixtral, Google Gemini 1.5 Pro and Google Gemini 1.5 Flash.
 
-<img
-  src="https://storage.googleapis.com/sourcegraph-assets/blog/cody-vscode-1.8.0/claude3-2.png"
-  alt="Choosing an chat model"
-  style={{ aspectRatio: '1330 / 624' }}
- />
+![LLM-models-for-cody-pro](https://storage.googleapis.com/sourcegraph-assets/Docs/vscode-llm-models-june2024.png)
 
-Cody Enterprise users get Claude 3 (Opus and Sonnet) as the default LLM models without extra cost. In addition, Enterprise users also get capabilities like BYOLLM (Bring Your Own LLM) key. Your site administrator determines the LLM; you cannot change it from the editor. However, when using Cody Gateway, you can [configure custom models](/cody/core-concepts/cody-gateway#configuring-custom-models) Anthropic (like Claude 2.0 and Claude Instant) and OpenAI (GPT 3.5 and GPT 4).
+Cody Enterprise users get Claude 3 (Opus and Sonnet) as the default LLM models without extra cost. In addition, Enterprise users also get capabilities like BYOLLM (Bring Your Own LLM) key. Your site administrator determines the LLM; you cannot change it from the editor. However, when using Cody Gateway, you can [configure custom models](/cody/core-concepts/cody-gateway#configuring-custom-models) Anthropic (like Claude 2.0 and Claude Instant), OpenAI (GPT 3.5 and GPT 4), Amazon Bedrock and Azure OpenAI Service.
 
 <Callout type="note">To use Claude 3 (Opus and Sonnets) models with Cody Enterprise, make sure you've upgraded your Sourcegraph instance to the latest version.</Callout>
 

--- a/docs/cody/core-concepts/token-limits.mdx
+++ b/docs/cody/core-concepts/token-limits.mdx
@@ -7,7 +7,7 @@ For Claude 3 Sonnet or Opus models users, Cody supports up to **30,000 tokens (~
 Here's a detailed breakdown of the token limits by model:
 
 <Tabs>
-  <Tab title="Free & Pro">
+  <Tab title="Free">
 |      **Model**      | **User Defined** | **Chat** **History** | **Output** |
 | ------------------- | ---------------- | -------------------- | ---------- |
 | gpt-3.5-turbo       | 7,000            | shared               | 4,000      |
@@ -21,20 +21,38 @@ Here's a detailed breakdown of the token limits by model:
 | **claude-3 Opus**   | **30,000**       | **15,000**           | **4,000**  |
 | mixtral 8x7b        | 7,000            | shared               | 4,000      |
   </Tab>
+
+<Tab title="Pro">
+|          **Model**          | **User Defined** | **Chat** **History** | **Output** |
+| --------------------------- | ---------------- | -------------------- | ---------- |
+| gpt-3.5-turbo               | 7,000            | shared               | 4,000      |
+| gpt-4                       | 7,000            | shared               | 4,000      |
+| gpt-4-turbo                 | 7,000            | shared               | 4,000      |
+| claude instant              | 7,000            | shared               | 4,000      |
+| claude-2.0                  | 7,000            | shared               | 4,000      |
+| claude-2.1                  | 7,000            | shared               | 4,000      |
+| claude-3 Haiku              | 7,000            | shared               | 4,000      |
+| **claude-3 Sonnet**         | **30,000**       | **15,000**           | **4,000**  |
+| **claude-3 Opus**           | **30,000**       | **15,000**           | **4,000**  |
+| **Google Gemini 1.5 Flash** | **30,000**       | **15,000**           | **4,000**  |
+| **Google Gemini 1.5 Pro**   | **30,000**       | **15,000**           | **4,000**  |
+| mixtral 8x7b                | 7,000            | shared               | 4,000      |
+  </Tab>
+
   <Tab title="Enterprise">
-|    **Model**    | **User Defined** | **Chat** **History** | **Output** |
-| --------------- | ---------------- | -------------------- | ---------- |
-| gpt-3.5-turbo   | 7,000            | shared               | 1,000      |
-| gpt-4o          | 7,000            | shared               | 1,000      |
-| gpt-4           | 7,000            | shared               | 1,000      |
-| gpt-4-turbo     | 7,000            | shared               | 1,000      |
-| claude instant  | 7,000            | shared               | 1,000      |
-| claude-2.0      | 7,000            | shared               | 1,000      |
-| claude-2.1      | 7,000            | shared               | 1,000      |
-| claude-3 Haiku  | 7,000            | shared               | 1,000      |
+|      **Model**      | **User Defined** | **Chat** **History** | **Output** |
+| ------------------- | ---------------- | -------------------- | ---------- |
+| gpt-3.5-turbo       | 7,000            | shared               | 1,000      |
+| gpt-4o              | 7,000            | shared               | 1,000      |
+| gpt-4               | 7,000            | shared               | 1,000      |
+| gpt-4-turbo         | 7,000            | shared               | 1,000      |
+| claude instant      | 7,000            | shared               | 1,000      |
+| claude-2.0          | 7,000            | shared               | 1,000      |
+| claude-2.1          | 7,000            | shared               | 1,000      |
+| claude-3 Haiku      | 7,000            | shared               | 1,000      |
 | **claude-3 Sonnet** | **30,000**       | **15,000**           | **4,000**  |
 | **claude-3 Opus**   | **30,000**       | **15,000**           | **4,000**  |
-| mixtral 8x7b    | 7,000            | shared               | 1,000      |
+| mixtral 8x7b        | 7,000            | shared               | 1,000      |
   </Tab>
 </Tabs>
 

--- a/docs/cody/usage-and-pricing.mdx
+++ b/docs/cody/usage-and-pricing.mdx
@@ -39,7 +39,17 @@ Cody Pro, designed for individuals or small teams at **$9 per user per month**, 
 
 The plan includes the ability to create an unlimited number of Custom Commands for personalized workflows. In addition to using the local context of your code to improve responses, you can embed up to **1 GB** of your private code for even better Cody responses that reflect a deep understanding of your code in VS Code, with JetBrains IDE support coming soon.
 
-Support for Cody Pro is available through our Support team via support@sourcegraph.com, ensuring prompt assistance and guidance. Finally, you'll have default support with Anthropic and StarCoder as the officially supported LLMs. Moreover, Pro accounts using VS Code and JetBrains IDEs will get an LLM selection for chat only. These LLMs are Claude Instant 1.2, Claude 2, Claude 3, ChatGPT 3.5 Turbo, ChatGPT 4 Turbo Preview, GPT-4o, and Mixtral.
+Support for Cody Pro is available through our Support team via support@sourcegraph.com, ensuring prompt assistance and guidance. Finally, you'll have default support with Anthropic and StarCoder as the officially supported LLMs. Moreover, Pro accounts using VS Code and JetBrains IDEs will get an LLM selection for chat only. These LLMs are:
+
+- Claude Instant 1.2
+- Claude 2
+- Claude 3
+- ChatGPT 3.5 Turbo
+- GPT-4o
+- ChatGPT 4 Turbo Preview
+- Mixtral
+- Google Gemini 1.5 Pro
+- Google Gemini 1.5 Flash
 
 <Callout type="note">There will be high daily limits to catch bad actors and prevent abuse, but under most normal usage, Pro users won't experience these limits.</Callout>
 
@@ -94,20 +104,20 @@ Security features include SAML/SSO for enhanced authentication and guardrails to
 
 The following table shows a high-level comparison of the three plans available on Cody.
 
-|           **Features**            |                          **Free**                          |                                           **Pro**                                           |            **Enterprise**             |
-| --------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------- |
-| **Autocompletion suggestions**    | 500 per month (whole + multi-line)                         | Unlimited                                                                                   | Unlimited                             |
-| **Chat/Command Executions**       | 20 per month                                               | Unlimited                                                                                   | Unlimited                             |
-| **Custom Commands**               | Supported                                                  | Supported                                                                                   | Supported                             |
-| **Embeddings (public code)**      | Supported                                                  | Supported                                                                                   | Supported                             |
-| **Keyword Context (local code)**  | Supported                                                  | Supported                                                                                   | Supported                             |
-| **Developer Limitations**         | 1 developer                                                | Up to 50 devs                                                                               | Scalable, consumption-based pricing   |
+|           **Features**            |                          **Free**                          |                                            **Pro**                                            |                   **Enterprise**                   |
+| --------------------------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| **Autocompletion suggestions**    | 500 per month (whole + multi-line)                         | Unlimited                                                                                     | Unlimited                                          |
+| **Chat/Command Executions**       | 20 per month                                               | Unlimited                                                                                     | Unlimited                                          |
+| **Custom Commands**               | Supported                                                  | Supported                                                                                     | Supported                                          |
+| **Embeddings (public code)**      | Supported                                                  | Supported                                                                                     | Supported                                          |
+| **Keyword Context (local code)**  | Supported                                                  | Supported                                                                                     | Supported                                          |
+| **Developer Limitations**         | 1 developer                                                | Up to 50 devs                                                                                 | Scalable, consumption-based pricing                |
 | **LLM Support**                   | Anthropic + StarCoder for Chat, Commands, and Autocomplete | Choice of LLMs for Chat and Commands (VS Code and JetBrains only), StarCoder and Autocomplete | Claude 3 and Bring Your Own LLM Key (experimental) |
-| **Code Editor Support**           | VS Code, JetBrains IDEs, and Neovim                        | VS Code, JetBrains IDEs, and Neovim                                                         | VS Code, JetBrains IDEs, and Neovim   |
-| **Single-Tenant and Self Hosted** | N/A                                                        | N/A                                                                                         | Yes                                   |
-| **SAML/SSO**                      | N/A                                                        | N/A                                                                                         | Yes                                   |
-| **Guardrails**                    | N/A                                                        | N/A                                                                                         | Yes                                   |
-| **Advanced Code Graph Context**   | N/A                                                        | N/A                                                                                         | Included                              |
-| **Multi-Code Host Context**       | N/A                                                        | N/A                                                                                         | Included                              |
-| **Discord Support**               | No                                                         | Yes                                                                                         | Yes                                   |
-| **24/5 Enhanced Support**         | N/A                                                        | N/A                                                                                         | Yes                                   |
+| **Code Editor Support**           | VS Code, JetBrains IDEs, and Neovim                        | VS Code, JetBrains IDEs, and Neovim                                                           | VS Code, JetBrains IDEs, and Neovim                |
+| **Single-Tenant and Self Hosted** | N/A                                                        | N/A                                                                                           | Yes                                                |
+| **SAML/SSO**                      | N/A                                                        | N/A                                                                                           | Yes                                                |
+| **Guardrails**                    | N/A                                                        | N/A                                                                                           | Yes                                                |
+| **Advanced Code Graph Context**   | N/A                                                        | N/A                                                                                           | Included                                           |
+| **Multi-Code Host Context**       | N/A                                                        | N/A                                                                                           | Included                                           |
+| **Discord Support**               | No                                                         | Yes                                                                                           | Yes                                                |
+| **24/5 Enhanced Support**         | N/A                                                        | N/A                                                                                           | Yes                                                |


### PR DESCRIPTION
The PRs adds changes to VS Code docs for the new release. Major changes include mentions of Google Gemini 1.5 Pro
and Google Gemini 1.5 Flash as the supported LLM Models for chat and commands.

Updates the:
- Usage and Pricing docs
- VS Code installation docs
- Images showing supported LLMs for Pro tiers
- Supported LLM docs