### PR TITLE
Point git-stats link to sourcegraph-public-snapshot

### DIFF
--- a/docs/admin/monorepo.mdx
+++ b/docs/admin/monorepo.mdx
@@ -27,12 +27,12 @@ Some monorepos use a custom command for `git fetch` to speed up fetch. Sourcegra
 
 ## Statistics
 
-You can help the Sourcegraph developers understand the scale of your monorepo by sharing some statistics with the team. The bash script [`git-stats`](https://github.com/sourcegraph/sourcegraph/blob/main/dev/git-stats) when run in your git repository will calculate these statistics.
+You can help the Sourcegraph developers understand the scale of your monorepo by sharing some statistics with the team. The bash script [`git-stats`](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/dev/git-stats) when run in your git repository will calculate these statistics.
 
 Example output on the Sourcegraph repository:
 
 ``` shellsession
-$ wget https://github.com/sourcegraph/sourcegraph/raw/main/dev/git-stats
+$ wget https://github.com/sourcegraph/sourcegraph-public-snapshot/raw/main/dev/git-stats
 $ chmod +x git-stats
 $ ./git-stats
 725M	. gitdir


### PR DESCRIPTION
There are quite a few other links which should be updated which I will look into later. Given this repository is now frozen, it might make sense to host this script in the docs repository?