### PR TITLE
Remove old versions from version selector drop down

### DIFF
--- a/docs/legacy.mdx
+++ b/docs/legacy.mdx
@@ -5,7 +5,7 @@
 <Accordion title="Sourcegraph 5.X">
 
   - [5.5](https://5.5.sourcegraph.com/)
-  - [5.4](https://5.4.sourcegraph.com/)
+  - [5.4](https://5.4.sourcegraph.com/docs)
   - [5.3](https://5.3.sourcegraph.com/)
   - [5.2](https://5.2.sourcegraph.com/)
   - [5.1](https://docs.sourcegraph.com/@5.1/)

--- a/src/data/versions.ts
+++ b/src/data/versions.ts
@@ -18,14 +18,6 @@ export const versions: VersionI[] = [
         name: 'v5.5',
         url: 'https://5.5.sourcegraph.com/'
     },
-    {
-        name: 'v5.4',
-        url: 'https://5.4.sourcegraph.com/docs'
-    },
-    {
-        name: 'v5.3',
-        url: 'https://5.3.sourcegraph.com/docs'
-    },
 ];
 
 export const latestVersion = versions[0];


### PR DESCRIPTION
The PR removes old versions from the version selector in our docs.