### PR TITLE
Updating Tailwind font families

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -103,8 +103,8 @@ export default {
     extend: {
       fontFamily: {
         sans: ['-apple-system', 'var(--font-inter)'],
-        display: ['var(--font-lexend)', { fontFeatureSettings: '"ss01"' }],
-        mono: ['SFMono-Regular', 'ui-monospace', 'Menlo', 'Monaco', 'Consolas', "Liberation Mono", "Courier New", 'monospace']
+        display: ['var(--font-inter)', { fontFeatureSettings: '"ss01"' }],
+        mono: ['Roboto-Mono', 'ui-monospace', 'Menlo', 'Monaco', 'Consolas', "Liberation Mono", "Courier New", 'monospace']
       },
       maxWidth: {
         '8xl': '88rem',


### PR DESCRIPTION
Updated Tailwind font families to use Inter for both Sans and Display. Mono font is not Roboto Mono. 
