### PR TITLE
Refactor our feature parity reference for Cody clients

### DIFF
--- a/docs/cody/clients/feature-reference.mdx
+++ b/docs/cody/clients/feature-reference.mdx
@@ -17,7 +17,7 @@
 | @-file                                   | ✅           | ✅             | ❌          | ✅                    |
 | @-symbol                                 | ✅           | ❌             | ❌          | ✅                    |
 | Ollama support (experimental)            | ✅           | ✅             | ❌          | ❌                    |
-| LLM Selection                            | ✅           | ✅             | ❌          | ❌                    |
+| LLM Selection                            | ✅           | ✅             | ❌          | ✅                    |
 | **Context Selection**                    |             |               |            |                      |
 | Single-repo context                      | ✅           | ✅             | ✅          | ✅                    |
 | Multi-repo context                       | ❌           | ❌             | ❌          | ✅ (public code only) |
@@ -52,7 +52,7 @@
 | Show context files                       | ✅           | ✅             | ✅          | ✅       |
 | @-file                                   | ✅           | ✅             | ❌          | ✅       |
 | @-symbol                                 | ✅           | ❌             | ❌          | ✅       |
-| LLM selection                            | ✅           | ✅             | ❌          | ❌       |
+| LLM selection                            | ✅           | ✅             | ❌          | ✅       |
 | Ollama support (experimental)            | ✅           | ✅             | ❌          | ❌       |
 | **Context Selection**                    |             |               |            |         |
 | Single-repo context                      | ✅           | ✅             | ✅          | ✅       |
@@ -100,7 +100,7 @@
 | Access to prompts and prompt library | ✅           | ❌             | ❌          | ✅       |
 | Custom commands                      | ✅           | ❌             | ❌          | ❌       |
 | Edit code                            | ✅           | ✅             | ❌          | ❌       |
-| Generate unit test                   | ❌           | ❌             | ✅          | ✅       |
+| Generate unit test                   | ❌           | ❌             | ✅          | ❌       |
 | Ask Cody to Fix                      | ✅           | ✅             | ❌          | ❌       |
 
 

--- a/docs/cody/clients/feature-reference.mdx
+++ b/docs/cody/clients/feature-reference.mdx
@@ -12,11 +12,10 @@
 | Chat with Cody                           | ✅           | ✅             | ✅          | ✅                    |
 | Chat history                             | ✅           | ✅             | ❌          | ✅                    |
 | Clear chat history                       | ✅           | ✅             | ❌          | ✅                    |
-| Stop chat generating                     | ✅           | ✅             | ❌          | ✅                    |
 | Edit sent messages                       | ✅           | ❌             | ❌          | ✅                    |
 | Show context files                       | ✅           | ✅             | ✅          | ✅                    |
-| @-file                                   | ✅           | ✅             | ❌          | ❌                    |
-| @-symbol                                 | ✅           | ❌             | ❌          | ❌                    |
+| @-file                                   | ✅           | ✅             | ❌          | ✅                    |
+| @-symbol                                 | ✅           | ❌             | ❌          | ✅                    |
 | Ollama support (experimental)            | ✅           | ✅             | ❌          | ❌                    |
 | LLM Selection                            | ✅           | ✅             | ❌          | ❌                    |
 | **Context Selection**                    |             |               |            |                      |
@@ -24,29 +23,20 @@
 | Multi-repo context                       | ❌           | ❌             | ❌          | ✅ (public code only) |
 | Local context                            | ✅           | ✅             | ❌          | ❌                    |
 | OpenCtx context providers (experimental) | ✅           | ❌             | ❌          | ❌                    |
+| **Prompts and Commands**                 |             |               |            |                      |
 | Access to prompts and Prompt library     | ✅           | ❌             | ❌          | ✅                    |
+| Custom commands                          | ✅           | ❌             | ❌          | ❌                    |
+| Edit code                                | ✅           | ✅             | ❌          | ❌                    |
+| Generate unit test                       | ❌           | ❌             | ✅          | ❌                    |
+| Ask Cody to Fix                          | ✅           | ✅             | ❌          | ❌                    |
 
 ## Code Autocomplete
 
