### PR TITLE
Update model config docs

### DIFF
--- a/docs/cody/clients/model-configuration.mdx
+++ b/docs/cody/clients/model-configuration.mdx
@@ -42,7 +42,10 @@ This requires site-admin privileges. To do so,
 ```json
     {
       // [...]
-      "cody.enabled": true
+      "cody.enabled": true,
+      "completions": {
+        "provider": "sourcegraph"
+      }
     }
 ```
 
@@ -319,6 +322,7 @@ The simplest way to configure your Sourcegraph Enterprise would be to add the fo
 
 ```json
   ...
+  "cody.enabled": true,
   "modelConfiguration": {
     "sourcegraph": {}
   },
@@ -360,6 +364,7 @@ The `"allow"` and `"deny"` fields, are arrays of [model references](#model-confi
 The following examples illustrate how to use all these settings in conjunction:
 
 ```json
+"cody.enabled": true,
 "modelConfiguration": {
   "sourcegraph": {
     "modelFilters": {
@@ -390,6 +395,7 @@ The `"modelConfiguration"` setting also contains a `"defaultModels"` field that 
 
 ```json
   ...
+  "cody.enabled": true,
   "modelConfiguration": {
     "defaultModels": {
       "chat": "anthropic::2023-06-01::claude-3.5-sonnet",
@@ -421,6 +427,7 @@ By defining a provider override in your Sourcegraph site configuration, you are 
 The following configuration shippet defines a single provider override with the ID `"anthropic"`.
 
 ```json
+"cody.enabled": true,
 "modelConfiguration": {
   // Do not use any Sourcegraph-supplied models.
   "sourcegraph": null,
@@ -487,6 +494,7 @@ With a provider defined, we can now specify custom models using that provider by
 The following configuration snippet defines a custom model, using the `"anthropic"` provider from the previous example.
 
 ```json
+"cody.enabled": true,
 "modelConfiguration": {
   ...
   "modelOverrides": [


### PR DESCRIPTION
<!-- Explain the changes introduced in your PR -->
Ideally, setting `"cody.enabled": true` in the site config should be sufficient to enable Cody with the default configuration. However, we discovered a bug where this isn’t currently the case. Without specifying the `"completions"` or `"modelConfiguration"` fields, the default Cody setup doesn’t work as expected. This PR updates the code examples on the model configuration page to clarify that the `"cody.enabled": true` field must always be accompanied by either the `"completions"` or `"modelConfiguration"` fields (for more details see https://github.com/sourcegraph/sourcegraph/pull/839).

## Pull Request approval

Although pull request approval is not enforced for this repository in order to reduce friction, merging without a review will generate a ticket for the docs team to review your changes. So if possible, have your pull request approved before merging.
