### PR TITLE
Update docker-compose version instructions

### DIFF
--- a/docs/admin/deploy/docker-compose/index.mdx
+++ b/docs/admin/deploy/docker-compose/index.mdx
@@ -92,7 +92,7 @@ For example, GitHub users can include their personal access token to clone repos
 https://<PERSONAL-ACCESS-TOKEN>@github.com/<USERNAME>/<REPO>.git
 ```
 
-#### Configure your deployment repository
+### Configure your deployment repository
 
 Continue with the following steps *after* you have created a public or private copy of the [deployment repository](https://github.com/sourcegraph/deploy-sourcegraph-docker/):
 
@@ -116,8 +116,9 @@ Continue with the following steps *after* you have created a public or private c
   - It also allows us to track all of the customizations made to your Sourcegraph instance.
 
 ```bash
-  # Specify the version you want to install
-  export SOURCEGRAPH_VERSION="v5.3.9104"
+  # Specify the version you want to install - find the latest version at sourcegraph.com/changelog
+  # Version should be formatted as "vX.X.XX", e.g. "v5.6.2535"
+  export SOURCEGRAPH_VERSION=""
   # Check out the selected version for use, in a new branch called "release"
   git checkout $SOURCEGRAPH_VERSION -b release
 ```


### PR DESCRIPTION
Removes static reference to an old version of Sourcegraph in the docker-compose instructions. TBD on how to make this dynamic so we don't have to manually update it in the docs.