### PR TITLE
Add fork:no and archived:no as search considerations

### DIFF
--- a/docs/admin/search.mdx
+++ b/docs/admin/search.mdx
@@ -18,6 +18,10 @@ By default, users cannot set a search timeout larger than 1 minute. Sourcegraph 
   },
 ```
 
+### Forks and Archives
+
+Sourcegraph search defaults to using `fork:no archived:no` as implied search values, excluding [forked](/code-search/queries/language#fork) and [archived](/code-search/queries/language#archived) repositories from search results. If you wish to include forked or achived repositories in your search results you must include the params `fork:yes` or `archived:yes`, respectively. 
+
 ## Exclude files and directories
 
 You can exclude files and directories from search by adding the file `.sourcegraph/ignore` to the root directory of your repository. Sourcegraph interprets each line in the _ignore_ file as a glob pattern. Files or directories matching those patterns will not show up in the search results.


### PR DESCRIPTION
Adds details around the implied fork:no and archived:no search results to search considerations page. This may need to be updated if/when these implied values are removed. 

See Linear comment [here](https://linear.app/sourcegraph/issue/SRCH-1305/morgan-stanley-repo-not-showing-up-in-search-results-unless-specified#comment-161dd719)
