### PR TITLE
docs(batches): explain web commit signing requirement

### DIFF
--- a/docs/admin/config/batch_changes.mdx
+++ b/docs/admin/config/batch_changes.mdx
@@ -188,6 +188,8 @@ Sourcegraph can be configured to [sign commits pushed to GitHub](https://docs.gi
 
 At present, only GitHub code hosts (both Cloud and Enterprise) are supported, and only GitHub App signing is supported. Support for other code hosts and signing methods may be added in the future.
 
+<Callout type="note"> Commit signing on GitHub Enterprise requires [web commit signing](https://docs.github.com/en/enterprise-server@3.14/admin/configuring-settings/configuring-user-applications-for-your-enterprise/configuring-web-commit-signing#enabling-web-commit-signing) to be enabled. Otherwise commits from GitHub apps will be unverified.</Callout>
+
 GitHub Apps are also the recommended way to [sync repositories on GitHub](/admin/code_hosts/github#using-a-github-app). However, **they are not a replacement for [PATs](/batch-changes/configuring-credentials#personal-access-tokens) in Batch Changes**. It is **also** necessary to create a separate GitHub App for Batch Changes commit signing even if you already have an App connected for the same code host for repository syncing because the Apps require different permissions. The process for creating each type of GitHub App is almost identical.
 
 To create a GitHub App for commit signing and connect it to Sourcegraph:


### PR DESCRIPTION
We found out that commits for GHE will be unverified, unless the instance admin enables web commit signing: https://sourcegraph.slack.com/archives/C04MYFW01NV/p1725436182449839?thread_ts=1725378971.454109&cid=C04MYFW01NV

This PR documents this requirement.

For SRCH-883
For SRCH-802