-|                  **Feature**                  | **VS Code** | **JetBrains** | **Neovim** | **Web** |
-| --------------------------------------------- | ----------- | ------------- | ---------- | ------- |
-| Single-line autocompletion                    | ✅           | ✅             | ✅          | ❌       |
-| Single-line, multi-part autocompletion        | ✅           | ✅             | ✅          | ❌       |
-| Multi-line, inline autocompletion             | ✅           | ✅             | ✅          | ❌       |
-| Dynamic multi-line autocompletion             | ✅           | ✅             | ❌          | ❌       |
-| Enable/Disable by language                    | ✅           | ✅             | ❌          | ❌       |
-| Customize autocomplete colors                 | ❌           | ✅             | ✅          | ❌       |
-| Cycle through multiple completion suggestions | ✅           | ✅             | ✅          | ❌       |
-| Ollama support (experimental)                 | ✅           | ❌             | ❌          | ❌       |
-
-## Commands
-
-|    **Feature**     | **VS Code** | **JetBrains** | **Neovim** | **Web** |
-| ------------------ | ----------- | ------------- | ---------- | ------- |
-| Custom commands    | ✅           | ❌             | ❌          | ❌       |
-| Edit code          | ✅           | ✅             | ❌          | ❌       |
-| Generate unit test | ❌           | ❌             | ✅          | ✅       |
-| Ask Cody to Fix    | ✅           | ❌             | ❌          | ❌       |
+|                  **Feature**                  | **VS Code** | **JetBrains** | **Neovim** |
+| --------------------------------------------- | ----------- | ------------- | ---------- |
+| Single and multi-line autocompletion          | ✅           | ✅             | ✅          |
+| Cycle through multiple completion suggestions | ✅           | ✅             | ✅          |
+| Ollama support (experimental)                 | ✅           | ❌             | ❌          |
 
   </Tab>
   <Tab title="Pro">
@@ -58,48 +48,31 @@
 | Chat with Cody                           | ✅           | ✅             | ✅          | ✅       |
 | Chat history                             | ✅           | ✅             | ❌          | ✅       |
 | Clear chat history                       | ✅           | ✅             | ❌          | ✅       |
-| Stop chat generating                     | ✅           | ✅             | ❌          | ✅       |
 | Edit sent messages                       | ✅           | ❌             | ❌          | ✅       |
 | Show context files                       | ✅           | ✅             | ✅          | ✅       |
-| @-file                                   | ✅           | ✅             | ❌          | ❌       |
-| @-symbol                                 | ✅           | ❌             | ❌          | ❌       |
+| @-file                                   | ✅           | ✅             | ❌          | ✅       |
+| @-symbol                                 | ✅           | ❌             | ❌          | ✅       |
 | LLM selection                            | ✅           | ✅             | ❌          | ❌       |
 | Ollama support (experimental)            | ✅           | ✅             | ❌          | ❌       |
+| **Context Selection**                    |             |               |            |         |
 | Single-repo context                      | ✅           | ✅             | ✅          | ✅       |
 | Multi-repo context                       | ❌           | ❌             | ❌          | ❌       |
 | Local context                            | ✅           | ✅             | ❌          | ❌       |
 | OpenCtx context providers (experimental) | ✅           | ❌             | ❌          | ❌       |
+| **Prompts and Commands**                 |             |               |            |         |
 | Access to prompts and prompt library     | ✅           | ❌             | ❌          | ✅       |
-
+| Custom commands                          | ✅           | ❌             | ❌          | ❌       |
+| Edit code                                | ✅           | ✅             | ❌          | ❌       |
+| Generate unit test                       | ❌           | ❌             | ✅          | ❌       |
+| Ask Cody to Fix                          | ✅           | ✅             | ❌          | ❌       |
 
 ## Code Autocomplete
 
-|                  **Feature**                  | **VS Code** | **JetBrains** | **Neovim** | **Web** |
-| --------------------------------------------- | ----------- | ------------- | ---------- | ------- |
-| Single-line autocompletion                    | ✅           | ✅             | ✅          | ❌       |
-| Single-line, multi-part autocompletion        | ✅           | ✅             | ✅          | ❌       |
-| Multi-line, inline autocompletion             | ✅           | ✅             | ✅          | ❌       |
-| Dynamic multi-line autocompletion             | ✅           | ✅             | ❌          | ❌       |
-| Enable/Disable by language                    | ✅           | ✅             | ❌          | ❌       |
-| Customize autocomplete colors                 | ❌           | ✅             | ✅          | ❌       |
-| Cycle through multiple completion suggestions | ✅           | ✅             | ✅          | ❌       |
-| Ollama support (experimental)                 | ✅           | ❌             | ❌          | ❌       |
-
-## Commands
-
-|          **Feature**           | **VS Code** | **JetBrains** | **Neovim** | **Web** |
-| ------------------------------ | ----------- | ------------- | ---------- | ------- |
-| Custom commands                | ✅           | ❌             | ❌          | ❌       |
-| Edit code                      | ✅           | ✅             | ❌          | ❌       |
-| Generate docstring             | ✅           | ✅             | ✅          | ✅       |
-| Generate unit test             | ❌           | ❌             | ✅          | ✅       |
-| Generate unit test v2 (inline) | ✅           | ✅             | ❌          | ❌       |
-| Explain code                   | ✅           | ✅             | ✅          | ✅       |
-| Smell code                     | ✅           | ✅             | ✅          | ✅       |
-| Ask Cody to Fix                | ✅           | ❌             | ❌          | ❌       |
-| Reset chat                     | ✅           | ❌             | ❌          | ❌       |
-| Improve variable names         | ❌           | ❌             | ❌          | ✅       |
-| Ollama support (experimental)  | ✅           | ✅             | ❌          | ❌       |
+|                  **Feature**                  | **VS Code** | **JetBrains** | **Neovim** |
+| --------------------------------------------- | ----------- | ------------- | ---------- |
+| Single and multi-line autocompletion          | ✅           | ✅             | ✅          |
+| Cycle through multiple completion suggestions | ✅           | ✅             | ✅          |
+| Ollama support (experimental)                 | ✅           | ❌             | ❌          |
 
   </Tab>
     <Tab title="Enterprise">
