### PR TITLE
update Slack notifs code monitoring docs, remove beta label

### DIFF
--- a/docs/code_monitoring/how-tos/index.mdx
+++ b/docs/code_monitoring/how-tos/index.mdx
@@ -1,5 +1,5 @@
 # How-tos
 
 * [Starting points](/code_monitoring/how-tos/starting_points)
-* [Setting up Slack notifications](/code_monitoring/how-tos/slack) (Beta)
+* [Setting up Slack notifications](/code_monitoring/how-tos/slack)
 * [Setting up Webhook notifications](/code_monitoring/how-tos/webhook) (Beta)

--- a/docs/code_monitoring/how-tos/slack.mdx
+++ b/docs/code_monitoring/how-tos/slack.mdx
@@ -1,21 +1,22 @@
-# Setting up Slack notifications
+# Slack notifications for code monitors
 
-<Callout type="note">This feature is in beta.</Callout>
+You can set up [code monitors](/code_monitoring) to send notifications about new matching search results to Slack channels.
 
-Slack notifications are supported via webhooks. Webhooks are special URLs that Sourcegraph's Code Monitoring
-can call in order to send a message to a Slack channel when there are new search results for a query.
-In order to use Slack notifications, you must first create a Slack application in your organization's Slack workspace,
-add a webhook for a Slack channel within that application, and then configure a code monitor in Sourcegraph to
-use that webhook's URL.
+## Requirements
 
-## Prerequisites
+- You must have permission to create apps in your organization's Slack workspace.
 
-- You must not have have the setting `experimentalFeatures.codeMonitoringWebHooks` disabled in your user, org, or global settings.
-- You must have permission to create apps inside of your organization's Slack workspace
+## Usage
 
-## Creating a Slack webhook
+1. In Sourcegraph, click on the "Code Monitoring" nav item at the top of the page.
+1. Create a new code monitor or edit an existing monitor by clicking on the "Edit" button next to it.
+1. Go through the standard steps for a code monitor (if it's a new one) and select the action **Send Slack message to channel**.
+1. Paste your webhook URL into the "Webhook URL" field. (See "[Creating a Slack incoming webhook URL](#creating-a-slack-incoming-webhook-url)" below for detailed instructions.)
+1. Click on the "Continue" button, and then the "Save" button.
 
-1. Navigate to https://api.slack.com/apps and sign in to your Slack account if necessary.
+### Creating a Slack incoming webhook URL
+
+1. Go to https://api.slack.com/apps and sign in to your Slack account if necessary.
 1. Click on the "Create an app" button.
 1. Create your app "From scratch".
 1. Give your app a name and select the workplace you want notifications sent to.
@@ -26,12 +27,3 @@ use that webhook's URL.
 1. Select the channel you want notifications sent to, then click on the "Allow" button.
 1. Your webhook URL is now created! Click the copy button to copy it to your clipboard.
  <video src="https://storage.googleapis.com/sourcegraph-assets/search/code-monitoring/slack-tutorial/2-create-webhook.mp4" controls />
-
-## Configuring a code monitor to send Slack notifications
-
-1. In Sourcegraph, click on the "Code Monitoring" nav item at the top of the page.
-1. Create a new code monitor or edit an existing monitor by clicking on the "Edit" button next to it.
-1. Go through the standard configuration steps for a code monitor and select action "Send Slack message to channel".
-1. Paste your webhook URL into the "Webhook URL" field.
-1. Click on the "Continue" button, and then the "Save" button.
- <video src="https://storage.googleapis.com/sourcegraph-assets/search/code-monitoring/slack-tutorial/3-create-monitor.mp4" controls />


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/SRCH-521/ensure-slack-notifs-feature-is-documented-and-on-marketing-site