### PR TITLE
Add guidance for Android Studio for JCEF

### DIFF
--- a/docs/cody/troubleshooting.mdx
+++ b/docs/cody/troubleshooting.mdx
@@ -168,3 +168,18 @@ If you notice the Cody agent reaching 100% CPU utilization, try the following:
 1. Disable the Cody plugin.
 1. Re-enable the plugin.
 This simple action of turning the plugin off and on again can often resolve the high CPU usage issue.
+
+
+
+## Androud Studio extension
+
+### Cody cannot start. Stuck on spinning icon.
+
+This issue occurs because JCEF isn't supported in Android Studio and causes Cody not to start. The suggested workaround is to;
+
+1. Go to `Help` > `Find Action: Registry`.
+1. Scroll to `ide.browser.jcef.sandbox.enable`.
+1. Disable that key and close.
+1. Then go to `Help` > `Find Action: Choose Boot runtime for the IDE`.
+1. Select the last option.
+1. Restart Android Studion.


### PR DESCRIPTION
<!-- Explain the changes introduced in your PR -->
This update introduces a workaround for web view JCEF for Android Studio which isn't supported out of the box and causes Cody not to start and get stuck on the spinning icon.
## Pull Request approval

Although pull request approval is not enforced for this repository in order to reduce friction, merging without a review will generate a ticket for the docs team to review your changes. So if possible, have your pull request approved before merging.
