### PR TITLE
Quick fix technical changelog v5.8.1579

### DIFF
--- a/docs/technical-changelog.mdx
+++ b/docs/technical-changelog.mdx
@@ -4,7 +4,14 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 
 {/* CHANGELOG_START */}
 
+
 # sourcegraph 5 Release 8 Patch 1
+
+## v5.8.1579
+- [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.8.1579)
+- [docker-compose](https://github.com/sourcegraph/deploy-sourcegraph-docker/releases/tag/v5.8.1579)
+- [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.8.1579)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.8.1579)
 
 ### Features
 


### PR DESCRIPTION
This is a quick fix patch associated to https://linear.app/sourcegraph/issue/REL-490/add-semver-version-to-technical-changelog

<img width="1078" alt="Screenshot 2024-10-25 at 6 34 13 PM" src="https://github.com/user-attachments/assets/9d121219-4269-4567-a19d-16fe2ef9f8f4">

This addresses feedback that operationally users couldn't find the correct version tag for the release via the new changelog

The devx release tooling will be updated to generate releases of this form in subsequent releases. 

In progress generator fix: https://github.com/sourcegraph/devx-service/pull/284

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
