### PR TITLE
fix(rel): remove patch suffix

### DIFF
--- a/docs/technical-changelog.mdx
+++ b/docs/technical-changelog.mdx
@@ -722,7 +722,7 @@ The following PRs were merged onto the previous release branch but could not be 
 
 {/* RSS={"version":"sourcegraph 5 Release 8 Patch 1", "releasedAt": "2024-10-16"} */}
 
-# Sourcegraph 5 Release 8 Patch 0
+# Sourcegraph 5 Release 8
 
 ## v5.8.0
 - [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.8.0)
@@ -1368,7 +1368,7 @@ The following PRs were merged onto the previous release branch but could not be 
 
 {/* RSS={"version":"v5.7.2474", "releasedAt": "2024-09-18"} */}
 
-# Sourcegraph 5 Release 7 Patch 0
+# Sourcegraph 5 Release 7
 
 ## v5.7.0
 - [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.7.0)
@@ -1858,7 +1858,7 @@ The following PRs were merged onto the previous release branch but could not be 
 - [Backport 5.6.x] Fix Cody Web CSS [#64373](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/64373)
   - Make Cody Web styles more accessible.  Backport 2dd38b3ffd828a1596249c2780ca91bf4bce4bdd from #64370
 
-# Sourcegraph 5 Release 6 Patch 0
+# Sourcegraph 5 Release 6
 
 ## v5.6.0
 - [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.6.0)


### PR DESCRIPTION
Patch 0 isn't needed and is not part of our official naming scheme. Removing these manually now with followup on the source issue later.

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
