### PR TITLE
chore(changelog): backfill the releases, including captialization

### DIFF
--- a/docs/technical-changelog.mdx
+++ b/docs/technical-changelog.mdx
@@ -5,7 +5,7 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 {/* CHANGELOG_START */}
 
 
-# sourcegraph 5 Release 8 Patch 1
+# Sourcegraph 5 Release 8 Patch 1
 
 ## v5.8.1579
 - [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.8.1579)
@@ -51,8 +51,13 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 
 {/* RSS={"version":"sourcegraph 5 Release 8 Patch 1", "releasedAt": "2024-10-16"} */}
 
+# Sourcegraph 5 Release 8 Patch 0
 
-# v5.8.0
+## v5.8.0
+- [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.8.0)
+- [docker-compose](https://github.com/sourcegraph/deploy-sourcegraph-docker/releases/tag/v5.8.0)
+- [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.8.0)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.8.0)
 
 ### Features
 
@@ -654,8 +659,13 @@ The following PRs were merged onto the previous release branch but could not be 
 
 {/* RSS={"version":"v5.8.0", "releasedAt": "2024-10-08"} */}
 
+# Sourcegraph 5 Release 7 Patch 1
 
-# v5.7.2474
+## v5.7.2474
+- [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.7.2474)
+- [docker-compose](https://github.com/sourcegraph/deploy-sourcegraph-docker/releases/tag/v5.7.2474)
+- [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.7.2474)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.7.2474)
 
 ### Fix
 
@@ -687,8 +697,13 @@ The following PRs were merged onto the previous release branch but could not be 
 
 {/* RSS={"version":"v5.7.2474", "releasedAt": "2024-09-18"} */}
 
+# Sourcegraph 5 Release 7 Patch 0
 
-# v5.7.0
+## v5.7.0
+- [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.7.0)
+- [docker-compose](https://github.com/sourcegraph/deploy-sourcegraph-docker/releases/tag/v5.7.0)
+- [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.7.0)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.7.0)
 
 ### Features
 
@@ -1125,8 +1140,13 @@ The following PRs were merged onto the previous release branch but could not be 
 
 {/* RSS={"version":"v5.7.0", "releasedAt": "2024-09-04"} */}
 
+# Sourcegraph 5 Release 6 Patch 2
 
-# v5.6.2535
+## v5.6.2535
+- [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.6.2535)
+- [docker-compose](https://github.com/sourcegraph/deploy-sourcegraph-docker/releases/tag/v5.6.2535)
+- [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.6.2535)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.6.2535)
 
 {/* RSS={"version":"v5.6.2535", "releasedAt": "2024-08-22"} */}
 
@@ -1151,7 +1171,13 @@ The following PRs were merged onto the previous release branch but could not be 
 - [Backport 5.6.x] feat(cody): add deepseek-coder-v2-lite-base support [#103](https://github.com/sourcegraph/sourcegraph/pull/103) Backport f71fe081aa43ca40fef66c067c8eaf49d62d491e from #4
 - backporting #106 [#107](https://github.com/sourcegraph/sourcegraph/pull/107)
 
-# v5.6.185
+# Sourcegraph 5 Release 6 Patch 1
+
+## v5.6.185
+- [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.6.185)
+- [docker-compose](https://github.com/sourcegraph/deploy-sourcegraph-docker/releases/tag/v5.6.185)
+- [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.6.185)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.6.185)
 
 {/* RSS={"version":"v5.6.185", "releasedAt": "2024-08-08"} */}
 
@@ -1161,7 +1187,13 @@ The following PRs were merged onto the previous release branch but could not be 
 - [Backport 5.6.x] Fix Cody Web CSS [#64373](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/64373)
   - Make Cody Web styles more accessible.  Backport 2dd38b3ffd828a1596249c2780ca91bf4bce4bdd from #64370
 
-# v5.6.0
+# Sourcegraph 5 Release 6 Patch 0
+
+## v5.6.0
+- [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.6.0)
+- [docker-compose](https://github.com/sourcegraph/deploy-sourcegraph-docker/releases/tag/v5.6.0)
+- [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.6.0)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.6.0)
 
 {/* RSS={"version":"v5.6.0", "releasedAt": "2024-08-07"} */}
 


### PR DESCRIPTION
Backfill the old changelogs to be in accordance with the introduction of the canonical name policy: https://sourcegraph.com/docs/releases

See: https://github.com/sourcegraph/devx-service/pull/284#issuecomment-2442864646

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