@@ -111,51 +84,34 @@
 | Chat with Cody                       | ✅           | ✅             | ✅          | ✅       |
 | Chat history                         | ✅           | ✅             | ❌          | ✅       |
 | Clear chat history                   | ✅           | ✅             | ❌          | ✅       |
-| Stop chat generating                 | ✅           | ✅             | ❌          | ✅       |
 | Edit sent messages                   | ✅           | ❌             | ❌          | ✅       |
 | Show context files                   | ✅           | ✅             | ✅          | ✅       |
 | @-file                               | ✅           | ✅             | ❌          | ❌       |
 | @-symbol                             | ✅           | ❌             | ❌          | ❌       |
 | Admin LLM selection                  | ✅           | ✅             | ✅          | ✅       |
+| **Context Selection**                |             |               |            |         |
 | Single-repo context                  | ✅           | ✅             | ✅          | ✅       |
 | Multi-repo context                   | ✅           | ✅             | ❌          | ✅       |
 | Local context                        | ✅           | ✅             | ❌          | ❌       |
 | Embeddings                           | ❌           | ❌             | ❌          | ❌       |
 | Guardrails                           | ✅           | ✅             | ❌          | ✅       |
 | Repo-based Cody Context Filters      | ✅           | ✅             | ❌          | ✅       |
+| **Prompts and Commands**             |             |               |            |         |
 | Access to prompts and prompt library | ✅           | ❌             | ❌          | ✅       |
+| Custom commands                      | ✅           | ❌             | ❌          | ❌       |
+| Edit code                            | ✅           | ✅             | ❌          | ❌       |
+| Generate unit test                   | ❌           | ❌             | ✅          | ✅       |
+| Ask Cody to Fix                      | ✅           | ✅             | ❌          | ❌       |
 
 
 ## Code Autocomplete
 
-|                  **Feature**                  | **VS Code** | **JetBrains** | **Neovim** | **Web** |
-| --------------------------------------------- | ----------- | ------------- | ---------- | ------- |
-| Single-line autocompletion                    | ✅           | ✅             | ✅          | ❌       |
-| Single-line, multi-part autocompletion        | ✅           | ✅             | ✅          | ❌       |
-| Multi-line, inline autocompletion             | ✅           | ✅             | ✅          | ❌       |
-| Dynamic multi-line autocompletion             | ✅           | ✅             | ❌          | ❌       |
-| Enable/Disable by language                    | ✅           | ✅             | ❌          | ❌       |
-| Customize autocomplete colors                 | ❌           | ✅             | ✅          | ❌       |
-| Cycle through multiple completion suggestions | ✅           | ✅             | ✅          | ❌       |
-| Admin LLM selection                           | ✅           | ✅             | ✅          | ✅       |
-| OpenCtx context providers (Experimental)      | ✅           | ❌             | ❌          | ❌       |
-
-
-## Commands
-
-|          **Feature**           | **VS Code** | **JetBrains** | **Neovim** | **Web** |
-| ------------------------------ | ----------- | ------------- | ---------- | ------- |
-| Custom commands                | ✅           | ❌             | ❌          | ❌       |
-| Edit code                      | ✅           | ❌             | ❌          | ❌       |
-| Generate docstring             | ✅           | ✅             | ✅          | ✅       |
-| Generate unit test             | ❌           | ❌             | ✅          | ✅       |
-| Generate unit test v2 (inline) | ✅           | ✅             | ❌          | ❌       |
-| Explain code                   | ✅           | ✅             | ✅          | ✅       |
-| Smell code                     | ✅           | ✅             | ✅          | ✅       |
-| Ask Cody to Fix                | ✅           | ❌             | ❌          | ❌       |
-| Reset chat                     | ✅           | ❌             | ❌          | ❌       |
-| Improve variable names         | ❌           | ❌             | ❌          | ✅       |
-| Admin LLM selection            | ✅           | ✅             | ✅          | ✅       |
+|                  **Feature**                  | **VS Code** | **JetBrains** | **Neovim** |
+| --------------------------------------------- | ----------- | ------------- | ---------- |
+| Single and multi line autocompletion          | ✅           | ✅             | ✅          |
+| Cycle through multiple completion suggestions | ✅           | ✅             | ✅          |
+| Admin LLM selection                           | ✅           | ✅             | ✅          |
+| OpenCtx context providers (experimental)      | ✅           | ❌             | ❌          |
 
   </Tab>
 </Tabs>

--- a/docs/cody/clients/feature-reference.mdx
+++ b/docs/cody/clients/feature-reference.mdx
@@ -19,7 +19,6 @@
 | @-symbol                                 | ✅           | ❌             | ❌          | ❌                    |
 | Ollama support (experimental)            | ✅           | ✅             | ❌          | ❌                    |
 | LLM Selection                            | ✅           | ✅             | ❌          | ❌                    |
