### PR TITLE
Fix undefined suggested search results 

### DIFF
--- a/src/components/search/docsearch/DocSearchModal.tsx
+++ b/src/components/search/docsearch/DocSearchModal.tsx
@@ -171,7 +171,7 @@ export function DocSearchModal({
         initialState: {
           query: initialQuery,
           context: {
-            searchSuggestions: [],
+            searchSuggestions: ["Cody","Code Search"],
           },
         },
         insights,


### PR DESCRIPTION
Algolia stores the lvl0 hits as suggested searches. Our docsite currently only has 1 lvl0 (Documentation) causing the searches to be not useful.

As a quick fix, adding "Cody" and "Code Search" as initial suggestions fixes this. Long term, changing how our docs are getting scraped and getting the navbar headers to act as lvl0 is probably preferred.

<img width="1455" alt="Screenshot 2024-09-04 at 08 06 47" src="https://github.com/user-attachments/assets/8c525240-b804-413c-a816-fb308c11d948">


