### PR TITLE
Reduce customer confusion by removing installation links to old releases

### DIFF
--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -16,39 +16,39 @@ See the link to the corresponding release notes for more information on each rel
 
 Currently supported versions of Sourcegraph:
 
-| **Release** | **General Availability Date** | **Supported** | **Install**                                                                   | **Release Notes**                                       |
-|-------------|-------------------------------|---------------|-------------------------------------------------------------------------------|---------------------------------------------------------|
-| 5.5         | July 2024                     | ✅             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.5.1337)  | [Notes](https://sourcegraph.com/docs/CHANGELOG#551337)  |
-| 5.4         | May 2024                      | ✅             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.4.7765)  | [Notes](https://sourcegraph.com/docs/CHANGELOG#547765)  |
-| 5.3         | February 2024                 | ✅             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.3.12303) | [Notes](https://sourcegraph.com/docs/CHANGELOG#5312303) |
-| 5.2         | October 2023                  | ✅             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.2.7)     | [Notes](https://sourcegraph.com/docs/CHANGELOG#527)     |
-| 5.1         | June 2023                     | ✅             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.1.9)     | [Notes](https://sourcegraph.com/docs/CHANGELOG#519)     |
-| 5.0         | March 2023                    | ✅             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.0.6)     | [Notes](https://sourcegraph.com/docs/CHANGELOG#506)     |
-| 4.5         | February 2023                 | ✅             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v4.5.1)     | [Notes](https://sourcegraph.com/docs/CHANGELOG#451)     |
-| 4.4         | January 2023                  | ✅             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v4.4.2)     | [Notes](https://sourcegraph.com/docs/CHANGELOG#442)     |
-| 4.3         | December 2022                 | ✅             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v4.3.0)     | [Notes](https://sourcegraph.com/docs/CHANGELOG#431)     |
-| 4.2         | November 2022                 | ✅             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v4.2.0)     | [Notes](https://sourcegraph.com/docs/CHANGELOG#421)     |
-| 4.1         | October 2022                  | ✅             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v4.1.3)     | [Notes](https://sourcegraph.com/docs/CHANGELOG#413)     |
-| 4.0         | September 2022                | ✅             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v4.0.1)     | [Notes](https://sourcegraph.com/docs/CHANGELOG#401)     |
+| **Release** | **General Availability Date** | **Supported** | **Release Notes**                                       | **Install**                                                                   |
+|-------------|-------------------------------|---------------|---------------------------------------------------------|-------------------------------------------------------------------------------|
+| 5.5         | July 2024                     | ✅             | [Notes](https://sourcegraph.com/docs/CHANGELOG#551337)  | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.5.1337)  |
+| 5.4         | May 2024                      | ✅             | [Notes](https://sourcegraph.com/docs/CHANGELOG#547765)  |                                                                               |
+| 5.3         | February 2024                 | ✅             | [Notes](https://sourcegraph.com/docs/CHANGELOG#5312303) |                                                                               |
+| 5.2         | October 2023                  | ✅             | [Notes](https://sourcegraph.com/docs/CHANGELOG#527)     |                                                                               |
+| 5.1         | June 2023                     | ✅             | [Notes](https://sourcegraph.com/docs/CHANGELOG#519)     |                                                                               |
+| 5.0         | March 2023                    | ✅             | [Notes](https://sourcegraph.com/docs/CHANGELOG#506)     |                                                                               |
+| 4.5         | February 2023                 | ✅             | [Notes](https://sourcegraph.com/docs/CHANGELOG#451)     |                                                                               |
+| 4.4         | January 2023                  | ✅             | [Notes](https://sourcegraph.com/docs/CHANGELOG#442)     |                                                                               |
+| 4.3         | December 2022                 | ✅             | [Notes](https://sourcegraph.com/docs/CHANGELOG#431)     |                                                                               |
+| 4.2         | November 2022                 | ✅             | [Notes](https://sourcegraph.com/docs/CHANGELOG#421)     |                                                                               |
+| 4.1         | October 2022                  | ✅             | [Notes](https://sourcegraph.com/docs/CHANGELOG#413)     |                                                                               |
+| 4.0         | September 2022                | ✅             | [Notes](https://sourcegraph.com/docs/CHANGELOG#401)     |                                                                               |
 
 ## Deprecated Releases
 
 These versions fall outside the release lifecycle and are not supported anymore:
 
-| **Release** | **General Availability Date** | **Supported** | **Install**                                                                | **Release Notes**                                                               |
-|-------------|-------------------------------|---------------|----------------------------------------------------------------------------|---------------------------------------------------------------------------------|
-| 3.43        | August 2022                   | ❌             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v3.43.2) | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3432) |
-| 3.42        | July 2022                     | ❌             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v3.42.2) | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3422) |
-| 3.41        | June 2022                     | ❌             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v3.41.1) | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3422) |
-| 3.40        | May 2022                      | ❌             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v3.40.2) | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3402) |
-| 3.39        | April 2022                    | ❌             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v3.39.1) | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3391) |
-| 3.38        | March 2022                    | ❌             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v3.38.1) | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3391) |
-| 3.37        | February 2022                 | ❌             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v3.37.0) | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3391) |
-| 3.36        | January 2022                  | ❌             | [Install](https://github.com/sourcegraph/sourcegraph/releases/tag/v3.36.3) | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3363) |
-| 3.35        | December 2021                 | ❌             | -                                                                          | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3352) |
-| 3.34        | November 2021                 | ❌             | -                                                                          | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3352) |
-| 3.33        | October 2021                  | ❌             | -                                                                          | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3332) |
-| 3.32        | September 2021                | ❌             | -                                                                          | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3321) |
-| 3.31        | August 2021                   | ❌             | -                                                                          | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3321) |
-| 3.30        | July 2021                     | ❌             | -                                                                          | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3321) |
-| 3.29        | June 2021                     | ❌             | -                                                                          | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3321) |
+| **Release** | **General Availability Date** | **Supported** | **Release Notes**                                                               |
+|-------------|-------------------------------|---------------|---------------------------------------------------------------------------------|
+| 3.43        | August 2022                   | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3432) |
+| 3.42        | July 2022                     | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3422) |
+| 3.41        | June 2022                     | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3422) |
+| 3.40        | May 2022                      | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3402) |
+| 3.39        | April 2022                    | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3391) |
+| 3.38        | March 2022                    | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3391) |
+| 3.37        | February 2022                 | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3391) |
+| 3.36        | January 2022                  | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3363) |
+| 3.35        | December 2021                 | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3352) |
+| 3.34        | November 2021                 | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3352) |
+| 3.33        | October 2021                  | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3332) |
+| 3.32        | September 2021                | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3321) |
+| 3.31        | August 2021                   | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3321) |
+| 3.30        | July 2021                     | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3321) |
+| 3.29        | June 2021                     | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3321) |


### PR DESCRIPTION
Customers get confused about our position on how long they should stay on old versions, or which version they should install, when they see mixed signals in our docs and public handbook. Removing the links to install prior versions helps clarify that the paved path is only to install the latest release.