### PR TITLE
Docs for VS Code release v1.24.0

### DIFF
--- a/docs/cody/capabilities/supported-models.mdx
+++ b/docs/cody/capabilities/supported-models.mdx
@@ -4,22 +4,22 @@
 
 Cody supports a variety of cutting edge large language models for use in Chat and Commands, allowing you to select the best model for your use case.  Free users are defaulted to the Claude 3 Sonnet model from Anthropic, while Pro users have access to select any supported model.
 
-| **Provider** |                                                                   **Model**                                                                   |    **Free**    |    **Pro**     | **Enterprise** |
-| :----------- | :-------------------------------------------------------------------------------------------------------------------------------------------- | :------------- | :------------- | :------------- |
-| OpenAI       | [gpt-3.5 turbo](https://platform.openai.com/docs/models/gpt-3-5-turbo)                                                                        | -              | ✅              | ✅              |
-| OpenAI       | [gpt-4](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#:~:text=to%20Apr%202023-,gpt%2D4,-Currently%20points%20to)              | -              | -              | ✅              |
-| OpenAI       | [gpt-4 turbo](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#:~:text=TRAINING%20DATA-,gpt%2D4%2D0125%2Dpreview,-New%20GPT%2D4) | -              | ✅              | ✅              |
-| OpenAI       | [gpt-4o](https://platform.openai.com/docs/models/gpt-4o) | -              | ✅              | ✅              |
-| Anthropic    | [claude-3 Haiku](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                     | -              | ✅              | ✅              |
-| Anthropic    | [claude-3 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                    | ✅              | ✅              | ✅              |
-| Anthropic    | [claude-3.5 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                    | ✅              | ✅              | -              |
-| Anthropic    | [claude-3 Opus](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                      | -              | ✅              | ✅              |
-| Mistral      | [mixtral 8x7b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best)                        | -              | ✅              | -              |
-| Mistral      | [mixtral 8x22b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best)                       | -              | ✅              | -              |
-| Ollama      | [variety](https://ollama.com/)                                                                                                                | experimental | experimental | -              |
-| Google Gemini      | [1.5 Pro](https://deepmind.google/technologies/gemini/pro/)                                                                                                                | - | ✅ | ✅              |
-| Google Gemini       | [1.5 Flash](https://deepmind.google/technologies/gemini/flash/)                                                                                                                | - | ✅ | ✅              |
-|              |                                                                                                                                               |                |                |                |                                                                                                                                           |                |                |                |
+| **Provider**  |                                                                   **Model**                                                                   |   **Free**   |   **Pro**    | **Enterprise** |     |     |     |     |
+| :------------ | :-------------------------------------------------------------------------------------------------------------------------------------------- | :----------- | :----------- | :------------- | --- | --- | --- | --- |
+| OpenAI        | [gpt-3.5 turbo](https://platform.openai.com/docs/models/gpt-3-5-turbo)                                                                        | ✅            | ✅            | ✅              |     |     |     |     |
+| OpenAI        | [gpt-4](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#:~:text=to%20Apr%202023-,gpt%2D4,-Currently%20points%20to)              | -            | -            | ✅              |     |     |     |     |
+| OpenAI        | [gpt-4 turbo](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#:~:text=TRAINING%20DATA-,gpt%2D4%2D0125%2Dpreview,-New%20GPT%2D4) | -            | ✅            | ✅              |     |     |     |     |
+| OpenAI        | [gpt-4o](https://platform.openai.com/docs/models/gpt-4o)                                                                                      | -            | ✅            | ✅              |     |     |     |     |
+| Anthropic     | [claude-3 Haiku](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                     | ✅            | ✅            | ✅              |     |     |     |     |
+| Anthropic     | [claude-3 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                    | ✅            | ✅            | ✅              |     |     |     |     |
+| Anthropic     | [claude-3.5 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                  | ✅            | ✅            | -              |     |     |     |     |
+| Anthropic     | [claude-3 Opus](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                      | -            | ✅            | ✅              |     |     |     |     |
+| Mistral       | [mixtral 8x7b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best)                        | ✅            | ✅            | -              |     |     |     |     |
+| Mistral       | [mixtral 8x22b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best)                       | ✅            | ✅            | -              |     |     |     |     |
+| Ollama        | [variety](https://ollama.com/)                                                                                                                | experimental | experimental | -              |     |     |     |     |
+| Google Gemini | [1.5 Pro](https://deepmind.google/technologies/gemini/pro/)                                                                                   | ✅            | ✅            | ✅              |     |     |     |     |
+| Google Gemini | [1.5 Flash](https://deepmind.google/technologies/gemini/flash/)                                                                               | ✅            | ✅            | ✅              |     |     |     |     |
+|               |                                                                                                                                               |              |              |                |     |     |     |     |
 
 <Callout type="note">To use Claude 3 (Opus and Sonnets) models with Cody Enterprise, make sure you've upgraded your Sourcegraph instance to the latest version.</Callout>
 

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -278,7 +278,7 @@ Cody offers quick, ready-to-use [Commands](/cody/capabilities/commands) for comm
 - **Edit Code**: Edit code with instructions
 - **Explain Code**: Describe your code with more details
 - **Find Code Smells**: Identify bad code practices and bugs
-- **Generate unit tests**: Write tests for your code
+- **Generate Unit Tests**: Write tests for your code
 - **Custom commands**: Helps you write and define your own commands
 
 Let's understand how the `/doc` command generates code documentation for a function.

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -326,7 +326,7 @@ Claude Sonnet 3 is the default LLM model for Cody Free users for Chat and Comman
 | Mistral       | [mixtral 8x7b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best)                        | ✅            | ✅            |     |     |     |     |
 | Mistral       | [mixtral 8x22b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best)                       | ✅            | ✅            |     |     |     |     |
 | Ollama        | [variety](https://ollama.com/)                                                                                                                | experimental | experimental |     |     |     |     |
-| Google Gemini | [1.5 Pro](https://deepmind.google/technologies/gemini/pro/)                                                                                   | ✅            | ✅            |     |     |     |     |
+| Google | [Gemini 1.5 Pro](https://deepmind.google/technologies/gemini/pro/)                                                                                   | ✅            | ✅            |     |     |     |     |
 | Google Gemini | [1.5 Flash](https://deepmind.google/technologies/gemini/flash/)                                                                               | ✅            | ✅            |     |     |     |     |
 |               |                                                                                                                                               |              |              |     |     |     |     |
 

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -327,7 +327,7 @@ Claude Sonnet 3 is the default LLM model for Cody Free users for Chat and Comman
 | Mistral       | [mixtral 8x22b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best)                       | ✅            | ✅            |     |     |     |     |
 | Ollama        | [variety](https://ollama.com/)                                                                                                                | experimental | experimental |     |     |     |     |
 | Google | [Gemini 1.5 Pro](https://deepmind.google/technologies/gemini/pro/)                                                                                   | ✅            | ✅            |     |     |     |     |
-| Google Gemini | [1.5 Flash](https://deepmind.google/technologies/gemini/flash/)                                                                               | ✅            | ✅            |     |     |     |     |
+| Google | [Gemini 1.5 Flash](https://deepmind.google/technologies/gemini/flash/)                                                                               | ✅            | ✅            |     |     |     |     |
 |               |                                                                                                                                               |              |              |     |     |     |     |
 
 

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -276,7 +276,7 @@ Cody offers quick, ready-to-use [Commands](/cody/capabilities/commands) for comm
 - **New Chat**: Ask Cody a question
 - **Document Code**: Add code documentation
 - **Edit Code**: Edit code with instructions
-- **Explain code**: Describe your code with more details
+- **Explain Code**: Describe your code with more details
 - **Find Code Smells**: Identify bad code practices and bugs
 - **Generate unit tests**: Write tests for your code
 - **Custom commands**: Helps you write and define your own commands

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -273,13 +273,13 @@ For repos mentioned in the `exclude` field, Cody's commands are disabled, and yo
 
 Cody offers quick, ready-to-use [Commands](/cody/capabilities/commands) for common actions to write, describe, fix, and smell code. These allow you to run predefined actions with smart context-fetching anywhere in the editor, like:
 
-- Ask Cody a question
-- Add code documentation
-- Edit code with instructions
-- Explain code
-- Identify code smells
-- Generate unit tests
-- Custom commands
+- **New Chat**: Ask Cody a question
+- **Document Code**: Add code documentation
+- **Edit Code**: Edit code with instructions
+- **Explain code**: Describe your code with more details
+- **Find Code Smells**: Identify bad code practices and bugs
+- **Generate unit tests**: Write tests for your code
+- **Custom commands**: Helps you write and define your own commands
 
 Let's understand how the `/doc` command generates code documentation for a function.
 
@@ -311,9 +311,22 @@ Cody also works with Cursor, Gitpod, IDX, and other similar VS Code forks. To ac
 
 ## Supported LLM models
 
-Claude Sonnet 3 is the default LLM model for Cody Free users for Chat and Commands. Users on Cody **Pro** can choose from a list of supported LLM models for Chat, Commands, and Autocomplete. These LLMs are Claude Instant, Claude 2.0, Claude 2.1, Claude 3 (Haiku, Opus and Sonnet), Claude 3.5 Sonnet, ChatGPT 3.5 Turbo, ChatGPT 4 Turbo Preview, GPT-4o, Mixtral, Google Gemini 1.5 Pro and Google Gemini 1.5 Flash.
+Claude Sonnet 3 is the default LLM model for Cody Free users for Chat and Commands. Users on Cody **Free** and **Pro** can choose from a list of supported LLM models for Chat and Commands. Here's a preview:
 
-![LLM-models-for-cody-pro](https://storage.googleapis.com/sourcegraph-assets/Docs/vscode-llm-models-june20-2024.png)
+|   **Cody Free**    |           **Cody Pro**            |
+| ------------------ | --------------------------------- |
+| Claude 3 Sonnet    | Claude Instant                    |
+| Claude 3.5 Sonnnet | Claude 2.0                        |
+| Claude 3 Haiku     | Claude 3 (Haiku, Opus and Sonnet) |
+| GPT 3.5 Turbo      | Claude 3.5 Sonnet                 |
+| Gemini 1.5 Flash   | GPT 3.5 Turbo                     |
+| Gemini 1.5 Pro     | GPT 4 Turbo Preview               |
+| Mixtral 8x22B      | GPT-4o                            |
+| Mixtral 8x7B       | Mixtral                           |
+| Mixtral 8x7B       | Gemini 1.5 Pro                    |
+| Mixtral 8x7B       | Gemini 1.5 Flash                  |
+
+![LLM-models-for-cody-free](https://storage.googleapis.com/sourcegraph-assets/Docs/LLM-Select-Free.png)
 
 Cody Enterprise users get Claude 3 (Opus and Sonnet) as the default LLM models without extra cost. In addition, Enterprise users also get capabilities like BYOLLM (Bring Your Own LLM) key. Your site administrator determines the LLM; you cannot change it from the editor. However, when using Cody Gateway, you can [configure custom models](/cody/core-concepts/cody-gateway#configuring-custom-models) Anthropic (like Claude 2.0 and Claude Instant), OpenAI (GPT 3.5 and GPT 4), Amazon Bedrock and Azure OpenAI Service.
 

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -313,18 +313,24 @@ Cody also works with Cursor, Gitpod, IDX, and other similar VS Code forks. To ac
 
 Claude Sonnet 3 is the default LLM model for Cody Free users for Chat and Commands. Users on Cody **Free** and **Pro** can choose from a list of supported LLM models for Chat and Commands. Here's a preview:
 
-|   **Cody Free**    |           **Cody Pro**            |
-| ------------------ | --------------------------------- |
-| Claude 3 Sonnet    | Claude Instant                    |
-| Claude 3.5 Sonnnet | Claude 2.0                        |
-| Claude 3 Haiku     | Claude 3 (Haiku, Opus and Sonnet) |
-| GPT 3.5 Turbo      | Claude 3.5 Sonnet                 |
-| Gemini 1.5 Flash   | GPT 3.5 Turbo                     |
-| Gemini 1.5 Pro     | GPT 4 Turbo Preview               |
-| Mixtral 8x22B      | GPT-4o                            |
-| Mixtral 8x7B       | Mixtral                           |
-| Mixtral 8x7B       | Gemini 1.5 Pro                    |
-| Mixtral 8x7B       | Gemini 1.5 Flash                  |
+| **Provider**  |                                                                   **Model**                                                                   |   **Free**   |   **Pro**    |     |     |     |     |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | ------------ | --- | --- | --- | --- |
+| OpenAI        | [gpt-3.5 turbo](https://platform.openai.com/docs/models/gpt-3-5-turbo)                                                                        | ✅            | ✅            |     |     |     |     |
+| OpenAI        | [gpt-4](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#:~:text=to%20Apr%202023-,gpt%2D4,-Currently%20points%20to)              | -            | -            |     |     |     |     |
+| OpenAI        | [gpt-4 turbo](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#:~:text=TRAINING%20DATA-,gpt%2D4%2D0125%2Dpreview,-New%20GPT%2D4) | -            | ✅            |     |     |     |     |
+| OpenAI        | [gpt-4o](https://platform.openai.com/docs/models/gpt-4o)                                                                                      | -            | ✅            |     |     |     |     |
+| Anthropic     | [claude-3 Haiku](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                     | ✅            | ✅            |     |     |     |     |
+| Anthropic     | [claude-3 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                    | ✅            | ✅            |     |     |     |     |
+| Anthropic     | [claude-3.5 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                  | ✅            | ✅            |     |     |     |     |
+| Anthropic     | [claude-3 Opus](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                      | -            | ✅            |     |     |     |     |
+| Mistral       | [mixtral 8x7b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best)                        | ✅            | ✅            |     |     |     |     |
+| Mistral       | [mixtral 8x22b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best)                       | ✅            | ✅            |     |     |     |     |
+| Ollama        | [variety](https://ollama.com/)                                                                                                                | experimental | experimental |     |     |     |     |
+| Google Gemini | [1.5 Pro](https://deepmind.google/technologies/gemini/pro/)                                                                                   | ✅            | ✅            |     |     |     |     |
+| Google Gemini | [1.5 Flash](https://deepmind.google/technologies/gemini/flash/)                                                                               | ✅            | ✅            |     |     |     |     |
+|               |                                                                                                                                               |              |              |     |     |     |     |
+
+
 
 ![LLM-models-for-cody-free](https://storage.googleapis.com/sourcegraph-assets/Docs/LLM-Select-Free.png)
 

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -281,7 +281,7 @@ Cody offers quick, ready-to-use [Commands](/cody/capabilities/commands) for comm
 - **Generate Unit Tests**: Write tests for your code
 - **Custom Commands**: Helps you write and define your own commands
 
-Let's understand how the `/doc` command generates code documentation for a function.
+Let's understand how the `Document Code` command generates code documentation for a function.
 
 <video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto', aspectRatio: '1920 / 1080' }}>
   <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/code-comments-cody.mp4" type="video/mp4" />

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -279,7 +279,7 @@ Cody offers quick, ready-to-use [Commands](/cody/capabilities/commands) for comm
 - **Explain Code**: Describe your code with more details
 - **Find Code Smells**: Identify bad code practices and bugs
 - **Generate Unit Tests**: Write tests for your code
-- **Custom commands**: Helps you write and define your own commands
+- **Custom Commands**: Helps you write and define your own commands
 
 Let's understand how the `/doc` command generates code documentation for a function.
 

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -311,32 +311,15 @@ Cody also works with Cursor, Gitpod, IDX, and other similar VS Code forks. To ac
 
 ## Supported LLM models
 
-Claude Sonnet 3 is the default LLM model for Cody Free users for Chat and Commands. Users on Cody **Free** and **Pro** can choose from a list of supported LLM models for Chat and Commands. Here's a preview:
-
-| **Provider**  |                                                                   **Model**                                                                   |   **Free**   |   **Pro**    |     |     |     |     |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | ------------ | --- | --- | --- | --- |
-| OpenAI        | [gpt-3.5 turbo](https://platform.openai.com/docs/models/gpt-3-5-turbo)                                                                        | ✅            | ✅            |     |     |     |     |
-| OpenAI        | [gpt-4](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#:~:text=to%20Apr%202023-,gpt%2D4,-Currently%20points%20to)              | -            | -            |     |     |     |     |
-| OpenAI        | [gpt-4 turbo](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#:~:text=TRAINING%20DATA-,gpt%2D4%2D0125%2Dpreview,-New%20GPT%2D4) | -            | ✅            |     |     |     |     |
-| OpenAI        | [gpt-4o](https://platform.openai.com/docs/models/gpt-4o)                                                                                      | -            | ✅            |     |     |     |     |
-| Anthropic     | [claude-3 Haiku](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                     | ✅            | ✅            |     |     |     |     |
-| Anthropic     | [claude-3 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                    | ✅            | ✅            |     |     |     |     |
-| Anthropic     | [claude-3.5 Sonnet](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                  | ✅            | ✅            |     |     |     |     |
-| Anthropic     | [claude-3 Opus](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)                                                      | -            | ✅            |     |     |     |     |
-| Mistral       | [mixtral 8x7b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best)                        | ✅            | ✅            |     |     |     |     |
-| Mistral       | [mixtral 8x22b](https://mistral.ai/technology/#models:~:text=of%20use%20cases.-,Mixtral%208x7B,-Currently%20the%20best)                       | ✅            | ✅            |     |     |     |     |
-| Ollama        | [variety](https://ollama.com/)                                                                                                                | experimental | experimental |     |     |     |     |
-| Google | [Gemini 1.5 Pro](https://deepmind.google/technologies/gemini/pro/)                                                                                   | ✅            | ✅            |     |     |     |     |
-| Google | [Gemini 1.5 Flash](https://deepmind.google/technologies/gemini/flash/)                                                                               | ✅            | ✅            |     |     |     |     |
-|               |                                                                                                                                               |              |              |     |     |     |     |
-
-
+Claude Sonnet 3 is the default LLM model for Cody Free users for Chat and Commands. Users on Cody **Free** and **Pro** can choose from a list of supported LLM models for Chat and Commands.
 
 ![LLM-models-for-cody-free](https://storage.googleapis.com/sourcegraph-assets/Docs/LLM-Select-Free.png)
 
 Cody Enterprise users get Claude 3 (Opus and Sonnet) as the default LLM models without extra cost. In addition, Enterprise users also get capabilities like BYOLLM (Bring Your Own LLM) key. Your site administrator determines the LLM; you cannot change it from the editor. However, when using Cody Gateway, you can [configure custom models](/cody/core-concepts/cody-gateway#configuring-custom-models) Anthropic (like Claude 2.0 and Claude Instant), OpenAI (GPT 3.5 and GPT 4), Amazon Bedrock and Azure OpenAI Service.
 
 <Callout type="note">To use Claude 3 (Opus and Sonnets) models with Cody Enterprise, make sure you've upgraded your Sourcegraph instance to the latest version.</Callout>
+
+<Callout type="note">Read and learn more about the [supported LLMs](/cody/capabilities/supported-models) and [token limits](/cody/core-concepts/token-limits) on Cody Free, Pro and Enterprise.</Callout>
 
 ## Supported local Ollama models with Cody
 

--- a/docs/cody/core-concepts/token-limits.mdx
+++ b/docs/cody/core-concepts/token-limits.mdx
@@ -15,7 +15,6 @@ Here's a detailed breakdown of the token limits by model:
 |       **Model**       | **Conversation Context** | **@-mention Context** | **Output** |
 | --------------------- | ------------------------ | --------------------- | ---------- |
 | gpt-3.5-turbo         | 7,000                    | shared                | 4,000      |
-| gpt-4                 | 7,000                    | shared                | 4,000      |
 | gpt-4-turbo           | 7,000                    | shared                | 4,000      |
 | gpt 4o                | 7,000                    | shared                | 4,000      |
 | claude instant        | 7,000                    | shared                | 4,000      |

--- a/docs/cody/core-concepts/token-limits.mdx
+++ b/docs/cody/core-concepts/token-limits.mdx
@@ -10,41 +10,46 @@ All other models are currently capped at **7,000 tokens** of shared context betw
 
 Here's a detailed breakdown of the token limits by model:
 
-
-
 <Tabs>
   <Tab title="Free">
-|      **Model**      | **Conversation Context** | **@-mention Context** | **Output** |
-| ------------------- | ------------------------ | --------------------- | ---------- |
-| gpt-3.5-turbo       | 7,000                    | shared                | 4,000      |
-| gpt-4               | 7,000                    | shared                | 4,000      |
-| gpt-4-turbo         | 7,000                    | shared                | 4,000      |
-| claude instant      | 7,000                    | shared                | 4,000      |
-| claude-2.0          | 7,000                    | shared                | 4,000      |
-| claude-2.1          | 7,000                    | shared                | 4,000      |
-| claude-3 Haiku      | 7,000                    | shared                | 4,000      |
-| **claude-3 Sonnet** | **15,000**               | **30,000**            | **4,000**  |
+|       **Model**       | **Conversation Context** | **@-mention Context** | **Output** |
+| --------------------- | ------------------------ | --------------------- | ---------- |
+| gpt-3.5-turbo         | 7,000                    | shared                | 4,000      |
+| gpt-4                 | 7,000                    | shared                | 4,000      |
+| gpt-4-turbo           | 7,000                    | shared                | 4,000      |
+| gpt 4o                | 7,000                    | shared                | 4,000      |
+| claude instant        | 7,000                    | shared                | 4,000      |
+| claude-2.0            | 7,000                    | shared                | 4,000      |
+| claude-2.1            | 7,000                    | shared                | 4,000      |
+| claude-3 Haiku        | 7,000                    | shared                | 4,000      |
+| **claude-3 Sonnet**   | **15,000**               | **30,000**            | **4,000**  |
 | **claude-3.5 Sonnet** | **15,000**               | **45,000**            | **4,000**  |
-| **claude-3 Opus**   | **15,000**               | **30,000**            | **4,000**  |
-| mixtral 8x7b        | 7,000                    | shared                | 4,000      |
+| **claude-3 Opus**     | **15,000**               | **30,000**            | **4,000**  |
+| mixtral 8x7B          | 7,000                    | shared                | 4,000      |
+| mixtral 8x22B         | 7,000                    | shared                | 4,000      |
+| gemini 1.5 pro        | 7,000                    | shared                | 4,000      |
+| gemini 1.5 flash      | 7,000                    | shared                | 4,000      |
+
+
+
   </Tab>
 
 <Tab title="Pro">
-|      **Model**      | **Conversation Context** | **@-mention Context** | **Output** |
-| ------------------- | ------------------------ | --------------------- | ---------- |
-| gpt-3.5-turbo       | 7,000                    | shared                | 4,000      |
-| gpt-4               | 7,000                    | shared                | 4,000      |
-| gpt-4-turbo         | 7,000                    | shared                | 4,000      |
-| claude instant      | 7,000                    | shared                | 4,000      |
-| claude-2.0          | 7,000                    | shared                | 4,000      |
-| claude-2.1          | 7,000                    | shared                | 4,000      |
-| claude-3 Haiku      | 7,000                    | shared                | 4,000      |
-| **claude-3 Sonnet** | **15,000**               | **30,000**            | **4,000**  |
-| **claude-3.5 Sonnet** | **15,000**               | **45,000**            | **4,000**  |
-| **claude-3 Opus**   | **15,000**               | **30,000**            | **4,000**  |
-| **Google Gemini 1.5 Flash** | **15,000**       | **30,000**            | **4,000**  |
-| **Google Gemini 1.5 Pro**   | **15,000**       | **30,000**            | **4,000**  |
-| mixtral 8x7b        | 7,000                    | shared                | 4,000      |
+|          **Model**          | **Conversation Context** | **@-mention Context** | **Output** |
+| --------------------------- | ------------------------ | --------------------- | ---------- |
+| gpt-3.5-turbo               | 7,000                    | shared                | 4,000      |
+| gpt-4                       | 7,000                    | shared                | 4,000      |
+| gpt-4-turbo                 | 7,000                    | shared                | 4,000      |
+| claude instant              | 7,000                    | shared                | 4,000      |
+| claude-2.0                  | 7,000                    | shared                | 4,000      |
+| claude-2.1                  | 7,000                    | shared                | 4,000      |
+| claude-3 Haiku              | 7,000                    | shared                | 4,000      |
+| **claude-3 Sonnet**         | **15,000**               | **30,000**            | **4,000**  |
+| **claude-3.5 Sonnet**       | **15,000**               | **45,000**            | **4,000**  |
+| **claude-3 Opus**           | **15,000**               | **30,000**            | **4,000**  |
+| **Google Gemini 1.5 Flash** | **15,000**               | **30,000**            | **4,000**  |
+| **Google Gemini 1.5 Pro**   | **15,000**               | **30,000**            | **4,000**  |
+| mixtral 8x7b                | 7,000                    | shared                | 4,000      |
   </Tab>
 
   <Tab title="Enterprise">

--- a/docs/cody/core-concepts/token-limits.mdx
+++ b/docs/cody/core-concepts/token-limits.mdx
@@ -27,8 +27,8 @@ Here's a detailed breakdown of the token limits by model:
 | **claude-3 Opus**     | **15,000**               | **30,000**            | **4,000**  |
 | mixtral 8x7B          | 7,000                    | shared                | 4,000      |
 | mixtral 8x22B         | 7,000                    | shared                | 4,000      |
-| gemini 1.5 pro        | 7,000                    | shared                | 4,000      |
-| gemini 1.5 flash      | 7,000                    | shared                | 4,000      |
+| Google Gemini 1.5 Flash        | 7,000                    | shared                | 4,000      |
+| Google Gemini 1.5 Pro      | 7,000                    | shared                | 4,000      |
 
 
 

--- a/docs/cody/core-concepts/token-limits.mdx
+++ b/docs/cody/core-concepts/token-limits.mdx
@@ -17,7 +17,6 @@ Here's a detailed breakdown of the token limits by model:
 | gpt-3.5-turbo         | 7,000                    | shared                | 4,000      |
 | gpt-4-turbo           | 7,000                    | shared                | 4,000      |
 | gpt 4o                | 7,000                    | shared                | 4,000      |
-| claude instant        | 7,000                    | shared                | 4,000      |
 | claude-2.0            | 7,000                    | shared                | 4,000      |
 | claude-2.1            | 7,000                    | shared                | 4,000      |
 | claude-3 Haiku        | 7,000                    | shared                | 4,000      |

--- a/docs/cody/core-concepts/token-limits.mdx
+++ b/docs/cody/core-concepts/token-limits.mdx
@@ -24,7 +24,6 @@ Here's a detailed breakdown of the token limits by model:
 | claude-3 Haiku        | 7,000                    | shared                | 4,000      |
 | **claude-3 Sonnet**   | **15,000**               | **30,000**            | **4,000**  |
 | **claude-3.5 Sonnet** | **15,000**               | **45,000**            | **4,000**  |
-| **claude-3 Opus**     | **15,000**               | **30,000**            | **4,000**  |
 | mixtral 8x7B          | 7,000                    | shared                | 4,000      |
 | mixtral 8x22B         | 7,000                    | shared                | 4,000      |
 | Google Gemini 1.5 Flash        | 7,000                    | shared                | 4,000      |


### PR DESCRIPTION
This PR adds docs changes for VS Code release v1.24.0. Features the following changes:

- Addition of LLM Selection to Free tier
- Update screenshot for LLM selection on Free Tier
- Update our Supported LLMs page