### PR TITLE
Webhook GA docs for SG 5.7 release

### DIFF
--- a/docs/admin/config/webhooks/index.mdx
+++ b/docs/admin/config/webhooks/index.mdx
@@ -1,4 +1,4 @@
 # Webhooks
 
 - [Incoming webhooks](/admin/config/webhooks/incoming)
-- [Outgoing webhooks](/admin/config/webhooks/outgoing) (Beta)
+- [Outgoing webhooks](/admin/config/webhooks/outgoing)

--- a/docs/admin/config/webhooks/outgoing.mdx
+++ b/docs/admin/config/webhooks/outgoing.mdx
@@ -1,6 +1,6 @@
 # Outgoing webhooks
 
-<Callout type="note"> This feature is currently in beta and supported on Sourcegraph versions 5.0 or more.</Callout>
+<Callout type="note"> This feature is supported on Sourcegraph versions 5.0 or more.</Callout>
 
 Outgoing webhooks can be configured on a Sourcegraph instance in order to send Sourcegraph events to external tools and services. This allows for deeper integrations between Sourcegraph and other applications.
 

--- a/docs/batch-changes/configuring-credentials.mdx
+++ b/docs/batch-changes/configuring-credentials.mdx
@@ -201,6 +201,14 @@ GitHub apps follow the same concepts as [personal and global access tokens](#typ
 - GitHub apps can only be used with GitHub code hosts.
 - The forking mechanism (`fork:true`) is only supported if the GitHub app has access to all repositories of the installation, and if the origin repository and the fork are in the same organization that the GitHub app is installed to ([GitHub Docs](https://docs.github.com/en/rest/repos/forks?apiVersion=2022-11-28#create-a-fork)).
 
+### Migrating from PATs to GitHub Apps
+
+You can migrate your credentials from PATs to GitHub Apps by deleting the PAT credential and creating a GitHub app credential.
+
+Batch Changes will look at the available credentials, and pick one that matches the targeted namespace (e.g. organization).
+
+You can continue to use existing batch changes without modifications.
+
 ### Adding a GitHub app
 
 Adding a GitHub app is done through the Batch Changes section of your user settings:

--- a/docs/code_monitoring/how-tos/index.mdx
+++ b/docs/code_monitoring/how-tos/index.mdx
@@ -2,4 +2,4 @@
 
 * [Starting points](/code_monitoring/how-tos/starting_points)
 * [Setting up Slack notifications](/code_monitoring/how-tos/slack)
-* [Setting up Webhook notifications](/code_monitoring/how-tos/webhook) (Beta)
+* [Setting up Webhook notifications](/code_monitoring/how-tos/webhook)

--- a/docs/code_monitoring/how-tos/webhook.mdx
+++ b/docs/code_monitoring/how-tos/webhook.mdx
@@ -1,7 +1,5 @@
 # Setting up Webhook notifications
 
-<Callout type="note">This feature is in beta.</Callout>
-
 Webhook notifications provide a way to execute custom responses to a code monitor notification.
 They are implemented as a POST request to a URL of your choice. The body of the request is defined
 by Sourcegraph, and contains all the information available about the cause of the notification.


### PR DESCRIPTION
The PR ships docs for the Webhooks GA scheduled to go live with Sourcegraph 5.7 release.

- https://linear.app/sourcegraph/issue/PROD-251/edit-docs-for-code-monitoring-webhooks-to-remove-any-mention-of-beta#comment-8b570d5f