### PR TITLE
Clarify what name to use in alloworgsmap

### DIFF
--- a/docs/admin/auth/index.mdx
+++ b/docs/admin/auth/index.mdx
@@ -89,7 +89,7 @@ Then add the following lines to your site configuration:
       "clientSecret": "replace-with-the-oauth-client-secret",
       "allowSignup": false,  // CAUTION: Set to true to enable signup. If nothing is specified in `allowOrgs` or `allowOrgsMap`, any GitHub user can sign up.
       "allowOrgs": ["your-org-name"], // Restrict logins and sign-ups if enabled to members of these orgs.
-      "allowOrgsMap": { "orgName": ["your-team-name"]} // Restrict logins and sign-ups if enabled to members of teams that belong to a given org.
+      "allowOrgsMap": { "orgName": ["Your Team Name"]} // Restrict logins and sign-ups if enabled to members of teams that belong to a given org.
     }
   ]
 }
@@ -154,15 +154,20 @@ When combined with `"allowSignup": false` or unset, an admin should first create
 
   Note that subteams inheritance is not supported — the name of child teams (subteams) should be informed so their members can be granted access to Sourcegraph.
 
+  When configuring teams in allowOrgsMap, use the team's display name. If the team names do not match exactly, users will be unable to create an account.
+
   ```json
     {
        "type": "github",
       // ...
       "allowOrgsMap": {
         "org1": [
-          "team1", "subteam1"
+          "Your Team Name"
         ],
         "org2": [
+          "team1", "subteam1"
+        ],
+        "org3": [
           "subteam2"
         ]
       }


### PR DESCRIPTION
We use the "name" field from the GitHub API response to match the name in alloworgsmap. For example, "Team Name" will work, but "team-name" won't.

    "name": "Team Name",

https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#list-teams-for-the-authenticated-user

https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@07ca65aec65a8ce528846277127b061e98a825ee/-/blob/cmd/frontend/internal/auth/githuboauth/session.go?L286

<!-- Explain the changes introduced in your PR -->

## Pull Request approval

Although pull request approval is not enforced for this repository in order to reduce friction, merging without a review will generate a ticket for the docs team to review your changes. So if possible, have your pull request approved before merging.
