### PR TITLE
chore(Source): Update Perforce docs to include new search feature

### DIFF
--- a/docs/admin/repo/perforce.mdx
+++ b/docs/admin/repo/perforce.mdx
@@ -247,6 +247,18 @@ When enabled, URLs for Perforce code hosts will use the Changelist (CL) ID inste
 - Viewing a specific file added / removed / modified in a specific CL
 - Viewing the list of CLs
 
+
+### Searching within a specific changelist
+You can search within a specific changelist by referring the the changelist as a reference path like `changelist/123` where 123 is the changelist id. For example, given a repo path of `Talkhouse/main` and a changelist id of `123`, you can search within that changelist by using the following query:
+```
+repo:^Talkhouse/main$@changelist/123 text to find
+```
+
+or 
+```
+repo:^Talkhouse/main$ rev:changelist/123 text to find
+```
+
 #### Limitations
 
 - After a depot is cloned or fetched, Sourcegraph computes and stores mappings of CL IDs to commit SHAs. This mapping can take several minutes for large clones/fetches. When a background mapping job is running, the depot won't be serviceable as URLs referring to CL IDs may not resolve and users may see an error while interacting with the depot.

--- a/docs/admin/repo/perforce.mdx
+++ b/docs/admin/repo/perforce.mdx
@@ -249,7 +249,7 @@ When enabled, URLs for Perforce code hosts will use the Changelist (CL) ID inste
 
 
 ### Searching within a specific changelist
-You can search within a specific changelist by referring the the changelist as a reference path like `changelist/123` where 123 is the changelist id. For example, given a repo path of `Talkhouse/main` and a changelist id of `123`, you can search within that changelist by using the following query:
+As of Sourcegraph 5.5, you can search within a specific changelist by referring the the changelist as a reference path like `changelist/123` where 123 is the changelist id. For example, given a repo path of `Talkhouse/main` and a changelist id of `123`, you can search within that changelist by using the following query:
 ```
 repo:^Talkhouse/main$@changelist/123 text to find
 ```


### PR DESCRIPTION
We recently added the ability for searching a specific changelist id for a perforce repo. This PR updates the docs to include info on how this works. 