### PR TITLE
Prefer `brew install` on macOS as Homebrew is more ergonomic

### DIFF
--- a/docs/cli/quickstart.mdx
+++ b/docs/cli/quickstart.mdx
@@ -12,13 +12,13 @@ In this guide, you'll install the Sourcegraph CLI, `src`, connect it to your Sou
 
 ### macOS
 
+```
+brew install sourcegraph/src-cli/src-cli
+```
+or
 ```sh
 curl -L https://sourcegraph.com/.api/src-cli/src_darwin_amd64 -o /usr/local/bin/src
 chmod +x /usr/local/bin/src
-```
-or
-```
-brew install sourcegraph/src-cli/src-cli
 ```
 
 ### Linux

--- a/docs/cli/quickstart.mdx
+++ b/docs/cli/quickstart.mdx
@@ -12,7 +12,7 @@ In this guide, you'll install the Sourcegraph CLI, `src`, connect it to your Sou
 
 ### macOS
 
-```
+```sh
 brew install sourcegraph/src-cli/src-cli
 ```
 or


### PR DESCRIPTION
Per the tin: most macOS developers will have Homebrew, and I think they'll prefer installing through Homebrew instead of an unmanaged binary sitting on disk.