### PR TITLE
Mark scip-clang as generally available

### DIFF
--- a/docs/code-search/code-navigation/precise_code_navigation.mdx
+++ b/docs/code-search/code-navigation/precise_code_navigation.mdx
@@ -40,7 +40,7 @@ Precise Code Navigation requires language-specific indexes to be generated and u
 | ---------------------- | --------------------------------------------------------------------------------- | --------------------- |
 | Go                     | [scip-go](https://sourcegraph.com/github.com/sourcegraph/scip-go)                 | 🟢 Generally available |
 | TypeScript, JavaScript | [scip-typescript](https://sourcegraph.com/github.com/sourcegraph/scip-typescript) | 🟢 Generally available |
-| C, C++                 | [scip-clang](https://sourcegraph.com/github.com/sourcegraph/scip-clang)           | 🟡 Partially available |
+| C, C++, CUDA           | [scip-clang](https://sourcegraph.com/github.com/sourcegraph/scip-clang)           | 🟢 Generally available |
 | Java, Kotlin, Scala    | [scip-java](https://sourcegraph.com/github.com/sourcegraph/scip-java)             | 🟢 Generally available |
 | Rust                   | [rust-analyzer](https://sourcegraph.com/github.com/rust-lang/rust-analyzer)       | 🟢 Generally available |
 | Python                 | [scip-python](https://sourcegraph.com/github.com/sourcegraph/scip-python)         | 🟢 Generally available |


### PR DESCRIPTION
Forgot to update this table earlier.