### PR TITLE
Update deploy_executors.mdx

### DIFF
--- a/docs/admin/executors/deploy_executors.mdx
+++ b/docs/admin/executors/deploy_executors.mdx
@@ -150,7 +150,7 @@ TMP_FILE="$(mktemp -d)" bash -c 'echo "<password>" | docker --config "${TMP_FILE
 You can also run the following:
 
 ```bash
-echo "username:password" | base64
+echo -n "username:password" | base64
 ```
 
 and then paste the result of that into a JSON string like this:


### PR DESCRIPTION
Added flag "-n" to "echo "username:password" | base64" for creating executor secrets. As is - it appends a new line which causes authentication to fail when pasted into the executor secret

<!-- Explain the changes introduced in your PR -->

## Pull Request approval

Although pull request approval is not enforced for this repository in order to reduce friction, merging without a review will generate a ticket for the docs team to review your changes. So if possible, have your pull request approved before merging.