-| ---------------------------------------- | ----------- | ------------- | ---------- | -------------------- |
 | **Context Selection**                    |             |               |            |                      |
 | Single-repo context                      | ✅           | ✅             | ✅          | ✅                    |
 | Multi-repo context                       | ❌           | ❌             | ❌          | ✅ (public code only) |

--- a/docs/cody/clients/feature-reference.mdx
+++ b/docs/cody/clients/feature-reference.mdx
@@ -2,34 +2,30 @@
 
 <p className="subtitle">This document compares Cody's features and capabilities across different clients and platforms like VS Code, JetBrains, Neovim, and Sourcegraph.com (Web UI). The comparison is based on Cody Free, Pro, and Enterprise users.</p>
 
-
 <Tabs>
   <Tab title="Free">
 
 ## Chat
 
-|          **Feature**          | **VS Code** | **JetBrains** | **Neovim** | **Web** |
-| ----------------------------- | ----------- | ------------- | ---------- | ------- |
-| Chat with Cody                | ✅           | ✅             | ✅          | ✅       |
-| Chat history                  | ✅           | ✅             | ❌          | ✅       |
-| Clear chat history            | ✅           | ✅             | ❌          | ✅       |
-| Stop chat generating          | ✅           | ✅             | ❌          | ✅       |
-| Edit sent messages            | ✅           | ❌             | ❌          | ✅       |
-| Show context files            | ✅           | ✅             | ✅          | ✅       |
-| @-file                        | ✅           | ✅             | ❌          | ❌       |
-| @-symbol                      | ✅           | ❌             | ❌          | ❌       |
-| Ollama support (experimental) | ✅           | ✅             | ❌          | ❌       |
-| LLM Selection                 | ✅           | ✅             | ❌          | ❌       |
-
-### Context Selection
-
 |               **Feature**                | **VS Code** | **JetBrains** | **Neovim** |       **Web**        |
 | ---------------------------------------- | ----------- | ------------- | ---------- | -------------------- |
+| Chat with Cody                           | ✅           | ✅             | ✅          | ✅                    |
+| Chat history                             | ✅           | ✅             | ❌          | ✅                    |
+| Clear chat history                       | ✅           | ✅             | ❌          | ✅                    |
+| Stop chat generating                     | ✅           | ✅             | ❌          | ✅                    |
+| Edit sent messages                       | ✅           | ❌             | ❌          | ✅                    |
+| Show context files                       | ✅           | ✅             | ✅          | ✅                    |
+| @-file                                   | ✅           | ✅             | ❌          | ❌                    |
+| @-symbol                                 | ✅           | ❌             | ❌          | ❌                    |
+| Ollama support (experimental)            | ✅           | ✅             | ❌          | ❌                    |
+| LLM Selection                            | ✅           | ✅             | ❌          | ❌                    |
+| ---------------------------------------- | ----------- | ------------- | ---------- | -------------------- |
+| **Context Selection**                    |             |               |            |                      |
 | Single-repo context                      | ✅           | ✅             | ✅          | ✅                    |
 | Multi-repo context                       | ❌           | ❌             | ❌          | ✅ (public code only) |
 | Local context                            | ✅           | ✅             | ❌          | ❌                    |
 | OpenCtx context providers (experimental) | ✅           | ❌             | ❌          | ❌                    |
-
+| Access to prompts and Prompt library     | ✅           | ❌             | ❌          | ✅                    |
 
 ## Code Autocomplete
 
@@ -46,52 +42,36 @@
 
 ## Commands
 
-|          **Feature**           | **VS Code** | **JetBrains** | **Neovim** | **Web** |
-| ------------------------------ | ----------- | ------------- | ---------- | ------- |
-| Custom commands                | ✅           | ❌             | ❌          | ❌       |
-| Edit code                      | ✅           | ✅             | ❌          | ❌       |
-| Generate docstring             | ✅           | ✅             | ✅          | ✅       |
-| Generate unit test             | ❌           | ❌             | ✅          | ✅       |
-| Generate unit test v2 (inline) | ✅           | ✅             | ❌          | ❌       |
-| Explain code                   | ✅           | ✅             | ✅          | ✅       |
-| Smell code                     | ✅           | ✅             | ✅          | ✅       |
-| Ask Cody to Fix                | ✅           | ❌             | ❌          | ❌       |
-| Reset chat                     | ✅           | ❌             | ❌          | ❌       |
-| Improve variable names         | ❌           | ❌             | ❌          | ✅       |
-| Ollama support (experimental)  | ✅           | ✅             | ❌          | ❌       |
-
-## Prompts and Prompt Library
-
-|             **Feature**              | **VS Code** | **JetBrains** | **Neovim** | **Web** |
-| ------------------------------------ | ----------- | ------------- | ---------- | ------- |
-| Access to prompts and prompt library | ✅           | ❌             | ❌          | ✅       |
+|    **Feature**     | **VS Code** | **JetBrains** | **Neovim** | **Web** |
+| ------------------ | ----------- | ------------- | ---------- | ------- |
+| Custom commands    | ✅           | ❌             | ❌          | ❌       |
+| Edit code          | ✅           | ✅             | ❌          | ❌       |
+| Generate unit test | ❌           | ❌             | ✅          | ✅       |
+| Ask Cody to Fix    | ✅           | ❌             | ❌          | ❌       |
 
   </Tab>
   <Tab title="Pro">
 
 ## Chat
 
