### PR TITLE
Remove cody.enable step when getting verbose logs and use export logs command

### DIFF
--- a/docs/cody/troubleshooting.mdx
+++ b/docs/cody/troubleshooting.mdx
@@ -22,6 +22,7 @@ VS Code logs can be accessed via the **Outputs** view. You will need to set Cody
 - You can now see the logs in the Outputs view
 - Open the view via the menu bar: `View > Output`
 - Select **Cody by Sourcegraph** from the dropdown list
+- You can export the logs by using the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows/Linux) and searching for the "Cody Debug: Export Logs" command
 
 ![View Cody's autocomplete logs from the Output View in VS Code](https://storage.googleapis.com/sourcegraph-assets/Docs/autocomplete-logs.png)
 

--- a/docs/cody/troubleshooting.mdx
+++ b/docs/cody/troubleshooting.mdx
@@ -15,9 +15,9 @@ If you're experiencing issues with Cody not responding in chat, follow these ste
 
 ### Access Cody logs
 
-VS Code logs can be accessed via the **Outputs** view. To access logs, you need to enable Cody logs in verbose mode. To do so:
+VS Code logs can be accessed via the **Outputs** view. You will need to set Cody to verbose mode to ensure important information to debug is on the logs. To do so:
 
-- Go to the Cody Extension Settings and enable: `Cody › Debug: Enable` and `Cody › Debug: Verbose`
+- Go to the Cody Extension Settings and enable: `Cody › Debug: Verbose`
 - Restart or reload your VS Code editor
 - You can now see the logs in the Outputs view
 - Open the view via the menu bar: `View > Output`


### PR DESCRIPTION

Since 1.16.0 we no longer need to enable cody debug it is enabled by default. This updates doc to remove this and also use the export logs command for easier log retrieval