### PR TITLE
chore(release): One last run at Canonical Names (Backfill)

### DIFF
--- a/docs/technical-changelog.mdx
+++ b/docs/technical-changelog.mdx
@@ -54,7 +54,7 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 {/* RSS={"version":"v5.9.45", "releasedAt": "2024-11-05"} */}
 
 
-# 5.9
+# 5.9 Patch 0
 
 ## v5.9.0
 
@@ -764,7 +764,7 @@ The following PRs were merged onto the previous release branch but could not be 
 
 {/* RSS={"version":"sourcegraph 5 Release 8 Patch 1", "releasedAt": "2024-10-16"} */}
 
-# 5.8
+# 5.8 Patch 0
 
 ## v5.8.0
 - [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.8.0)
@@ -1410,7 +1410,7 @@ The following PRs were merged onto the previous release branch but could not be 
 
 {/* RSS={"version":"v5.7.2474", "releasedAt": "2024-09-18"} */}
 
-# 5.7
+# 5.7 Patch 0
 
 ## v5.7.0
 - [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.7.0)
@@ -1900,7 +1900,7 @@ The following PRs were merged onto the previous release branch but could not be 
 - [Backport 5.6.x] Fix Cody Web CSS [#64373](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/64373)
   - Make Cody Web styles more accessible.  Backport 2dd38b3ffd828a1596249c2780ca91bf4bce4bdd from #64370
 
-# 5.6
+# 5.6 Patch 0
 
 ## v5.6.0
 - [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.6.0)


### PR DESCRIPTION
One last run at Canonical Names (Backfill)

See internal conv: https://sourcegraph.slack.com/archives/C02E4HE42BX/p1730917823118489?thread_ts=1730801659.955189&cid=C02E4HE42BX

<img width="1060" alt="Screenshot 2024-11-06 at 12 14 48 PM" src="https://github.com/user-attachments/assets/d75eb70f-1527-4af1-a894-d5232aae4b19">

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
