### PR TITLE
Remove Ollama Support from ENT

### DIFF
--- a/docs/cody/clients/feature-reference.mdx
+++ b/docs/cody/clients/feature-reference.mdx
@@ -158,7 +158,6 @@
 | Enable/Disable by language                    | ✅           | ✅             | ❌          | ❌       |
 | Customize autocomplete colors                 | ❌           | ✅             | ✅          | ❌       |
 | Cycle through multiple completion suggestions | ✅           | ✅             | ✅          | ❌       |
-| Ollama support (experimental)                 | ✅           | ❌             | ❌          | ❌       |
 | Admin LLM selection                           | ✅           | ✅             | ✅          | ✅       |
 | OpenCtx context providers (Experimental)      | ✅           | ❌             | ❌          | ❌       |
 
@@ -177,7 +176,6 @@
 | Ask Cody to Fix                | ✅           | ❌             | ❌          | ❌       |
 | Reset chat                     | ✅           | ❌             | ❌          | ❌       |
 | Improve variable names         | ❌           | ❌             | ❌          | ✅       |
-| Ollama support (experimental)  | ✅           | ❌             | ❌          | ❌       |
 | Admin LLM selection            | ✅           | ✅             | ✅          | ✅       |
 
   </Tab>


### PR DESCRIPTION
PR removes buggy info on Ollama support for ENT. It is only supported on PLG tiers.