### PR TITLE
Add wording to `smartContextWindow` docs so the reader knows that the…

### DIFF
--- a/docs/cody/clients/enable-cody-enterprise.mdx
+++ b/docs/cody/clients/enable-cody-enterprise.mdx
@@ -71,9 +71,19 @@ Cody Enterprise supports searching up to 10 repositories to find relevant contex
 
 <Callout type="note">The `smartContextWindow` configuration is available with Sourcegraph `v>=v5.4.5099` for VS Code (`v>=1.20.0`) and JetBrains (`v>=6.0.0`) Cody clients.</Callout>
 
-Sourcegraph Enterprise versions >=5.4.5099 have the `smartContextWindow` configuration enabled by default. You can access this configuration from the **Site Admin > Site configuration** panel.
+Sourcegraph Enterprise versions >=5.4.5099 have the `smartContextWindow` configuration enabled by default. You can access this configuration from the **Site Admin > Site configuration** panel as part of the `completions` section:
 
-Once enabled, your Cody IDE extension will follow the most optimized context window settings for the selected models and ignore the value configured in the `chatModelMaxTokens` field.
+```json
+{
+  // [...]
+  "cody.enabled": true,
+  "completions": {
+    "smartContextWindow": "enabled"
+  }
+}
+```
+
+When enabled, your Cody IDE extension will follow the most optimized context window settings for the selected models and ignore the value configured in the `chatModelMaxTokens` field.
 
 This feature allows you to configure the context window size based on the selected model and has separate context bandwidths for chat input and user-added context. The `smartContextWindow` configuration is currently supported for the Claude-3 Opus, Claude-3 Sonnet, GPT-4o, and GPT Turbo LLM models.
 


### PR DESCRIPTION
… setting is in the `completions` section
