### PR TITLE
Make the SRC_HEADER_ env variable a little bit more discoverable

### DIFF
--- a/docs/cli/explanations/env.mdx
+++ b/docs/cli/explanations/env.mdx
@@ -22,7 +22,7 @@ If the environment variable is not set, it'll default to "https://sourcegraph.co
 
 To create an access token, please refer to "[Creating an access token](/cli/how-tos/creating_an_access_token)".
 
-## Adding request headers with `SRC_HEADER_`
+## Adding request headers with `SRC_HEADER_` (Proxy Authentication with `src`)
 
 If your instance is behind an authenticating proxy that requires additional headers, they can be supplied via environment variables. Any environment variable passed starting with the string `SRC_HEADER_{string-A}="String-B"` will be passed into the request with form `String-A: String-B`. See examples below:
 


### PR DESCRIPTION
Added a little bit more discoverability to our `SRC_HEADER_` section