### PR TITLE
Updated editorId Property to editorIds open_in_editor.mdx

### DIFF
--- a/docs/integration/open_in_editor.mdx
+++ b/docs/integration/open_in_editor.mdx
@@ -50,7 +50,7 @@ To open repository files in your Documents directory:
 ```json
 {
   "openInEditor": {
-    "editorId": "idea",
+    "editorIds": ["idea"],
     "projectPaths.default": "/Users/USERNAME/Documents"
   }
 }
@@ -84,7 +84,7 @@ To open repository files in your Documents directory:
 ```json
 {
   "openInEditor": {
-    "editorId": "vscode",
+    "editorIds": ["vscode"],
     "projectPaths.default": "/Users/USERNAME/Documents"
   }
 }
@@ -97,7 +97,7 @@ To open repository files in your Documents directory:
 ```json
 {
   "openInEditor": {
-    "editorId": "vscode",
+    "editorIds": ["vscode"],
     "projectPaths.default": "C:\Users\USERNAME\Documents"
   }
 }
@@ -110,7 +110,7 @@ To open repository files in your Home directory:
 ```json
 {
   "openInEditor": {
-    "editorId": "vscode",
+    "editorIds": ["vscode"],
     "projectPaths.default": "//wsl$/Ubuntu-18.04/home"
   }
 }
@@ -134,7 +134,7 @@ Uses the assigned path for the detected Operating System when available:
 ```json
 {
   "openInEditor": {
-    "editorId": "vscode",
+    "editorIds": ["vscode"],
     // basePath is required as the default path when no Operating System is detected
     "projectPaths.default": "/Users/USERNAME/Documents/",
     "projectPaths.windows": "/C:/Users/USERNAME/folder/",
@@ -153,7 +153,7 @@ To open directory where the repository files reside in a remote server:
 ```json
 {
   "openInEditor": {
-    "editorId": "custom",
+    "editorIds": ["custom"],
     "projectPaths.default": "/Users/USERNAME/Documents/",
     // Replaces USER@HOSTNAME as appropriate.
     "custom.urlPattern": "vscode://vscode-remote/ssh-remote+USER@HOSTNAME%file",
@@ -170,7 +170,7 @@ Adds `sourcegraph-` in front of the string that matches the `(?<=Documents\/)(.*
 ```json
 {
   "openInEditor": {
-    "editorId": "vscode",
+    "editorIds": ["vscode"],
     "projectPaths.default": "/Users/USERNAME/Documents/",
     "replacements": { "(?<=Documents\/)(.*[\\\/])": "sourcegraph-$1" }
     // vscode://file//Users/USERNAME/Documents/REPO-NAME/package.json => vscode://file//Users/USERNAME/Documents/sourcegraph-REPO-NAME/package.json
@@ -185,7 +185,7 @@ Removes `sourcegraph-` from the final URL.
 ```json
 {
   "openInEditor": {
-    "editorId": "vscode",
+    "editorIds": ["vscode"],
     "projectPaths.default": "/Users/USERNAME/Documents/",
     "replacements": { "sourcegraph-": "" }
     // vscode://file//Users/USERNAME/Documents/sourcegraph-REST-OF_REPO-NAME/package.json => vscode://file//Users/USERNAME/Documents/REST-OF_REPO-NAME/package.json


### PR DESCRIPTION
The editorId property has been updated to editorIds. The use of the editorId property will now result in an error, as it is no longer supported. Updating the configurations to use the new editorIds list format to avoid issues.


## Pull Request approval

Although pull request approval is not enforced for this repository in order to reduce friction, merging without a review will generate a ticket for the docs team to review your changes. So if possible, have your pull request approved before merging.