-|          **Feature**          | **VS Code** | **JetBrains** | **Neovim** | **Web** |
-| ----------------------------- | ----------- | ------------- | ---------- | ------- |
-| Chat with Cody                | ✅           | ✅             | ✅          | ✅       |
-| Chat history                  | ✅           | ✅             | ❌          | ✅       |
-| Clear chat history            | ✅           | ✅             | ❌          | ✅       |
-| Stop chat generating          | ✅           | ✅             | ❌          | ✅       |
-| Edit sent messages            | ✅           | ❌             | ❌          | ✅       |
-| Show context files            | ✅           | ✅             | ✅          | ✅       |
-| @-file                        | ✅           | ✅             | ❌          | ❌       |
-| @-symbol                      | ✅           | ❌             | ❌          | ❌       |
-| LLM selection                 | ✅           | ✅             | ❌          | ❌       |
-| Ollama support (experimental) | ✅           | ✅             | ❌          | ❌       |
-
-### Context Selection
-
 |               **Feature**                | **VS Code** | **JetBrains** | **Neovim** | **Web** |
 | ---------------------------------------- | ----------- | ------------- | ---------- | ------- |
+| Chat with Cody                           | ✅           | ✅             | ✅          | ✅       |
+| Chat history                             | ✅           | ✅             | ❌          | ✅       |
+| Clear chat history                       | ✅           | ✅             | ❌          | ✅       |
+| Stop chat generating                     | ✅           | ✅             | ❌          | ✅       |
+| Edit sent messages                       | ✅           | ❌             | ❌          | ✅       |
+| Show context files                       | ✅           | ✅             | ✅          | ✅       |
+| @-file                                   | ✅           | ✅             | ❌          | ❌       |
+| @-symbol                                 | ✅           | ❌             | ❌          | ❌       |
+| LLM selection                            | ✅           | ✅             | ❌          | ❌       |
+| Ollama support (experimental)            | ✅           | ✅             | ❌          | ❌       |
 | Single-repo context                      | ✅           | ✅             | ✅          | ✅       |
 | Multi-repo context                       | ❌           | ❌             | ❌          | ❌       |
 | Local context                            | ✅           | ✅             | ❌          | ❌       |
 | OpenCtx context providers (experimental) | ✅           | ❌             | ❌          | ❌       |
+| Access to prompts and prompt library     | ✅           | ❌             | ❌          | ✅       |
+
 
 ## Code Autocomplete
 
@@ -122,41 +102,29 @@
 | Improve variable names         | ❌           | ❌             | ❌          | ✅       |
 | Ollama support (experimental)  | ✅           | ✅             | ❌          | ❌       |
 
-## Prompts and Prompt Library
-
-|             **Feature**              | **VS Code** | **JetBrains** | **Neovim** | **Web** |
-| ------------------------------------ | ----------- | ------------- | ---------- | ------- |
-| Access to prompts and prompt library | ✅           | ❌             | ❌          | ✅       |
-
   </Tab>
     <Tab title="Enterprise">
 
 ## Chat
 
-|     **Feature**      | **VS Code** | **JetBrains** | **Neovim** | **Web** |
-| -------------------- | ----------- | ------------- | ---------- | ------- |
-| Chat with Cody       | ✅           | ✅             | ✅          | ✅       |
-| Chat history         | ✅           | ✅             | ❌          | ✅       |
-| Clear chat history   | ✅           | ✅             | ❌          | ✅       |
-| Stop chat generating | ✅           | ✅             | ❌          | ✅       |
-| Edit sent messages   | ✅           | ❌             | ❌          | ✅       |
-| Show context files   | ✅           | ✅             | ✅          | ✅       |
-| @-file               | ✅           | ✅             | ❌          | ❌       |
-| @-symbol             | ✅           | ❌             | ❌          | ❌       |
-| Admin LLM selection  | ✅           | ✅             | ✅          | ✅       |
-
-
-### Context Selection
-
-|           **Feature**           | **VS Code** | **JetBrains** | **Neovim** | **Web** |
-| ------------------------------- | ----------- | ------------- | ---------- | ------- |
-| Single-repo context             | ✅           | ✅             | ✅          | ✅       |
-| Multi-repo context              | ✅           | ✅             | ❌          | ✅       |
-| Local context                   | ✅           | ✅             | ❌          | ❌       |
-| Embeddings                      | ❌           | ❌             | ❌          | ❌       |
-| Guardrails                      | ✅           | ✅             | ❌          | ✅       |
-| Repo-based Cody Context Filters | ✅           | ✅             | ❌          | ✅       |
-
+|             **Feature**              | **VS Code** | **JetBrains** | **Neovim** | **Web** |
+| ------------------------------------ | ----------- | ------------- | ---------- | ------- |
+| Chat with Cody                       | ✅           | ✅             | ✅          | ✅       |
+| Chat history                         | ✅           | ✅             | ❌          | ✅       |
+| Clear chat history                   | ✅           | ✅             | ❌          | ✅       |
+| Stop chat generating                 | ✅           | ✅             | ❌          | ✅       |
+| Edit sent messages                   | ✅           | ❌             | ❌          | ✅       |
+| Show context files                   | ✅           | ✅             | ✅          | ✅       |
+| @-file                               | ✅           | ✅             | ❌          | ❌       |
+| @-symbol                             | ✅           | ❌             | ❌          | ❌       |
+| Admin LLM selection                  | ✅           | ✅             | ✅          | ✅       |
+| Single-repo context                  | ✅           | ✅             | ✅          | ✅       |
+| Multi-repo context                   | ✅           | ✅             | ❌          | ✅       |
+| Local context                        | ✅           | ✅             | ❌          | ❌       |
+| Embeddings                           | ❌           | ❌             | ❌          | ❌       |
+| Guardrails                           | ✅           | ✅             | ❌          | ✅       |
+| Repo-based Cody Context Filters      | ✅           | ✅             | ❌          | ✅       |
+| Access to prompts and prompt library | ✅           | ❌             | ❌          | ✅       |
 
 
 ## Code Autocomplete
