### PR TITLE
Remove mentions of LLM selection drop down from ENT tier

### DIFF
--- a/docs/cody/clients/enable-cody-enterprise.mdx
+++ b/docs/cody/clients/enable-cody-enterprise.mdx
@@ -116,10 +116,6 @@ A few considerations to keep in view:
 
 <Callout type="info">You can read and learn more about [Cody's input and output token limits here](/cody/core-concepts/token-limits).</Callout>
 
-<!-- ## LLM Selection
-
-Enterprise users can choose from a list of supported LLM models for Chat. Admins must enable the LLM selection dropdown. Once enabled, they can choose which models will be available for end users in their chat. -->
-
 ## Supported LLM models
 
 Enterprise users get Claude 3 (Opus and Sonnet) as the default LLM models without extra cost. Moreover, Enterprise users can use Claude 3.5 models through Cody Gateway, Anthropic BYOK, AWS Bedrock (limited availability), and GCP Vertex.

--- a/docs/cody/clients/enable-cody-enterprise.mdx
+++ b/docs/cody/clients/enable-cody-enterprise.mdx
@@ -116,9 +116,9 @@ A few considerations to keep in view:
 
 <Callout type="info">You can read and learn more about [Cody's input and output token limits here](/cody/core-concepts/token-limits).</Callout>
 
-## LLM Selection
+<!-- ## LLM Selection
 
-Enterprise users can choose from a list of supported LLM models for Chat. Admins must enable the LLM selection dropdown. Once enabled, they can choose which models will be available for end users in their chat.
+Enterprise users can choose from a list of supported LLM models for Chat. Admins must enable the LLM selection dropdown. Once enabled, they can choose which models will be available for end users in their chat. -->
 
 ## Supported LLM models
 

--- a/docs/cody/clients/feature-reference.mdx
+++ b/docs/cody/clients/feature-reference.mdx
@@ -134,7 +134,6 @@
 | @-file               | ✅           | ✅             | ❌          | ❌       |
 | @-symbol             | ✅           | ❌             | ❌          | ❌       |
 | Admin LLM selection  | ✅           | ✅             | ✅          | ✅       |
-| Users LLM selection  | ✅           | ✅             | ❌          | ❌       |
 
 
 ### Context Selection
@@ -183,8 +182,6 @@
 | Improve variable names         | ❌           | ❌             | ❌          | ✅       |
 | Ollama support (experimental)  | ✅           | ❌             | ❌          | ❌       |
 | Admin LLM selection            | ✅           | ✅             | ✅          | ✅       |
-| Users LLM selection            | ✅           | ✅             | ❌          | ❌       |
-
 
   </Tab>
 </Tabs>

--- a/docs/cody/clients/install-jetbrains.mdx
+++ b/docs/cody/clients/install-jetbrains.mdx
@@ -151,7 +151,7 @@ Like the Edit Code and Generate Unit Test commands, you can generate inline docu
 
 ## Supported LLM models
 
-Users on Cody **Free** and **Pro** can choose from a list of supported LLM models for Chat and Commands. Claude Sonnet 3 is the default LLM model for Cody Free users for Chat and Commands. Users on Cody Free and Pro can choose from a list of supported LLM models for Chat and Commands.
+Users on Cody **Free** and **Pro** can choose from a list of supported LLM models for Chat and Commands. Both Cody Free and Pro users can choose from a list of supported LLM models for Chat and Commands.
 
 <Callout type="info">For Cody Enterprise, admins must enable the LLM selection dropdown. Once enabled, they can choose which models will be available for end users in their chat.</Callout>
 

--- a/docs/cody/clients/install-jetbrains.mdx
+++ b/docs/cody/clients/install-jetbrains.mdx
@@ -161,7 +161,7 @@ Enterprise users get Claude 3 (Opus and Sonnet) as the default LLM models withou
 
 <Callout type="info">For enterprise users on AWS Bedrock: 3.5 Sonnet is unavailable in `us-west-2` but available in `us-east-1`. Check the current model availability on AWS and your customer's instance location before switching. Provisioned throughput via AWS is not supported for 3.5 Sonnet.</Callout>
 
-You also get additional capabilities like BYOLLM (Bring Your Own LLM), supporting Single-Tenant and Self Hosted setups for flexible coding environments. Your site administrator determines the LLM, and cannot be changed within the editor. However, Cody Enterprise users when using Cody Gateway have the ability to [configure custom models](/cody/core-concepts/cody-gateway#configuring-custom-models) Anthropic (like Claude 2.0 and Claude Instant), OpenAI (GPT 3.5 and GPT 4) and Google Gemini 1.5 models (Flash and Pro).
+You also get additional capabilities like BYOLLM (Bring Your Own LLM), supporting Single-Tenant and Self Hosted setups for flexible coding environments. Your site administrator determines the LLM, and cannot be changed within the editor. However, Cody Enterprise users when using Cody Gateway have the ability to [configure custom models](/cody/core-concepts/cody-gateway#configuring-custom-models) Anthropic (like Claude 3 Opus and Claude Haiku), OpenAI (GPT 3.5 Turbo and GPT 4 Turbo) and Google Gemini 1.5 models (Flash and Pro).
 
 <Callout type="note">Read and learn more about the [supported LLMs](/cody/capabilities/supported-models) and [token limits](/cody/core-concepts/token-limits) on Cody Free, Pro and Enterprise.</Callout>
 

--- a/docs/cody/clients/install-jetbrains.mdx
+++ b/docs/cody/clients/install-jetbrains.mdx
@@ -151,7 +151,7 @@ Like the Edit Code and Generate Unit Test commands, you can generate inline docu
 
 ## Supported LLM models
 
-Users on Cody **Free**, **Pro**, and **Enterprise** can choose from a list of supported LLM models for Chat and Commands. Claude Sonnet 3 is the default LLM model for Cody Free users for Chat and Commands. Users on Cody Free and Pro can choose from a list of supported LLM models for Chat and Commands.
+Users on Cody **Free** and **Pro** can choose from a list of supported LLM models for Chat and Commands. Claude Sonnet 3 is the default LLM model for Cody Free users for Chat and Commands. Users on Cody Free and Pro can choose from a list of supported LLM models for Chat and Commands.
 
 <Callout type="info">For Cody Enterprise, admins must enable the LLM selection dropdown. Once enabled, they can choose which models will be available for end users in their chat.</Callout>
 
@@ -162,10 +162,6 @@ Enterprise users get Claude 3 (Opus and Sonnet) as the default LLM models withou
 <Callout type="info">For enterprise users on AWS Bedrock: 3.5 Sonnet is unavailable in `us-west-2` but available in `us-east-1`. Check the current model availability on AWS and your customer's instance location before switching. Provisioned throughput via AWS is not supported for 3.5 Sonnet.</Callout>
 
 You also get additional capabilities like BYOLLM (Bring Your Own LLM), supporting Single-Tenant and Self Hosted setups for flexible coding environments. Your site administrator determines the LLM, and cannot be changed within the editor. However, Cody Enterprise users when using Cody Gateway have the ability to [configure custom models](/cody/core-concepts/cody-gateway#configuring-custom-models) Anthropic (like Claude 2.0 and Claude Instant), OpenAI (GPT 3.5 and GPT 4) and Google Gemini 1.5 models (Flash and Pro).
-
-<Callout type="note">Read more about all the supported LLM models [here](/cody/capabilities/supported-models)</Callout>
-
-<Callout type="note">Read and learn more about the [supported LLMs](/cody/capabilities/supported-models) and [token limits](/cody/core-concepts/token-limits) on Cody Free, Pro and Enterprise.</Callout>
 
 <Callout type="note">Read and learn more about the [supported LLMs](/cody/capabilities/supported-models) and [token limits](/cody/core-concepts/token-limits) on Cody Free, Pro and Enterprise.</Callout>
 

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -313,7 +313,7 @@ Cody also works with Cursor, Gitpod, IDX, and other similar VS Code forks. To ac
 
 Claude Sonnet 3.5 is the default LLM model for inline edits and commands. If you've used Claude 3 Sonnet for inline edit or commands before, remember to manually update the model. The default model change only affects new users.
 
-Users on Cody **Free**, **Pro**, and **Enterprise** can choose from a list of supported LLM models for Chat and Commands. For Cody Enterprise, admins must enable the LLM selection dropdown. Once enabled, they can choose which models will be available for end users in their chat.
+Users on Cody **Free** and **Pro** can choose from a list of supported LLM models for Chat and Commands.
 
 ![LLM-models-for-cody-free](https://storage.googleapis.com/sourcegraph-assets/Docs/LLM-Select-Free.png)
 


### PR DESCRIPTION
We delayed the release of LLM drop-down from ENT customers. We need to remove mentions from the docs.

- https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1720756890186079
