### PR TITLE
docs(batches): drop github apps exclusion

### DIFF
--- a/docs/batch-changes/configuring-credentials.mdx
+++ b/docs/batch-changes/configuring-credentials.mdx
@@ -107,7 +107,7 @@ The `workflow` scope is technically only required if your batch changes modify f
 
 When working with organizations that have SAML SSO (Single Sign On) enabled, configuring credentials requires an additional step that [involves white-listing the token for use in that organization](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on).
 
-<Callout type="info">At present, only classic personal access tokens (PATs) are supported. Alternative token types like OAuth access tokens (e.g., OAuth apps), installation access tokens (e.g., GitHub apps), and fine-grained personal access tokens (PATv2) are not supported.</Callout>
+<Callout type="info">At present, only classic personal access tokens (PATs) are supported. Alternative token types like OAuth access tokens (e.g., OAuth apps), and fine-grained personal access tokens (PATv2) are not supported.</Callout>
 
 ### GitHub Enterprise
 
@@ -129,7 +129,7 @@ When working with organizations that have SAML SSO (Single Sign On) enabled, con
 
 <Callout type="warning">Currently, for customers on an instance of GitHub Enterprise Cloud that uses [SSH certificate authorities](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-git-access-to-your-organizations-repositories/about-ssh-certificate-authorities) and requires SSH certificates to authenticate, we are unable to provide a means of authenticating Batch Changes to your code host.</Callout>
 
-<Callout type="info">At present, only classic personal access tokens (PATs) are supported. Alternative token types like OAuth access tokens (e.g. OAuth apps), installation access tokens (e.g., GitHub apps), and fine-grained personal access tokens (PATv2) are not supported.</Callout>
+<Callout type="info">At present, only classic personal access tokens (PATs) are supported. Alternative token types like OAuth access tokens (e.g. OAuth apps), and fine-grained personal access tokens (PATv2) are not supported.</Callout>
 
 ### GitLab
 


### PR DESCRIPTION
We now support github apps and can drop the warning that excludes them.

## Pull Request approval

Although pull request approval is not enforced for this repository in order to reduce friction, merging without a review will generate a ticket for the docs team to review your changes. So if possible, have your pull request approved before merging.