@@ -189,12 +157,6 @@
 | Reset chat                     | ✅           | ❌             | ❌          | ❌       |
 | Improve variable names         | ❌           | ❌             | ❌          | ✅       |
 | Admin LLM selection            | ✅           | ✅             | ✅          | ✅       |
-
-## Prompts and Prompt Library
-
-|             **Feature**              | **VS Code** | **JetBrains** | **Neovim** | **Web** |
-| ------------------------------------ | ----------- | ------------- | ---------- | ------- |
-| Access to prompts and prompt library | ✅           | ❌             | ❌          | ✅       |
 
   </Tab>
 </Tabs>

--- a/docs/cody/clients/feature-reference.mdx
+++ b/docs/cody/clients/feature-reference.mdx
@@ -7,111 +7,111 @@
 
 ## Chat
 
-|               **Feature**                | **VS Code** | **JetBrains** | **Neovim** |       **Web**        |
-| ---------------------------------------- | ----------- | ------------- | ---------- | -------------------- |
-| Chat with Cody                           | ✅           | ✅             | ✅          | ✅                    |
-| Chat history                             | ✅           | ✅             | ❌          | ✅                    |
-| Clear chat history                       | ✅           | ✅             | ❌          | ✅                    |
-| Edit sent messages                       | ✅           | ❌             | ❌          | ✅                    |
-| Show context files                       | ✅           | ✅             | ✅          | ✅                    |
-| @-file                                   | ✅           | ✅             | ❌          | ✅                    |
-| @-symbol                                 | ✅           | ❌             | ❌          | ✅                    |
-| Ollama support (experimental)            | ✅           | ✅             | ❌          | ❌                    |
-| LLM Selection                            | ✅           | ✅             | ❌          | ✅                    |
-| **Context Selection**                    |             |               |            |                      |
-| Single-repo context                      | ✅           | ✅             | ✅          | ✅                    |
-| Multi-repo context                       | ❌           | ❌             | ❌          | ✅ (public code only) |
-| Local context                            | ✅           | ✅             | ❌          | ❌                    |
-| OpenCtx context providers (experimental) | ✅           | ❌             | ❌          | ❌                    |
-| **Prompts and Commands**                 |             |               |            |                      |
-| Access to prompts and Prompt library     | ✅           | ❌             | ❌          | ✅                    |
-| Custom commands                          | ✅           | ❌             | ❌          | ❌                    |
-| Edit code                                | ✅           | ✅             | ❌          | ❌                    |
-| Generate unit test                       | ❌           | ❌             | ✅          | ❌                    |
-| Ask Cody to Fix                          | ✅           | ✅             | ❌          | ❌                    |
+|               **Feature**                | **VS Code** | **JetBrains** |       **Web**        |
+| ---------------------------------------- | ----------- | ------------- | -------------------- |
+| Chat with Cody                           | ✅           | ✅             | ✅                    |
+| Chat history                             | ✅           | ✅             | ✅                    |
+| Clear chat history                       | ✅           | ✅             | ✅                    |
+| Edit sent messages                       | ✅           | ❌             | ✅                    |
+| Show context files                       | ✅           | ✅             | ✅                    |
+| @-file                                   | ✅           | ✅             | ✅                    |
+| @-symbol                                 | ✅           | ❌             | ✅                    |
+| Ollama support (experimental)            | ✅           | ✅             | ❌                    |
+| LLM Selection                            | ✅           | ✅             | ✅                    |
+| **Context Selection**                    |             |               |                      |
+| Single-repo context                      | ✅           | ✅             | ✅                    |
+| Multi-repo context                       | ❌           | ❌             | ✅ (public code only) |
+| Local context                            | ✅           | ✅             | ❌                    |
+| OpenCtx context providers (experimental) | ✅           | ❌             | ❌                    |
+| **Prompts and Commands**                 |             |               |                      |
+| Access to prompts and Prompt library     | ✅           | ❌             | ✅                    |
+| Custom commands                          | ✅           | ❌             | ❌                    |
+| Edit code                                | ✅           | ✅             | ❌                    |
+| Generate unit test                       | ❌           | ❌             | ❌                    |
+| Ask Cody to Fix                          | ✅           | ✅             | ❌                    |
 
 ## Code Autocomplete
 
