### PR TITLE
Add callout for perforce repos converted to git

### DIFF
--- a/docs/code_insights/explanations/current_limitations_of_code_insights.mdx
+++ b/docs/code_insights/explanations/current_limitations_of_code_insights.mdx
@@ -81,7 +81,7 @@ Code Insights does not yet support running over specific revisions.
 
 Code Insights only supports git based repositories and does not support perforce repositories that have sub-repo permissions enabled.
 
-<Callout type="note"> Perforce depots converted to git are also currently not supported for Code Insights </Callout>
+<Callout type="note"> Perforce depots converted to git are also currently not supported for Code Insights.</Callout>
 
 ## Feature parity limitations
 

--- a/docs/code_insights/explanations/current_limitations_of_code_insights.mdx
+++ b/docs/code_insights/explanations/current_limitations_of_code_insights.mdx
@@ -81,6 +81,8 @@ Code Insights does not yet support running over specific revisions.
 
 Code Insights only supports git based repositories and does not support perforce repositories that have sub-repo permissions enabled.
 
+<Callout type="note"> Perforce depots converted to git are also currently not supported for Code Insights </Callout>
+
 ## Feature parity limitations
 
 ### Features currently available only on insights over all your repositories


### PR DESCRIPTION
<!-- Explain the changes introduced in your PR -->

## Pull Request approval
This PR adds a callout to guide customers who may have converted their Perforce depots to git but might encounter an issue where code insights are still not available on those depots.

Although pull request approval is not enforced for this repository in order to reduce friction, merging without a review will generate a ticket for the docs team to review your changes. So if possible, have your pull request approved before merging.
