### PR TITLE
batches: document new version field

### DIFF
--- a/docs/batch-changes/batch-spec-yaml-reference.mdx
+++ b/docs/batch-changes/batch-spec-yaml-reference.mdx
@@ -2,6 +2,28 @@
 
 <p className="subtitle">Sourcegraph Batch Changes use [batch specs](/batch-changes/create-a-batch-change#writing-a-batch-spec) to define batch changes. This page is a reference guide to the batch spec YAML format in which batch specs are defined.</p>
 
+## `version`
+
+The `version` of the batch spec. Defaults to 1 if not specified. New batch specs should use version 2.
+We recommend to always specify the version.
+
+### Version 1
+
+default
+
+### Version 2 (recommended)
+
+Introduced in Sourcegraph version 5.5.
+Queries defined under [`on.repositoriesMatchingQuery`](#onrepositoriesmatchingquery) default to keyword search instead of standard search.
+Authors can override the default by specifying the pattern type explicitly.
+Refer to the [search syntax docs](/code-search/queries) for more information about pattern types.
+
+### Example
+
+```yaml
+version: 2
+```
+
 ## `name`
 
 The `name` of the batch change, which is unique among all batch changes in the namespace. A batch change's name is case-preserving.
@@ -45,7 +67,7 @@ The set of repositories (and branches) on which the batch change would run. It's
 
 ```yaml
 on:
-  - repositoriesMatchingQuery: lang:go fmt.Sprintf("%d", :[v]) patterntype:structural
+  - repositoriesMatchingQuery: lang:go fmt.Sprintf\("%d", \w+\) patterntype:regexp
   - repository: github.com/sourcegraph/sourcegraph
 ```
 
@@ -54,6 +76,8 @@ on:
 A Sourcegraph search query that matches a set of repositories (and branches). Each matched repository branch is added to the list of repositories on which the batch change will run.
 
 Your search query should answer the question, "Where do I want to run this batch change?". Search result matches for things like commits, symbols, or file owners will be ignored.
+
+It's good practice to explicitly specify the pattern type. If you don't specify a pattern type, the default is determined by the [batch spec version](#version).
 
 <Callout type="tip">See [Code Search Queries](/code-search/queries/) docs for more information.</Callout>
 
@@ -66,7 +90,7 @@ on:
 
 ```yaml
 on:
-  - repositoriesMatchingQuery: lang:typescript file:web const changesetStatsFragment
+  - repositoriesMatchingQuery: lang:typescript file:web \"const changesetStatsFragment\" patterntype:keyword
 ```
 
 ## `on.repository`

--- a/docs/batch-changes/batch-spec-yaml-reference.mdx
+++ b/docs/batch-changes/batch-spec-yaml-reference.mdx
@@ -9,7 +9,9 @@ We recommend to always specify the version.
 
 ### Version 1
 
-default
+The schema version before Sourcegraph version 5.5.
+For now, if no version is specified, batch changes will use this schema version.
+It is recommended to switch to version 2.
 
 ### Version 2 (recommended)
 

--- a/docs/batch-changes/create-a-batch-change.mdx
+++ b/docs/batch-changes/create-a-batch-change.mdx
@@ -26,6 +26,7 @@ This part of the guide will walk you through creating a batch change on your loc
 To create a Batch Change, you need a **batch spec** describing the change. Here is an example batch spec that describes a batch change to add **Hello World** to all `README` files:
 
 ```yaml
+version: 2
 name: hello-world
 description: Add Hello World to READMEs
 

--- a/docs/batch-changes/quickstart.mdx
+++ b/docs/batch-changes/quickstart.mdx
@@ -44,6 +44,7 @@ A **batch spec** is a YAML file that defines a batch change. It specifies which 
 Save the following batch spec as `hello-world.batch.yaml`:
 
 ```yaml
+version: 2
 name: hello-world
 description: Add Hello World to READMEs
 


### PR DESCRIPTION
This adds documentation for the new batch spec version.

Relates to https://github.com/sourcegraph/sourcegraph/pull/63613

Closes SPLF-130