### PR TITLE
Fix typo "unliked" to "unlike"

### DIFF
--- a/docs/admin/auth/index.mdx
+++ b/docs/admin/auth/index.mdx
@@ -213,7 +213,7 @@ You can use the following filters to control how users can create accounts and s
 
   When `false`, sign-up with GitLab will be blocked. In this case, new users can only sign in after an admin creates their account on Sourcegraph. The user account email should match their primary emails on GitLab (which are always verified).
 
-  *If not set, unliked with GitHub, it defaults to `true`, allowing any GitLab user with access to your instance to sign up*.
+  *If not set, unlike with GitHub, it defaults to `true`, allowing any GitLab user with access to your instance to sign up*.
 
 
   ```json


### PR DESCRIPTION
Fixed typo in the following line: If not set, unliked with GitHub, it defaults to true, allowing any GitLab user with access to your instance to sign up.

<!-- Explain the changes introduced in your PR -->

## Pull Request approval

Although pull request approval is not enforced for this repository in order to reduce friction, merging without a review will generate a ticket for the docs team to review your changes. So if possible, have your pull request approved before merging.