-|                  **Feature**                  | **VS Code** | **JetBrains** | **Neovim** |
-| --------------------------------------------- | ----------- | ------------- | ---------- |
-| Single and multi-line autocompletion          | ✅           | ✅             | ✅          |
-| Cycle through multiple completion suggestions | ✅           | ✅             | ✅          |
-| Ollama support (experimental)                 | ✅           | ❌             | ❌          |
+|                  **Feature**                  | **VS Code** | **JetBrains** |
+| --------------------------------------------- | ----------- | ------------- |
+| Single and multi-line autocompletion          | ✅           | ✅             |
+| Cycle through multiple completion suggestions | ✅           | ✅             |
+| Ollama support (experimental)                 | ✅           | ❌             |
 
   </Tab>
   <Tab title="Pro">
 
 ## Chat
 
-|               **Feature**                | **VS Code** | **JetBrains** | **Neovim** | **Web** |
-| ---------------------------------------- | ----------- | ------------- | ---------- | ------- |
-| Chat with Cody                           | ✅           | ✅             | ✅          | ✅       |
-| Chat history                             | ✅           | ✅             | ❌          | ✅       |
-| Clear chat history                       | ✅           | ✅             | ❌          | ✅       |
-| Edit sent messages                       | ✅           | ❌             | ❌          | ✅       |
-| Show context files                       | ✅           | ✅             | ✅          | ✅       |
-| @-file                                   | ✅           | ✅             | ❌          | ✅       |
-| @-symbol                                 | ✅           | ❌             | ❌          | ✅       |
-| LLM selection                            | ✅           | ✅             | ❌          | ✅       |
-| Ollama support (experimental)            | ✅           | ✅             | ❌          | ❌       |
-| **Context Selection**                    |             |               |            |         |
-| Single-repo context                      | ✅           | ✅             | ✅          | ✅       |
-| Multi-repo context                       | ❌           | ❌             | ❌          | ❌       |
-| Local context                            | ✅           | ✅             | ❌          | ❌       |
-| OpenCtx context providers (experimental) | ✅           | ❌             | ❌          | ❌       |
-| **Prompts and Commands**                 |             |               |            |         |
-| Access to prompts and prompt library     | ✅           | ❌             | ❌          | ✅       |
-| Custom commands                          | ✅           | ❌             | ❌          | ❌       |
-| Edit code                                | ✅           | ✅             | ❌          | ❌       |
-| Generate unit test                       | ❌           | ❌             | ✅          | ❌       |
-| Ask Cody to Fix                          | ✅           | ✅             | ❌          | ❌       |
+|               **Feature**                | **VS Code** | **JetBrains** | **Web** |
+| ---------------------------------------- | ----------- | ------------- | ------- |
+| Chat with Cody                           | ✅           | ✅             | ✅       |
+| Chat history                             | ✅           | ✅             | ✅       |
+| Clear chat history                       | ✅           | ✅             | ✅       |
+| Edit sent messages                       | ✅           | ❌             | ✅       |
+| Show context files                       | ✅           | ✅             | ✅       |
+| @-file                                   | ✅           | ✅             | ✅       |
+| @-symbol                                 | ✅           | ❌             | ✅       |
+| LLM selection                            | ✅           | ✅             | ✅       |
+| Ollama support (experimental)            | ✅           | ✅             | ❌       |
+| **Context Selection**                    |             |               |         |
+| Single-repo context                      | ✅           | ✅             | ✅       |
+| Multi-repo context                       | ❌           | ❌             | ❌       |
+| Local context                            | ✅           | ✅             | ❌       |
+| OpenCtx context providers (experimental) | ✅           | ❌             | ❌       |
+| **Prompts and Commands**                 |             |               |         |
+| Access to prompts and prompt library     | ✅           | ❌             | ✅       |
+| Custom commands                          | ✅           | ❌             | ❌       |
+| Edit code                                | ✅           | ✅             | ❌       |
+| Generate unit test                       | ❌           | ❌             | ❌       |
+| Ask Cody to Fix                          | ✅           | ✅             | ❌       |
 
 ## Code Autocomplete
 
