### PR TITLE
Update details about Claude Sonnet 3.5 Model for Pro

### DIFF
--- a/docs/cody/capabilities/supported-models.mdx
+++ b/docs/cody/capabilities/supported-models.mdx
@@ -12,6 +12,7 @@ Cody supports a variety of cutting edge large language models for use in Chat an
 | OpenAI       | [gpt-4o](https://platform.openai.com/docs/models/gpt-4o) | -              | ✅              | ✅              |
 | Anthropic    | [claude-3 Haiku](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                     | -              | ✅              | ✅              |
 | Anthropic    | [claude-3 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                    | ✅              | ✅              | ✅              |
+| Anthropic    | [claude-3.5 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                    | ✅              | ✅              | -              |
 | Anthropic    | [claude-3 Opus](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                      | -              | ✅              | ✅              |
 | Mistral      | [mixtral 8x7b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best)                        | -              | ✅              | -              |
 | Mistral      | [mixtral 8x22b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best)                       | -              | ✅              | -              |

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -311,9 +311,9 @@ Cody also works with Cursor, Gitpod, IDX, and other similar VS Code forks. To ac
 
 ## Supported LLM models
 
-Claude 3 Sonnet is the default LLM model for Cody Free users for Chat and Commands. Users on Cody **Pro** can choose from a list of supported LLM models for Chat, Commands, and Autocomplete. These LLMs are Claude Instant, Claude 2.0, Claude 2.1, Claude 3 (Haiku, Opus and Sonnet), ChatGPT 3.5 Turbo, ChatGPT 4 Turbo Preview, GPT-4o, Mixtral, Google Gemini 1.5 Pro and Google Gemini 1.5 Flash.
+Claude Sonnet 3.5 is the default LLM model for Cody Free users for Chat and Commands. Users on Cody **Pro** can choose from a list of supported LLM models for Chat, Commands, and Autocomplete. These LLMs are Claude Instant, Claude 2.0, Claude 2.1, Claude 3 (Haiku, Opus and Sonnet), Claude 3.5 Sonnet, ChatGPT 3.5 Turbo, ChatGPT 4 Turbo Preview, GPT-4o, Mixtral, Google Gemini 1.5 Pro and Google Gemini 1.5 Flash.
 
-![LLM-models-for-cody-pro](https://storage.googleapis.com/sourcegraph-assets/Docs/vscode-llm-models-june2024.png)
+![LLM-models-for-cody-pro](https://storage.googleapis.com/sourcegraph-assets/Docs/vscode-llm-models-june20-2024.png)
 
 Cody Enterprise users get Claude 3 (Opus and Sonnet) as the default LLM models without extra cost. In addition, Enterprise users also get capabilities like BYOLLM (Bring Your Own LLM) key. Your site administrator determines the LLM; you cannot change it from the editor. However, when using Cody Gateway, you can [configure custom models](/cody/core-concepts/cody-gateway#configuring-custom-models) Anthropic (like Claude 2.0 and Claude Instant), OpenAI (GPT 3.5 and GPT 4), Amazon Bedrock and Azure OpenAI Service.
 

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -311,7 +311,7 @@ Cody also works with Cursor, Gitpod, IDX, and other similar VS Code forks. To ac
 
 ## Supported LLM models
 
-Claude Sonnet 3.5 is the default LLM model for Cody Free users for Chat and Commands. Users on Cody **Pro** can choose from a list of supported LLM models for Chat, Commands, and Autocomplete. These LLMs are Claude Instant, Claude 2.0, Claude 2.1, Claude 3 (Haiku, Opus and Sonnet), Claude 3.5 Sonnet, ChatGPT 3.5 Turbo, ChatGPT 4 Turbo Preview, GPT-4o, Mixtral, Google Gemini 1.5 Pro and Google Gemini 1.5 Flash.
+Claude Sonnet 3 is the default LLM model for Cody Free users for Chat and Commands. Users on Cody **Pro** can choose from a list of supported LLM models for Chat, Commands, and Autocomplete. These LLMs are Claude Instant, Claude 2.0, Claude 2.1, Claude 3 (Haiku, Opus and Sonnet), Claude 3.5 Sonnet, ChatGPT 3.5 Turbo, ChatGPT 4 Turbo Preview, GPT-4o, Mixtral, Google Gemini 1.5 Pro and Google Gemini 1.5 Flash.
 
 ![LLM-models-for-cody-pro](https://storage.googleapis.com/sourcegraph-assets/Docs/vscode-llm-models-june20-2024.png)
 


### PR DESCRIPTION
This PR updates the following:

- Adds mention of Claude Sonnet 3.5 as another supported LLM model for Chat and Commands for Cody Pro VS Code users
- Updates our Supported LLMs docs 
- Mentions that Claude Sonnet 3.5 is the default model for Chat and Commands for Cody Free users

### Reference:

- https://sourcegraph.slack.com/archives/C05AGQYD528/p1718896254676939