### PR TITLE
Fix(docs): fix character escape in .mdx file

### DIFF
--- a/docs/technical-changelog.mdx
+++ b/docs/technical-changelog.mdx
@@ -4,7 +4,7 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 
 {/* CHANGELOG_START */}
 
-# sourcegraph 5 Release 9 Patch 0
+# Sourcegraph 5 Release 9
 
 ## v5.9.0
 
@@ -126,7 +126,7 @@ that we observed on the user's incoming request
 
 #### Site Admin
 
-- site config 'telemetry: { disableLocalEventLogs }' to disable event_logs [#1275](https://github.com/sourcegraph/sourcegraph/pull/1275)
+- site config 'telemetry: \{ disableLocalEventLogs \}' to disable event_logs [#1275](https://github.com/sourcegraph/sourcegraph/pull/1275)
   - Long-term local retention of user telemetry as 'event logs' can now be disabled entirely via the `telemetry: { disableLocalEventLogs }` site configuration.
 
 #### Sub_repo_perms


### PR DESCRIPTION
.mdx files crash when `{` characters are not escaped. 

Also fix capitalization and remove "patch 0" as this goes against our convention. 

Closes: [REL-507: Fix errors on supported release notes links](https://linear.app/sourcegraph/issue/REL-507/fix-errors-on-supported-release-notes-links)

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
