### PR TITLE
Docs changes for Cody featuring Sourcegraph v5.7 release

### DIFF
--- a/docs/batch-changes/configuring-credentials.mdx
+++ b/docs/batch-changes/configuring-credentials.mdx
@@ -194,12 +194,12 @@ When Sourcegraph is configured to [clone repositories using SSH via the `gitURLT
 
 EXPERIMENTAL: Using GitHub Apps to authenticate Batch Changes is currently experimental, and there may still be some rough edges.
 
-Features currently not supported are
-- running a batch change with `fork: true` that targets a public repository on github.com
-
-This is only available for GitHub code hosts.
-
 GitHub apps follow the same concepts as [personal and global access tokens](#types-of-access-tokens-used-by-batch-changes).
+
+### Limitations
+
+- GitHub apps can only be used with GitHub code hosts.
+- The forking mechanism (`fork:true`) is only supported if the GitHub app has access to all repositories of the installation, and if the origin repository and the fork are in the same organization that the GitHub app is installed to ([GitHub Docs](https://docs.github.com/en/rest/repos/forks?apiVersion=2022-11-28#create-a-fork)).
 
 ### Adding a GitHub app
 

--- a/docs/cody/clients/cody-with-sourcegraph.mdx
+++ b/docs/cody/clients/cody-with-sourcegraph.mdx
@@ -2,8 +2,6 @@
 
 <p className="subtitle">Learn how to use Cody in the web interface with your Sourcegraph.com instance.</p>
 
-<Callout type="info"> The new unified chat UI for Cody for web is currently available to users on Sourcegraph versions >=5.5.</Callout>
-
 In addition to the Cody extensions for [VS Code](/cody/clients/install-vscode), [JetBrains](/cody/clients/install-jetbrains) IDEs, and [Neovim](/cody/clients/install-neovim), Cody is also available in the Sourcegraph web app. Community users can use Cody for free by logging into their accounts on Sourcegraph.com, and enterprise users can use Cody within their Sourcegraph instance.
 
 <LinkCards>
@@ -27,9 +25,11 @@ The chat interface for Cody on the web is similar to the one you get with the [V
 
 The chat interface with your Code Search queries is operated per chat. You cannot run multiple chats and store them in parallel. A new chat window opens whenever you click the Cody button from the query editor or the top header.
 
+<Callout type="info"> The new and improved chat UI for Cody for web is currently available to users on Sourcegraph versions >=5.5. It's recommeded to update your Sourcegraph instance to the latest version to use this new chat interface. </Callout>
+
 ## LLM Selection
 
-Sourcegraph.com users with Cody **Free** and **Pro** can choose from a list of supported LLM models for a chat. Claude Sonnet 3 is the default LLM model, but users can select the LLM of their choice from the drop-down menu.
+Sourcegraph.com users with Cody **Free** and **Pro** can choose from a list of supported LLM models for a chat. Claude Sonnet 3.5 is the default LLM model, but users can select the LLM of their choice from the drop-down menu.
 
 ![llm-select-web](https://storage.googleapis.com/sourcegraph-assets/Docs/llm-select-web-0724.jpg)
 

--- a/docs/cody/clients/cody-with-sourcegraph.mdx
+++ b/docs/cody/clients/cody-with-sourcegraph.mdx
@@ -2,12 +2,12 @@
 
 <p className="subtitle">Learn how to use Cody in the web interface with your Sourcegraph.com instance.</p>
 
-<Callout type="info"> The new chat UI for Cody for web is currently in Beta and is available to users on Sourcegraph versions >=5.5.</Callout>
+<Callout type="info"> The new unified chat UI for Cody for web is currently available to users on Sourcegraph versions >=5.5.</Callout>
 
 In addition to the Cody extensions for [VS Code](/cody/clients/install-vscode), [JetBrains](/cody/clients/install-jetbrains) IDEs, and [Neovim](/cody/clients/install-neovim), Cody is also available in the Sourcegraph web app. Community users can use Cody for free by logging into their accounts on Sourcegraph.com, and enterprise users can use Cody within their Sourcegraph instance.
 
 <LinkCards>
-    <LinkCard href="https://sourcegraph.com/cody/chat" imgSrc="https://sourcegraph.com/.assets/img/sourcegraph-mark.svg" imgAlt="Cody for Web" title="Cody for Web (Beta)" description="Use Cody in the Sourcegraph Web App." />
+    <LinkCard href="https://sourcegraph.com/cody/chat" imgSrc="https://sourcegraph.com/.assets/img/sourcegraph-mark.svg" imgAlt="Cody for Web" title="Cody for Web" description="Use Cody in the Sourcegraph Web App." />
 </LinkCards>
 
 ## Initial setup
@@ -33,7 +33,7 @@ Sourcegraph.com users with Cody **Free** and **Pro** can choose from a list of s
 
 ![llm-select-web](https://storage.googleapis.com/sourcegraph-assets/Docs/llm-select-web-0724.jpg)
 
-Users on an Enterprise Sourcegraph instance do not have the option to choose an LLM model. Their site admin will configure the default LLM model for chat.
+Users on an Enterprise Sourcegraph instance do not have the option to choose an LLM model. Their site admin will configure the default LLM model for chat. However, Enterprise users with the new [model configuration](/cody/clients/model-configuration) can use the LLM selection dropdown to choose a chat model.
 
 ## Selecting Context with @-mentions
 

--- a/docs/cody/clients/feature-reference.mdx
+++ b/docs/cody/clients/feature-reference.mdx
@@ -21,7 +21,7 @@
 | Local context                            | ✅           | ✅             | ❌                    |
 | OpenCtx context providers (experimental) | ✅           | ❌             | ❌                    |
 | **Prompts and Commands**                 |             |               |                      |
-| Access to prompts and Prompt library     | ✅           | ❌             | ✅                    |
+| Access to prompts and Prompt library     | ✅           | ✅             | ✅                    |
 | Custom commands                          | ✅           | ❌             | ❌                    |
 | Edit code                                | ✅           | ✅             | ❌                    |
 | Generate unit test                       | ✅           | ✅             | ❌                    |

--- a/docs/cody/clients/install-jetbrains.mdx
+++ b/docs/cody/clients/install-jetbrains.mdx
@@ -89,6 +89,8 @@ Since your first message to Cody anchors the conversation, you can return to the
   <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jb-chat-interface-0824.mp4" type="video/mp4" />
 </video>
 
+<Callout type="info"> Users should be on the Cody for JetBrains extension v2023.2 or more to get this new and improved chat UI.</Callout>
+
 ### Changing LLM model for chat
 
 <Callout type="note"> You need to be a Cody Free or Pro user to have multi-model selection capability. Enterprise users with the new [model configuration](/cody/clients/model-configuration) can use the LLM selection dropdown to choose a chat model.</Callout>
@@ -138,16 +140,13 @@ When you start a new Cody chat, the chat input window opens with a default `@-me
 
 ![jb-context-retrieval](https://storage.googleapis.com/sourcegraph-assets/Docs/jb-context-retrieval-0824.jpg)
 
-At any point in time, you can edit these context chips or remove them completely if you do not want to use these as context. Any chat without a context chip will instruct Cody to use no codebase context. However, you can always provide an alternate `@-mention` file or symbols to let Cody use it as a new source of context.
+At any point in time, you can edit these context chips or remove them completely if you do not want to use these as context. Any chat without a context chip will instruct Cody to use no codebase context. However, you can always provide an alternate `@-mention` file to let Cody use it as a new source of context.
 
 When you have both a repository and files @-mentioned, Cody will search the repository for context while prioritizing the mentioned files.
 
 ### Selecting Context with @-mentions
 
-Cody's chat allows you to add files and symbols as context in your messages.
-
-- Type `@-file` and then a filename to include a file as a context
-- Type `@#` and then a symbol name to include the symbol's definition as context. Functions, methods, classes, types, etc., are all symbols
+Cody's chat allows you to add files as context in your messages. Type `@-file` and then a filename to include a file as a context.
 
 The `@-file` also supports line numbers to query the context of large files. You can add ranges of large files to your context by @-mentioning a large file and appending a number range to the filename, for example, `@filepath/filename:1-10`.
 
@@ -163,7 +162,7 @@ If Cody's answer isn't helpful, you can try asking again with different context:
 
 - **Public knowledge only**: Cody will not use your own code files as context; it’ll only use knowledge trained into the base model.
 - **Current file only**: Re-run the prompt again using just the current file as context.
-- **Add context**: Provides @-mention context options to improve the response by explicitly including files, symbols, remote repositories, or even web pages (by URL).
+- **Add context**: Provides @-mention context options to improve the response by explicitly including files, remote repositories, or even web pages (by URL).
 
 ![jb-rerun-context](https://storage.googleapis.com/sourcegraph-assets/Docs/jb-rerun-context-0824.jpg)
 

--- a/docs/cody/clients/install-jetbrains.mdx
+++ b/docs/cody/clients/install-jetbrains.mdx
@@ -116,7 +116,7 @@ For Edit:
 
 Users on Cody **Free** and **Pro** can choose from a list of supported LLM models for Chat and Commands. Both Cody Free and Pro users can choose from a list of supported LLM models for Chat and Commands.
 
-![llm-selection-cody](https://storage.googleapis.com/sourcegraph-assets/Docs/jb-llm-select-0724.png)
+![llm-selection-cody](https://storage.googleapis.com/sourcegraph-assets/Docs/jb-llm-select-0824.jpg)
 
 Enterprise users get Claude 3 (Opus and Sonnet) as the default LLM models without extra cost. Moreover, Enterprise users can use Claude 3.5 models through Cody Gateway, Anthropic BYOK, AWS Bedrock (limited availability), and GCP Vertex.
 
@@ -131,10 +131,6 @@ You also get additional capabilities like BYOLLM (Bring Your Own LLM), supportin
 <Callout type="note">Ollama support for JetBrains is in the Experimental stage and is available on Cody Free and Pro.</Callout>
 
 You can use Ollama models locally for Cody’s chat and commands. This lets you chat without sending messages over the internet to an LLM provider so that you can use Cody offline. To use Ollama locally, you’ll need to install Ollama and download a chat model such as CodeGemma or Llama3. [Read here for detailed instructions](https://sourcegraph.com/github.com/sourcegraph/jetbrains/-/blob/README.md#use-ollama-models-for-chat--commands).
-
-<video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto', aspectRatio: '1920 / 1080' }}>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jb-ollama.mp4" type="video/mp4" />
- </video>
 
 ## Smart Apply code suggestions
 
@@ -193,8 +189,6 @@ JetBrains users on the Free or Pro plan get single-repo support in chat and can 
 
 Cody automatically understands the context of your codebase for all Cody Free, Pro, and Enterprise users based on the project opened in your workspace. Enterprise users can add up to **9 additional repos (10 total, including the default project)** to use as context. The multi-repo context for Enterprise is powered by Sourcegraph code search and allows Cody to use the selected codebase to answer your questions.
 
-![context-selector](https://storage.googleapis.com/sourcegraph-assets/Docs/jb-chat-context.png)
-
 Moreover, Cody's chat allows you to add files as context in your messages. Type `@-file` in the Cody chat window and then a filename to include a file as context.
 
 ### Chat with multi-repo context
@@ -203,10 +197,6 @@ For Cody Free and Cody Pro users, if you delete all the context from the chat in
 
 Cody Enterprise users can add remote repositories from your Sourcegraph instance. You can type the name of your repositories into this interface and select up to **9 additional repos (10 total, including the default project)**. Cody will then search against those repositories and retrieve relevant files to answer your chat prompts.
 
-<video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto' }}>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jetbrains-cody-v6-multi-repo-context%20(1).mp4" type="video/mp4"/>
-</video>
-
 ### Cody Context Filters
 
 <Callout type="note">Context Filters is available for all Cody Enterprise users running Cody JetBrains extension version `>=6.0.0`.</Callout>
@@ -214,10 +204,6 @@ Cody Enterprise users can add remote repositories from your Sourcegraph instance
 Admins on the Sourcegraph Enterprise instance can use the Cody Context Filters to determine which repositories Cody can use as the context in its requests to third-party LLMs. Inside your site configuration, you can define a set of `include` and `exclude` rules that will be used to filter the list of repositories Cody can access.
 
 For repos mentioned in the `exclude` field, Cody's commands are disabled, and you cannot use them for context fetching. If you try running any of these, you'll be prompted with an error message. However, Cody chat will still work, and you can use it to ask questions.
-
-<video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto' }}>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jb-context-filters.mp4" type="video/mp4"/>
-</video>
 
 [Read more about the Cody Context Filters here →](/cody/capabilities/ignore-context)
 
@@ -231,7 +217,7 @@ Cody with JetBrains offers quick, ready-to-use [prompts and commands](/cody/capa
 - **Smell Code**: Finds code smells in your file
 - **Explain Code**: Expains code in your file
 
-![jetbrains-commands](https://storage.googleapis.com/sourcegraph-assets/Docs/jb-commands-new-ga.png)
+![jetbrains-prompts-commands](https://storage.googleapis.com/sourcegraph-assets/Docs/jb-prompts-commands-0824.jpg)
 
 Let's learn about how to use some of these commands:
 
@@ -305,6 +291,7 @@ To add or remove an account you can do the following:
 1. To remove, select your account and hit `-`. To add click `+` and choose the appropriate login method
 
 ## Change update channel for stable or nightly releases
+
 Our nightly release channel gets updated much more frequently and might be helpful to verify bug fixes that will come in the next stable release.
 To update your update channel you can do the following:
 

--- a/docs/cody/clients/install-jetbrains.mdx
+++ b/docs/cody/clients/install-jetbrains.mdx
@@ -79,6 +79,74 @@ function bubbleSort(array)
   <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jb-suggest-062024.mp4" type="video/mp4"/>
 </video>
 
+## Chat
+
+Cody chat in JetBrains is available in a unified interface opened right next to your code. Once connected to Sourcegraph, a new chat input field is opened with a default `@-mention` [context chips](#context-retrieval).
+
+All your previous and existing chats are stored for later use and can be accessed via the **History** icon from the top menu. You can download them to share or use later in a `.json` file or delete them altogether.
+
+### Chat interface
+
+The chat interface is designed intuitively. Your very first chat input lives at the top of the panel, and the first message in any chat log will stay pinned to the top of the chat. After your first message, the chat input window moves to the bottom of the sidebar.
+
+Since your first message to Cody anchors the conversation, you can return to the top chat box anytime, edit your prompt, or re-run it using a different LLM model.
+
+<video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto', aspectRatio: '1920 / 1080' }}>
+  <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jb-chat-interface-0824.mp4" type="video/mp4" />
+</video>
+
+### Changing LLM model for chat
+
+<Callout type="note"> You need to be a Cody Free or Pro user to have multi-model selection capability. Enterprise users with the new [model configuration](/cody/clients/model-configuration) can use the LLM selection dropdown to choose a chat model.</Callout>
+
+For Chat:
+
+- Open chat or toggle between editor and chat
+- Click on the model selector (which by default indicates Claude 3.5 Sonnet)
+- See the selection of models and click the model you desire. This model will now be the default model going forward on any new chats
+
+For Edit:
+
+- On any file, select some code and a right-click
+- Select **Cody > Edit Code**
+- Select the default model available (this is Claude Sonnet 3.5)
+- See the selection of models and click the model you desire. This model will now be the default model going forward on any new edits
+
+### Context retrieval
+
+When you start a new Cody chat, the chat input window opens with a default `@-mention` context chips for all the context it intends to use. This context is based on your current repository and current file (or a file selection if you have code highlighted).
+
+![jb-context-retrieval](https://storage.googleapis.com/sourcegraph-assets/Docs/jb-context-retrieval-0824.jpg)
+
+At any point in time, you can edit these context chips or remove them completely if you do not want to use these as context. Any chat without a context chip will instruct Cody to use no codebase context. However, you can always provide an alternate `@-mention` file or symbols to let Cody use it as a new source of context.
+
+When you have both a repository and files @-mentioned, Cody will search the repository for context while prioritizing the mentioned files.
+
+### Selecting Context with @-mentions
+
+Cody's chat allows you to add files and symbols as context in your messages.
+
+- Type `@-file` and then a filename to include a file as a context
+- Type `@#` and then a symbol name to include the symbol's definition as context. Functions, methods, classes, types, etc., are all symbols
+
+The `@-file` also supports line numbers to query the context of large files. You can add ranges of large files to your context by @-mentioning a large file and appending a number range to the filename, for example, `@filepath/filename:1-10`.
+
+When you `@-mention` files to add to Cody’s context window, the file lookup takes `files.exclude`, `search.exclude`, and `.gitgnore` files into account. This makes the file search faster as a result up to 100ms.
+
+Moreover, when you `@-mention` files, Cody will track the number of characters in those files against the context window limit of the selected chat model. As you `@-mention` multiple files, Cody will calculate how many tokens of the context window remain. When the remaining context window size becomes too small, you get **File too large** errors for further more `@-mention` files.
+
+Cody defaults to showing @-mention context chips for all the context it intends to use. When you open a new chat, Cody will show context chips for your current repository and current file (or file selection if you have code highlighted).
+
+### Rerun prompts with different context
+
+If Cody's answer isn't helpful, you can try asking again with different context:
+
+- **Public knowledge only**: Cody will not use your own code files as context; it’ll only use knowledge trained into the base model.
+- **Current file only**: Re-run the prompt again using just the current file as context.
+- **Add context**: Provides @-mention context options to improve the response by explicitly including files, symbols, remote repositories, or even web pages (by URL).
+
+![jb-rerun-context](https://storage.googleapis.com/sourcegraph-assets/Docs/jb-rerun-context-0824.jpg)
+
 ## Autocomplete
 
 Cody provides multi-line autocomplete as you type. Autocomplete suggestions appear as inlay suggestions and are enabled by default in your JetBrains IntelliJ editor. With this setting, there is a list of programming languages supported and enabled by default.
@@ -178,10 +246,6 @@ You can use Ollama models locally for Cody’s chat and commands. This lets you 
 <video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto', aspectRatio: '1920 / 1080' }}>
     <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jb-ollama.mp4" type="video/mp4" />
  </video>
-
-## Chat history
-
-Next to the **Chat** tab is **Chat History**, which displays Cody's previous chat interactions. You can revisit any previous chat interactions to get the context of the conversation. You can export your chat history as JSON files for later use.
 
 ## Context fetching mechanism
 

--- a/docs/cody/clients/install-jetbrains.mdx
+++ b/docs/cody/clients/install-jetbrains.mdx
@@ -66,17 +66,11 @@ Once Cody is successfully connected, you'll see that the sign-in panel has been 
 Cody provides intelligent code suggestions and context-aware autocompletions for numerous programming languages like JavaScript, Python, TypeScript, Go, etc.
 
 - Create a new file in IntelliJ, for example, `code.js`
-- Next, type the following algorithm function to sort an array of numbers
-
-```js
-function bubbleSort(array)
-```
-
 - As you start typing, Cody will automatically provide suggestions and context-aware completions based on your coding patterns and the code context
 - These autocomplete suggestions appear as grayed text. To accept the suggestion, press the `Tab` key
 
 <video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto' }}>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jb-suggest-062024.mp4" type="video/mp4"/>
+  <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jetbrains-cody-v6-autocomplete.mp4" type="video/mp4"/>
 </video>
 
 ## Chat

--- a/docs/cody/clients/install-jetbrains.mdx
+++ b/docs/cody/clients/install-jetbrains.mdx
@@ -230,7 +230,7 @@ You can run the inline edit command on a selected code snippet, an entire file, 
 Once you enter your prompt, Cody will perform inline edits that you can **Accept**, **Undo**, or **Show diff** for the change. You can also click **Edit & Retry** to iterate your prompt and get alternate suggestions.
 
 <video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto' }}>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jetbrains-cody-edit-code.mp4" type="video/mp4"/>
+  <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jb-code-edits-0824.mp4" type="video/mp4"/>
 </video>
 
 ### Inline unit tests
@@ -256,7 +256,7 @@ All you need to do is select and highlight the code line with the error and clic
 Like the Edit Code and Generate Unit Test commands, you can generate inline documentation for your code without opening the chat window. Doc command is available via hotkey, context menu, and Cody sidebar. Type `Shift + Ctrl + H`, and Cody will start generating documentation for your selected code snippet or the entire file.
 
 <video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto' }}>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jetbrains-cody-v6-document-code.mp4" type="video/mp4"/>
+  <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jb-document-code-0824.mp4" type="video/mp4"/>
 </video>
 
 ## Autocomplete

--- a/docs/cody/clients/install-jetbrains.mdx
+++ b/docs/cody/clients/install-jetbrains.mdx
@@ -112,6 +112,36 @@ For Edit:
 - Select the default model available (this is Claude Sonnet 3.5)
 - See the selection of models and click the model you desire. This model will now be the default model going forward on any new edits
 
+## Supported LLM models
+
+Users on Cody **Free** and **Pro** can choose from a list of supported LLM models for Chat and Commands. Both Cody Free and Pro users can choose from a list of supported LLM models for Chat and Commands.
+
+![llm-selection-cody](https://storage.googleapis.com/sourcegraph-assets/Docs/jb-llm-select-0724.png)
+
+Enterprise users get Claude 3 (Opus and Sonnet) as the default LLM models without extra cost. Moreover, Enterprise users can use Claude 3.5 models through Cody Gateway, Anthropic BYOK, AWS Bedrock (limited availability), and GCP Vertex.
+
+<Callout type="info">For enterprise users on AWS Bedrock: 3.5 Sonnet is unavailable in `us-west-2` but available in `us-east-1`. Check the current model availability on AWS and your customer's instance location before switching. Provisioned throughput via AWS is not supported for 3.5 Sonnet.</Callout>
+
+You also get additional capabilities like BYOLLM (Bring Your Own LLM), supporting Single-Tenant and Self Hosted setups for flexible coding environments. Your site administrator determines the LLM, and cannot be changed within the editor. However, Cody Enterprise users when using Cody Gateway have the ability to [configure custom models](/cody/core-concepts/cody-gateway#configuring-custom-models) Anthropic (like Claude 3 Opus and Claude Haiku), OpenAI (GPT 3.5 Turbo and GPT 4 Turbo) and Google Gemini 1.5 models (Flash and Pro).
+
+<Callout type="note">Read and learn more about the [supported LLMs](/cody/capabilities/supported-models) and [token limits](/cody/core-concepts/token-limits) on Cody Free, Pro and Enterprise.</Callout>
+
+## Ollama model support
+
+<Callout type="note">Ollama support for JetBrains is in the Experimental stage and is available on Cody Free and Pro.</Callout>
+
+You can use Ollama models locally for Cody’s chat and commands. This lets you chat without sending messages over the internet to an LLM provider so that you can use Cody offline. To use Ollama locally, you’ll need to install Ollama and download a chat model such as CodeGemma or Llama3. [Read here for detailed instructions](https://sourcegraph.com/github.com/sourcegraph/jetbrains/-/blob/README.md#use-ollama-models-for-chat--commands).
+
+<video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto', aspectRatio: '1920 / 1080' }}>
+    <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jb-ollama.mp4" type="video/mp4" />
+ </video>
+
+## Smart Apply code suggestions
+
+Cody lets you dynamically insert code from chat into your files with **Smart Apply**. Every time Cody provides you with a code suggestion, you can click the **Apply** button. Cody will then analyze your open code file, find where that relevant code should live, and add a diff.
+
+For chat messages where Cody provides multiple code suggestions, you can apply each in sequence to go from chat suggestions to written code.
+
 ### Context retrieval
 
 When you start a new Cody chat, the chat input window opens with a default `@-mention` context chips for all the context it intends to use. This context is based on your current repository and current file (or a file selection if you have code highlighted).
@@ -147,37 +177,57 @@ If Cody's answer isn't helpful, you can try asking again with different context:
 
 ![jb-rerun-context](https://storage.googleapis.com/sourcegraph-assets/Docs/jb-rerun-context-0824.jpg)
 
-## Autocomplete
+## Context fetching mechanism
 
-Cody provides multi-line autocomplete as you type. Autocomplete suggestions appear as inlay suggestions and are enabled by default in your JetBrains IntelliJ editor. With this setting, there is a list of programming languages supported and enabled by default.
+JetBrains users on the Free or Pro plan can leverage [local search](/cody/core-concepts/context#context-selection) as the primary context source for Cody chat. Local or remote embeddings will no longer be produced or used as a context source.
 
-To manually configure the Autocomplete feature,
+Enterprise users can leverage the full power of the Sourcegraph search engine as the primary context provider to Cody.
 
-- Go to the **Cody Settings...** from the Cody icon in the sidebar
-- Next, click the **Sourcegraph & Cody** dropdown and select **Cody**
-- The **Autocomplete** settings will appear with the list of **Enabled Languages**
+<Callout type="info"> Read more about [Context fetching mechanism](/cody/core-concepts/context/#context-fetching-mechanism) in detail.</Callout>
 
-Autocomplete suggestions use the same color as inline parameter hints according to your configured editor theme. However, you can optionally enable the **Custom color for completions** checkbox to customize the color of your choice.
+## Context scope
 
-In addition, you can use the following keyboard shortcuts to interact with Cody's autocomplete suggestions:
+JetBrains users on the Free or Pro plan get single-repo support in chat and can use one repo for context fetching. Enterprise users get multi-repo support in chat and can explicitly specify **up to 10 additional repos** they would like Cody to use for context.
 
-- `Tab` to accept a suggestion
-- `Alt + [` (Windows) or `Opt + [` (macOS) to cycle suggestions
-- `Alt + \` (Windows) or `Opt + \` (macOS) to manually trigger autocomplete if no suggestions have been returned
+## Context Selection
+
+Cody automatically understands the context of your codebase for all Cody Free, Pro, and Enterprise users based on the project opened in your workspace. Enterprise users can add up to **9 additional repos (10 total, including the default project)** to use as context. The multi-repo context for Enterprise is powered by Sourcegraph code search and allows Cody to use the selected codebase to answer your questions.
+
+![context-selector](https://storage.googleapis.com/sourcegraph-assets/Docs/jb-chat-context.png)
+
+Moreover, Cody's chat allows you to add files as context in your messages. Type `@-file` in the Cody chat window and then a filename to include a file as context.
+
+### Chat with multi-repo context
+
+For Cody Free and Cody Pro users, if you delete all the context from the chat input, Cody will not use any local context. When this happens, Cody doesn't search your local project for context and sends your prompt to the selected LLM.
+
+Cody Enterprise users can add remote repositories from your Sourcegraph instance. You can type the name of your repositories into this interface and select up to **9 additional repos (10 total, including the default project)**. Cody will then search against those repositories and retrieve relevant files to answer your chat prompts.
 
 <video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto' }}>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jetbrains-cody-v6-autocomplete.mp4" type="video/mp4"/>
+  <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jetbrains-cody-v6-multi-repo-context%20(1).mp4" type="video/mp4"/>
 </video>
 
-## Commands
+### Cody Context Filters
 
-Cody with JetBrains offers quick, ready-to-use Commands for common actions to write, describe, fix, and smell code. These allow you to run predefined actions with smart context-fetching anywhere in the editor.
+<Callout type="note">Context Filters is available for all Cody Enterprise users running Cody JetBrains extension version `>=6.0.0`.</Callout>
 
-These are broadly categorized into the Edit Commands and Chat Commands.
+Admins on the Sourcegraph Enterprise instance can use the Cody Context Filters to determine which repositories Cody can use as the context in its requests to third-party LLMs. Inside your site configuration, you can define a set of `include` and `exclude` rules that will be used to filter the list of repositories Cody can access.
+
+For repos mentioned in the `exclude` field, Cody's commands are disabled, and you cannot use them for context fetching. If you try running any of these, you'll be prompted with an error message. However, Cody chat will still work, and you can use it to ask questions.
+
+<video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto' }}>
+  <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jb-context-filters.mp4" type="video/mp4"/>
+</video>
+
+[Read more about the Cody Context Filters here →](/cody/capabilities/ignore-context)
+
+## Prompts and Commands
+
+Cody with JetBrains offers quick, ready-to-use [prompts and commands](/cody/capabilities/commands) for common actions to write, describe, fix, and smell code. These allow you to run predefined actions with smart context-fetching anywhere in the editor. These allow you to run predefined actions with smart context-fetching anywhere in the editor, like:
 
 - **Edit Code**: Makes inline code edits. You also get the option to select LLM for edit suggestions
 - **Document Code**: Create inline documentation for your code
-- **Generate Unit Test**: Creates inline unit tests for your code-
+- **Generate Unit Test**: Creates inline unit tests for your code
 - **Smell Code**: Finds code smells in your file
 - **Explain Code**: Expains code in your file
 
@@ -223,73 +273,27 @@ Like the Edit Code and Generate Unit Test commands, you can generate inline docu
   <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jetbrains-cody-v6-document-code.mp4" type="video/mp4"/>
 </video>
 
-## Supported LLM models
+## Autocomplete
 
-Users on Cody **Free** and **Pro** can choose from a list of supported LLM models for Chat and Commands. Both Cody Free and Pro users can choose from a list of supported LLM models for Chat and Commands.
+Cody provides multi-line autocomplete as you type. Autocomplete suggestions appear as inlay suggestions and are enabled by default in your JetBrains IntelliJ editor. With this setting, there is a list of programming languages supported and enabled by default.
 
-![llm-selection-cody](https://storage.googleapis.com/sourcegraph-assets/Docs/jb-llm-select-0724.png)
+To manually configure the Autocomplete feature,
 
-Enterprise users get Claude 3 (Opus and Sonnet) as the default LLM models without extra cost. Moreover, Enterprise users can use Claude 3.5 models through Cody Gateway, Anthropic BYOK, AWS Bedrock (limited availability), and GCP Vertex.
+- Go to the **Cody Settings...** from the Cody icon in the sidebar
+- Next, click the **Sourcegraph & Cody** dropdown and select **Cody**
+- The **Autocomplete** settings will appear with the list of **Enabled Languages**
 
-<Callout type="info">For enterprise users on AWS Bedrock: 3.5 Sonnet is unavailable in `us-west-2` but available in `us-east-1`. Check the current model availability on AWS and your customer's instance location before switching. Provisioned throughput via AWS is not supported for 3.5 Sonnet.</Callout>
+Autocomplete suggestions use the same color as inline parameter hints according to your configured editor theme. However, you can optionally enable the **Custom color for completions** checkbox to customize the color of your choice.
 
-You also get additional capabilities like BYOLLM (Bring Your Own LLM), supporting Single-Tenant and Self Hosted setups for flexible coding environments. Your site administrator determines the LLM, and cannot be changed within the editor. However, Cody Enterprise users when using Cody Gateway have the ability to [configure custom models](/cody/core-concepts/cody-gateway#configuring-custom-models) Anthropic (like Claude 3 Opus and Claude Haiku), OpenAI (GPT 3.5 Turbo and GPT 4 Turbo) and Google Gemini 1.5 models (Flash and Pro).
+In addition, you can use the following keyboard shortcuts to interact with Cody's autocomplete suggestions:
 
-<Callout type="note">Read and learn more about the [supported LLMs](/cody/capabilities/supported-models) and [token limits](/cody/core-concepts/token-limits) on Cody Free, Pro and Enterprise.</Callout>
-
-## Ollama model support
-
-<Callout type="note">Ollama support for JetBrains is in the Experimental stage and is available on Cody Free and Pro.</Callout>
-
-You can use Ollama models locally for Cody’s chat and commands. This lets you chat without sending messages over the internet to an LLM provider so that you can use Cody offline. To use Ollama locally, you’ll need to install Ollama and download a chat model such as CodeGemma or Llama3. [Read here for detailed instructions](https://sourcegraph.com/github.com/sourcegraph/jetbrains/-/blob/README.md#use-ollama-models-for-chat--commands).
-
-<video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto', aspectRatio: '1920 / 1080' }}>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jb-ollama.mp4" type="video/mp4" />
- </video>
-
-## Context fetching mechanism
-
-JetBrains users on the Free or Pro plan can leverage [local search](/cody/core-concepts/context#context-selection) as the primary context source for Cody chat. Local or remote embeddings will no longer be produced or used as a context source.
-
-Enterprise users can leverage the full power of the Sourcegraph search engine as the primary context provider to Cody.
-
-<Callout type="info"> Read more about [Context fetching mechanism](/cody/core-concepts/context/#context-fetching-mechanism) in detail.</Callout>
-
-## Context scope
-
-JetBrains users on the Free or Pro plan get single-repo support in chat and can use one repo for context fetching. Enterprise users get multi-repo support in chat and can explicitly specify **up to 10 additional repos** they would like Cody to use for context.
-
-## Context Selection
-
-Cody automatically understands the context of your codebase for all Cody Free, Pro, and Enterprise users based on the project opened in your workspace. Enterprise users can add up to **9 additional repos (10 total, including the default project)** to use as context. The multi-repo context for Enterprise is powered by Sourcegraph code search and allows Cody to use the selected codebase to answer your questions.
-
-![context-selector](https://storage.googleapis.com/sourcegraph-assets/Docs/jb-chat-context.png)
-
-Moreover, Cody's chat allows you to add files as context in your messages. Type `@-file` in the Cody chat window and then a filename to include a file as context.
-
-### Chat with multi-repo context
-
-The chat sidebar has an interface for selecting **chat context**. For Cody Free and Cody Pro users, you can turn the local chat context on or off. When the local project is turned off, Cody doesn't search your local project for context and sends your prompt to the selected LLM.
-
-Cody Enterprise users can add remote repositories from your Sourcegraph instance. You can type the name of your repositories into this interface and select up to **9 additional repos (10 total, including the default project)**. Cody will then search against those repositories and retrieve relevant files to answer your chat prompts.
+- `Tab` to accept a suggestion
+- `Alt + [` (Windows) or `Opt + [` (macOS) to cycle suggestions
+- `Alt + \` (Windows) or `Opt + \` (macOS) to manually trigger autocomplete if no suggestions have been returned
 
 <video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto' }}>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jetbrains-cody-v6-multi-repo-context%20(1).mp4" type="video/mp4"/>
+  <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jetbrains-cody-v6-autocomplete.mp4" type="video/mp4"/>
 </video>
-
-### Cody Context Filters
-
-<Callout type="note">Context Filters is available for all Cody Enterprise users running Cody JetBrains extension version `>=6.0.0`.</Callout>
-
-Admins on the Sourcegraph Enterprise instance can use the Cody Context Filters to determine which repositories Cody can use as the context in its requests to third-party LLMs. Inside your site configuration, you can define a set of `include` and `exclude` rules that will be used to filter the list of repositories Cody can access.
-
-For repos mentioned in the `exclude` field, Cody's commands are disabled, and you cannot use them for context fetching. If you try running any of these, you'll be prompted with an error message. However, Cody chat will still work, and you can use it to ask questions.
-
-<video width="1920" height="1080" loop playsInline controls style={{ width: '100%', height: 'auto' }}>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/jb-context-filters.mp4" type="video/mp4"/>
-</video>
-
-[Read more about the Cody Context Filters here →](/cody/capabilities/ignore-context)
 
 ## Add or remove account
 

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -138,12 +138,12 @@ A chat history icon at the top of your chat input window allows you to navigate 
 
 ### Changing LLM model for chat
 
-<Callout type="note"> You need to be a Cody Free or Pro user to have multi-model selection capability. This is not available for Cody Enterprise users.</Callout>
+<Callout type="note"> You need to be a Cody Free or Pro user to have multi-model selection capability. Enterprise users with the new [model configuration](/cody/clients/model-configuration) can use the LLM selection dropdown to choose a chat model.</Callout>
 
 For Chat:
 
 - Open chat or toggle between editor and chat (Opt+L/Alt+L)
-- Click on the model selector (which by default indicates Claude 3 Sonnet)
+- Click on the model selector (which by default indicates Claude 3.5 Sonnet)
 - See the selection of models and click the model you desire. This model will now be the default model going forward on any new chats
 
 For Edit:

--- a/docs/cody/usage-and-pricing.mdx
+++ b/docs/cody/usage-and-pricing.mdx
@@ -10,7 +10,7 @@ The free plan is designed for individuals to get started with Cody. It comes wit
 
 The free plan provides access to local context with keyword search and embeddings on open-source code via Sourcegraph.com. You get **200 MB** of embeddings over your lifetime and can manage these from the user settings in VS Code, with JetBrains IDE support coming soon. If you embed 150 MB of code, you can only embed another 50 MB of code. If you delete that 150 MB of code embedding, the original 200 MB of code embeddings will be available again.
 
-The free plan ensures local context utilization and allows you to seamlessly integrate Cody into your preferred client, whether it's VSCode, JetBrains, or Neovim. Finally, you'll have default support with Anthropic (Claude 3 Sonnet for Chat and Commands) and StarCoder as the officially supported LLMs.
+The free plan ensures local context utilization and allows you to seamlessly integrate Cody into your preferred client, whether it's VSCode, JetBrains, or Neovim. Finally, you'll have default support with Anthropic (Claude 3.5 Sonnet for Chat and Commands) and StarCoder as the officially supported LLMs.
 
 ### Billing cycle
 


### PR DESCRIPTION
This PR tackles all the docs changes in the Sourcegraph 5.7 release that are related to Cody. It caters the following projects:

- Cody Web GA
   - Removes the Beta label from everywhere we mention
   - Add mentions of LLM selector to only ENT users using the new model configuration

- JetBrains Unified Chat UI
   - Replace all media with old UI
   - Reorder of information based on a similar structure of VS Code docs

- Smart Apply in JetBrains 
- Mentions about Prompts in docs