### PR TITLE
Adds warning for bypassing duplicate email validation with allowSignup

### DIFF
--- a/docs/admin/auth/builtin.mdx
+++ b/docs/admin/auth/builtin.mdx
@@ -45,6 +45,10 @@ If enabled, new users can create a new account through this form, and log in to 
 
 ### Allow new users to request an account
 
+<Callout type="warning>
+For security reasons, `allowSignup` will bypass validation protecting against duplicate user emails. We recommend enabling this feature only if users are not being provisioned by other means.
+</Callout>
+
 When `allowSignup` is not set, or set to `false`, users will see a request account link instead.
 
 ![Login form with request access link](https://storage.googleapis.com/sourcegraph-assets/docs/images/admin/auth/login_request-access.png)


### PR DESCRIPTION
Per the conversation [here](https://sourcegraph.slack.com/archives/C05EMJM2SLR/p1727970897499269) we do not validate duplicate emails when creating users via allowSignup. This adds a warning to the docs explaining as such.