-|                  **Feature**                  | **VS Code** | **JetBrains** | **Neovim** |
-| --------------------------------------------- | ----------- | ------------- | ---------- |
-| Single and multi-line autocompletion          | ✅           | ✅             | ✅          |
-| Cycle through multiple completion suggestions | ✅           | ✅             | ✅          |
-| Ollama support (experimental)                 | ✅           | ❌             | ❌          |
+|                  **Feature**                  | **VS Code** | **JetBrains** |
+| --------------------------------------------- | ----------- | ------------- |
+| Single and multi-line autocompletion          | ✅           | ✅             |
+| Cycle through multiple completion suggestions | ✅           | ✅             |
+| Ollama support (experimental)                 | ✅           | ❌             |
 
   </Tab>
     <Tab title="Enterprise">
 
 ## Chat
 
-|             **Feature**              | **VS Code** | **JetBrains** | **Neovim** | **Web** |
-| ------------------------------------ | ----------- | ------------- | ---------- | ------- |
-| Chat with Cody                       | ✅           | ✅             | ✅          | ✅       |
-| Chat history                         | ✅           | ✅             | ❌          | ✅       |
-| Clear chat history                   | ✅           | ✅             | ❌          | ✅       |
-| Edit sent messages                   | ✅           | ❌             | ❌          | ✅       |
-| Show context files                   | ✅           | ✅             | ✅          | ✅       |
-| @-file                               | ✅           | ✅             | ❌          | ❌       |
-| @-symbol                             | ✅           | ❌             | ❌          | ❌       |
-| Admin LLM selection                  | ✅           | ✅             | ✅          | ✅       |
-| **Context Selection**                |             |               |            |         |
-| Single-repo context                  | ✅           | ✅             | ✅          | ✅       |
-| Multi-repo context                   | ✅           | ✅             | ❌          | ✅       |
-| Local context                        | ✅           | ✅             | ❌          | ❌       |
-| Embeddings                           | ❌           | ❌             | ❌          | ❌       |
-| Guardrails                           | ✅           | ✅             | ❌          | ✅       |
-| Repo-based Cody Context Filters      | ✅           | ✅             | ❌          | ✅       |
-| **Prompts and Commands**             |             |               |            |         |
-| Access to prompts and prompt library | ✅           | ❌             | ❌          | ✅       |
-| Custom commands                      | ✅           | ❌             | ❌          | ❌       |
-| Edit code                            | ✅           | ✅             | ❌          | ❌       |
-| Generate unit test                   | ❌           | ❌             | ✅          | ❌       |
-| Ask Cody to Fix                      | ✅           | ✅             | ❌          | ❌       |
+|             **Feature**              | **VS Code** | **JetBrains** | **Web** |
+| ------------------------------------ | ----------- | ------------- | ------- |
+| Chat with Cody                       | ✅           | ✅             | ✅       |
+| Chat history                         | ✅           | ✅             | ✅       |
+| Clear chat history                   | ✅           | ✅             | ✅       |
+| Edit sent messages                   | ✅           | ❌             | ✅       |
+| Show context files                   | ✅           | ✅             | ✅       |
+| @-file                               | ✅           | ✅             | ❌       |
+| @-symbol                             | ✅           | ❌             | ❌       |
+| Admin LLM selection                  | ✅           | ✅             | ✅       |
+| **Context Selection**                |             |               |         |
+| Single-repo context                  | ✅           | ✅             | ✅       |
+| Multi-repo context                   | ✅           | ✅             | ✅       |
+| Local context                        | ✅           | ✅             | ❌       |
+| Embeddings                           | ❌           | ❌             | ❌       |
+| Guardrails                           | ✅           | ✅             | ✅       |
+| Repo-based Cody Context Filters      | ✅           | ✅             | ✅       |
+| **Prompts and Commands**             |             |               |         |
+| Access to prompts and prompt library | ✅           | ❌             | ✅       |
+| Custom commands                      | ✅           | ❌             | ❌       |
+| Edit code                            | ✅           | ✅             | ❌       |
+| Generate unit test                   | ❌           | ❌             | ❌       |
+| Ask Cody to Fix                      | ✅           | ✅             | ❌       |
 
 
 ## Code Autocomplete
 
-|                  **Feature**                  | **VS Code** | **JetBrains** | **Neovim** |
-| --------------------------------------------- | ----------- | ------------- | ---------- |
-| Single and multi line autocompletion          | ✅           | ✅             | ✅          |
-| Cycle through multiple completion suggestions | ✅           | ✅             | ✅          |
-| Admin LLM selection                           | ✅           | ✅             | ✅          |
-| OpenCtx context providers (experimental)      | ✅           | ❌             | ❌          |
+|                  **Feature**                  | **VS Code** | **JetBrains** |
+| --------------------------------------------- | ----------- | ------------- |
+| Single and multi line autocompletion          | ✅           | ✅             |
+| Cycle through multiple completion suggestions | ✅           | ✅             |
+| Admin LLM selection                           | ✅           | ✅             |
+| OpenCtx context providers (experimental)      | ✅           | ❌             |
 
   </Tab>
 </Tabs>


### PR DESCRIPTION
This PR ships several improvements to our feature parity reference docs for Cody clients:

- Removes column for Neovim
- Remove Web from Autocomplete
- Move Commands, Context Selection, Prompts & Prompt Library under Chat column 

- https://sourcegraph.slack.com/archives/C01DXLN3D0T/p1723189248829639