### PR TITLE
docs(cody): add documentation for using custom API keys

### DIFF
--- a/docs/cody/faq.mdx
+++ b/docs/cody/faq.mdx
@@ -102,7 +102,7 @@ Please refer to this [terms and conditions](https://about.sourcegraph.com/terms/
 
 ### Can I use my own API keys?
 
-Yes! you can use your own API keys (Enterprise Users Only).
+Yes, [you can use your own API keys](https://sourcegraph.com/docs/cody/clients/install-vscode#experimental-models).
 
 ### Can I use Cody with my Cloud IDE?
 

--- a/docs/cody/faq.mdx
+++ b/docs/cody/faq.mdx
@@ -102,7 +102,7 @@ Please refer to this [terms and conditions](https://about.sourcegraph.com/terms/
 
 ### Can I use my own API keys?
 
-Yes, [you can use your own API keys](https://sourcegraph.com/docs/cody/clients/install-vscode#experimental-models).
+Yes, [you can use your own API keys](https://sourcegraph.com/docs/cody/clients/install-vscode#experimental-models). However, this is an experimental feature. Bring-your-own-API-key is fully supported in the Enterprise plan.
 
 ### Can I use Cody with my Cloud IDE?
 


### PR DESCRIPTION
- Add documentation for using custom API keys with Cody
- Link to the relevant section in the VSCode extension install guide