### PR TITLE
Removes unused `PRECISE_CODE_INTEL_HUNK_CACHE_SIZE` env variable

### DIFF
--- a/docs/code-search/code-navigation/envvars.mdx
+++ b/docs/code-search/code-navigation/envvars.mdx
@@ -8,7 +8,6 @@ The following are variables are read from the `frontend` service to control code
 
 |                       **Name**                        | **Default** |                          **Description**                          |
 | ------------------------------------------------- | ------- | ------------------------------------------------------------- |
-| `PRECISE_CODE_INTEL_HUNK_CACHE_SIZE`                                | `1000`  | The capacity of the git diff hunk cache.                      |
 | `PRECISE_CODE_INTEL_DIAGNOSTICS_COUNT_MIGRATION_BATCH_SIZE`         | `1000`  | The max no. of document records to migrate at a time.  |
 | `PRECISE_CODE_INTEL_DIAGNOSTICS_COUNT_MIGRATION_BATCH_INTERVAL`     | `1s`    | The timeout between processing migration batches.             |
 | `PRECISE_CODE_INTEL_DEFINITIONS_COUNT_MIGRATION_BATCH_SIZE`         | `1000`  | The maximum number of definition records to migrate at once.  |


### PR DESCRIPTION
Removes an environment variable that is no longer used as of https://github.com/sourcegraph/sourcegraph/pull/64027
