### PR TITLE
Fixing link to Google paper. Double slash misplaced.

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -17,7 +17,7 @@ More specifically, Sourcegraph is great for all developers except:
 
 ## Why do I need Code Search?
 
-Facebook and Google provide their employees with an in-house Sourcegraph-like code search and intelligence tool. A [published research paper from Google](https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/43835.pdf) and a [Google developer survey](https://docs.google.com/document/d/1LQxLk4E3lrb3fIsVKlANu_pUjnILteoWMMNiJQmqNVU/edit#heading=h.xxziwxixfqq3) showed that 98% of developers surveyed consider their Sourcegraph-like internal tool to be critical. Developers use it on average for 5.3 sessions each day. (Facebook's and Google's in-house tools are unavailable to other companies; use Sourcegraph instead.)
+Facebook and Google provide their employees with an in-house Sourcegraph-like code search and intelligence tool. A [published research paper from Google](https://static.googleusercontent.com/media/research.google.com//en/pubs/archive/43835.pdf) and a [Google developer survey](https://docs.google.com/document/d/1LQxLk4E3lrb3fIsVKlANu_pUjnILteoWMMNiJQmqNVU/edit#heading=h.xxziwxixfqq3) showed that 98% of developers surveyed consider their Sourcegraph-like internal tool to be critical. Developers use it on average for 5.3 sessions each day. (Facebook's and Google's in-house tools are unavailable to other companies; use Sourcegraph instead.)
 
 ## What do I use Sourcegraph for?
 


### PR DESCRIPTION
The double slash in the link was misplaced. Correct url to research paper is https://static.googleusercontent.com/media/research.google.com//en/pubs/archive/43835.pdf
