### PR TITLE
Fix broken URL in quickstart.mdx

### DIFF
--- a/docs/cli/quickstart.mdx
+++ b/docs/cli/quickstart.mdx
@@ -8,7 +8,7 @@ In this guide, you'll install the Sourcegraph CLI, `src`, connect it to your Sou
 
 ## Installation
 
-`src` is shipped as a single, standalone binary. You can get the latest release by following the instructions for your operating system below (check out the [repository](https://sourcegraph.com/github.com/sourcegraph/src-cli) for additional documentation):
+`src` is shipped as a single, standalone binary. You can get the latest release by following the instructions for your operating system below (check out the [repository](https://github.com/sourcegraph/src-cli) for additional documentation):
 
 ### macOS
 


### PR DESCRIPTION
Found this bad URL when reviewing the docs