### PR TITLE
Abstract older versions docs rerouting

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -23,45 +23,45 @@ const nextConfig = {
 				permanent: false
 			},
 			// // Redirect for docs for version 5.5 hosted at https://5.5.sourcegraph.com/
-			// {
-			// 	source: '/docs/v/5.5/:slug*',
-			// 	destination: '/docs/@5.5/:slug*',
-			// 	permanent: false,
-			// 	basePath: false
-			// },
-			// {
-			// 	source: '/docs/@5.5/:slug*',
-			// 	destination: 'https://5.5.sourcegraph.com/:slug*',
-			// 	permanent: false,
-			// 	basePath: false
-			// },
+			{
+				source: '/docs/v/:version((?!config.DOCS_LATEST_VERSION).*)/:slug*',
+				destination: '/docs/@:version/:slug*',
+				permanent: false,
+				basePath: false
+			},
+			{
+				source: '/docs/@:version/:slug*',
+				destination: 'https://:version.sourcegraph.com/:slug*',
+				permanent: false,
+				basePath: false
+			},
 			// Redirect for docs for version 5.3 hosted at https://5.3.sourcegraph.com/
-			{
-				source: '/docs/v/5.3/:slug*',
-				destination: '/docs/@5.3/:slug*',
-				permanent: false,
-				basePath: false
-			},
-			{
-				source: '/docs/@5.3/:slug*',
-				destination: 'https://5.3.sourcegraph.com/:slug*',
-				permanent: false,
-				basePath: false
-			},
+			// {
+			// 	source: '/docs/v/5.3/:slug*',
+			// 	destination: '/docs/@5.3/:slug*',
+			// 	permanent: false,
+			// 	basePath: false
+			// },
+			// {
+			// 	source: '/docs/@5.3/:slug*',
+			// 	destination: 'https://5.3.sourcegraph.com/:slug*',
+			// 	permanent: false,
+			// 	basePath: false
+			// },
 
-			// Redirect for docs for version 5.2 hosted at https://5.2.sourcegraph.com/
-			{
-				source: '/docs/v/5.2/:slug*',
-				destination: '/docs/@5.2/:slug*',
-				permanent: false,
-				basePath: false
-			},
-			{
-				source: '/docs/@5.2/:slug*',
-				destination: 'https://5.2.sourcegraph.com/:slug*',
-				permanent: false,
-				basePath: false
-			}
+			// // Redirect for docs for version 5.2 hosted at https://5.2.sourcegraph.com/
+			// {
+			// 	source: '/docs/v/5.2/:slug*',
+			// 	destination: '/docs/@5.2/:slug*',
+			// 	permanent: false,
+			// 	basePath: false
+			// },
+			// {
+			// 	source: '/docs/@5.2/:slug*',
+			// 	destination: 'https://5.2.sourcegraph.com/:slug*',
+			// 	permanent: false,
+			// 	basePath: false
+			// }
 		];
 	}
 };

--- a/next.config.js
+++ b/next.config.js
@@ -22,7 +22,7 @@ const nextConfig = {
 				destination: '/:slug*',
 				permanent: false
 			},
-			// // Redirect for docs for version 5.5 hosted at https://5.5.sourcegraph.com/
+			// // Redirect for docs older than latest version e.g. https://x.x.sourcegraph.com/
 			{
 				source: '/docs/v/:version((?!config.DOCS_LATEST_VERSION).*)/:slug*',
 				destination: '/docs/@:version/:slug*',
@@ -35,33 +35,6 @@ const nextConfig = {
 				permanent: false,
 				basePath: false
 			},
-			// Redirect for docs for version 5.3 hosted at https://5.3.sourcegraph.com/
-			// {
-			// 	source: '/docs/v/5.3/:slug*',
-			// 	destination: '/docs/@5.3/:slug*',
-			// 	permanent: false,
-			// 	basePath: false
-			// },
-			// {
-			// 	source: '/docs/@5.3/:slug*',
-			// 	destination: 'https://5.3.sourcegraph.com/:slug*',
-			// 	permanent: false,
-			// 	basePath: false
-			// },
-
-			// // Redirect for docs for version 5.2 hosted at https://5.2.sourcegraph.com/
-			// {
-			// 	source: '/docs/v/5.2/:slug*',
-			// 	destination: '/docs/@5.2/:slug*',
-			// 	permanent: false,
-			// 	basePath: false
-			// },
-			// {
-			// 	source: '/docs/@5.2/:slug*',
-			// 	destination: 'https://5.2.sourcegraph.com/:slug*',
-			// 	permanent: false,
-			// 	basePath: false
-			// }
 		];
 	}
 };


### PR DESCRIPTION
Older versions of the docs get rerouted to the site in the style of `https://${MAJOR}.${MINOR}.sourcegraph.com/docs`, for which we use the NextJS built-in redirect. This PR abstracts all older versions (those other than the NextJS-hydrated `config.DOCS_LATEST_VERSION`, preventing versions previously unlisted from being excluded from the pass-through (and resulting in broken docs links on our site).

## Testing

Run locally and tested with the various `source` permutation values. 

