### PR TITLE
all: update links to sourcegraph blobs to public snapshot

### DIFF
--- a/docs/admin/code_hosts/go.mdx
+++ b/docs/admin/code_hosts/go.mdx
@@ -28,7 +28,7 @@ Each entry in the `"urls"` array can contain basic auth if needed (e.g. `https:/
 ## Rate limiting
 
 By default, requests to the Go module proxies will be rate-limited
-based on a default internal limit. ([source](https://github.com/sourcegraph/sourcegraph/blob/main/schema/go-modules.schema.json))
+based on a default internal limit. ([source](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/schema/go-modules.schema.json))
 
 ```json
 "rateLimit": {

--- a/docs/admin/code_hosts/non-git.mdx
+++ b/docs/admin/code_hosts/non-git.mdx
@@ -114,4 +114,4 @@ For more complex setups, configure your `src-expose` by providing a local config
 src-expose -snapshot-config config.yaml
 ```
 
-See [an example YAML file containing available configuration options](https://github.com/sourcegraph/sourcegraph/blob/main/dev/src-expose/examples/example.yaml).
+See [an example YAML file containing available configuration options](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/dev/src-expose/examples/example.yaml).

--- a/docs/admin/deploy/kubernetes/index.mdx
+++ b/docs/admin/deploy/kubernetes/index.mdx
@@ -1105,7 +1105,7 @@ Some Persistent Volumes may be retained after the uninstall phase is complete. I
 [AWS EBS CSI driver]: https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
 [NGINX Ingress Controller]: https://github.com/kubernetes/ingress-nginx
 [Helm Changelog]: https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG
-[Sourcegraph Changelog]: https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG
+[Sourcegraph Changelog]: https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG
 [Sourcegraph Migrator]: https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph-migrator
 [Helm Diff]: https://github.com/databus23/helm-diff
 [Secrets]: https://kubernetes.io/docs/concepts/configuration/secret/

--- a/docs/admin/executors/deploy_executors_terraform.mdx
+++ b/docs/admin/executors/deploy_executors_terraform.mdx
@@ -410,7 +410,7 @@ Next, you can test whether the number of executors rises and shrinks as load spi
 ## Upgrading executors
 
 Upgrading executors is relatively uninvolved. Simply follow the instructions below.
-Also, check the [changelog](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG) for any Executors related breaking changes or new features or flags that you might want to configure. See [Executors maintenance](/admin/executors/deploy_executors#Maintaining-and-upgrading-executors) for version compatability.
+Also, check the [changelog](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG) for any Executors related breaking changes or new features or flags that you might want to configure. See [Executors maintenance](/admin/executors/deploy_executors#Maintaining-and-upgrading-executors) for version compatability.
 
 ### **Step 1:** Update the source version of the terraform modules
 

--- a/docs/admin/external_services/postgres.mdx
+++ b/docs/admin/external_services/postgres.mdx
@@ -122,7 +122,7 @@ In order to enable IAM Auth, you first need to:
   - For EKS (k8s deployment), use [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
   - For EC2 (docker-compose deployment), use [IAM roles for Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
 
-For [every services that require postgres database connection](https://github.com/sourcegraph/sourcegraph/blob/main/lib/servicecatalog/service-catalog.yaml), ensure below environment variables are configured:
+For [every services that require postgres database connection](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/lib/servicecatalog/service-catalog.yaml), ensure below environment variables are configured:
 
 - `PG_CONNECTION_UPDATER=EC2_ROLE_CREDENTIALS`
 - `PGSSLMODE=require`
@@ -315,7 +315,7 @@ The first migration fails since it attempts to add `COMMENT`s to installed exten
 failed to run migration for schema "frontend": failed upgrade migration 1528395834: ERROR: current transaction is aborted, commands ignored until end of transaction block (SQLSTATE 25P02)
 ```
 
-In this case, locate the UP [migration 1528395834](https://github.com/sourcegraph/sourcegraph/blob/main/migrations/frontend/1528395834_squashed_migrations.up.sql) and apply all SQL after the final `COMMENT ON EXTENSION` command following the [dirty database procedure](/admin/how-to/dirty_database).
+In this case, locate the UP [migration 1528395834](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/migrations/frontend/1528395834_squashed_migrations.up.sql) and apply all SQL after the final `COMMENT ON EXTENSION` command following the [dirty database procedure](/admin/how-to/dirty_database).
 
 **Dropping the `sg_service` role**
 

--- a/docs/admin/how-to/dirty_database.mdx
+++ b/docs/admin/how-to/dirty_database.mdx
@@ -84,7 +84,7 @@ Migration definitions for each database schema can be found in the children of t
 
 **Find the target migration with the version number identified in [step 1](#1-identify-incomplete-migration)**.
 
-**Run the code from the identified `<version>/up.sql` file explicitly using the `psql` CLI**. For example, if we take `version=1644515056` as an example, we can run the contents of [up migration file](https://github.com/sourcegraph/sourcegraph/blob/b20107113548ed7eeb8ba22d1fdb41e8d692cf18/migrations/frontend/1644515056/up.sql) via psql.
+**Run the code from the identified `<version>/up.sql` file explicitly using the `psql` CLI**. For example, if we take `version=1644515056` as an example, we can run the contents of [up migration file](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/b20107113548ed7eeb8ba22d1fdb41e8d692cf18/migrations/frontend/1644515056/up.sql) via psql.
 
 ```bash
 $ psql -h ... -U sg

--- a/docs/admin/how-to/dirty_database_pre_3_37.mdx
+++ b/docs/admin/how-to/dirty_database_pre_3_37.mdx
@@ -96,4 +96,4 @@ Additionally Grafana will alert you of an index is in this state. _The Grafana a
 ## Further resources
 
 * [Sourcegraph - Upgrading Sourcegraph to a new version](/admin/updates)
-* [Migrations README](https://github.com/sourcegraph/sourcegraph/blob/main/migrations/README) (Note some of the info contained here pertains to running Sourcegraphs development environment and should not be used on production instances)
+* [Migrations README](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/migrations/README) (Note some of the info contained here pertains to running Sourcegraphs development environment and should not be used on production instances)

--- a/docs/admin/http_https_configuration.mdx
+++ b/docs/admin/http_https_configuration.mdx
@@ -19,7 +19,7 @@ Sourcegraph's single Docker image and Kubernetes deployments use [NGINX](https:/
 
 ### Sourcegraph single instance (Docker)
 
-The first time Sourcegraph is run, it will create an [`nginx.conf`](https://github.com/sourcegraph/sourcegraph/blob/main/cmd/server/shared/assets/nginx.conf) file at:
+The first time Sourcegraph is run, it will create an [`nginx.conf`](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/cmd/server/shared/assets/nginx.conf) file at:
 
 - `~/.sourcegraph/config/nginx.conf` on the Docker/Sourcegraph host (presuming you're using the [quickstart `docker run` command](/#quick-install))
 - `/etc/sourcegraph/nginx.conf` inside the container

--- a/docs/admin/postgres.mdx
+++ b/docs/admin/postgres.mdx
@@ -67,7 +67,7 @@ Generally, no additional steps are required to upgrade the databases shipped alo
 
 #### Sourcegraph with Kubernetes
 
-**The upgrade process is different for [Sourcegraph Kubernetes deployments](/admin/deploy/kubernetes/)** because [by default](https://github.com/sourcegraph/sourcegraph/blob/main/docker-images/postgres-12/build.sh#L10), it uses `sourcegraph/postgres-12` which can be [customized with environment variables](https://github.com/sourcegraph/deploy-sourcegraph/blob/7edcadb/docs/configure#external-postgres).
+**The upgrade process is different for [Sourcegraph Kubernetes deployments](/admin/deploy/kubernetes/)** because [by default](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/docker-images/postgres-12/build.sh#L10), it uses `sourcegraph/postgres-12` which can be [customized with environment variables](https://github.com/sourcegraph/deploy-sourcegraph/blob/7edcadb/docs/configure#external-postgres).
 
 If you have changed `PGUSER`, `PGDATABASE` or `PGDATA`, then the `PG*OLD` and `PG*NEW` environment variables are
 required. Below are the defaults and documentation on what each variable is used for:

--- a/docs/admin/ssl_https_self_signed_cert_nginx.mdx
+++ b/docs/admin/ssl_https_self_signed_cert_nginx.mdx
@@ -50,7 +50,7 @@ Run `sudo ls -la ~/.sourcegraph/config` and you should see the CA and SSL certif
 ## 3. Adding SSL support to NGINX
 
 Edit the [default
-`~/.sourcegraph/config/nginx.conf`](https://github.com/sourcegraph/sourcegraph/blob/main/cmd/server/shared/assets/nginx.conf),
+`~/.sourcegraph/config/nginx.conf`](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/cmd/server/shared/assets/nginx.conf),
 so that port `7080` redirects to `7443` and `7443` is served with SSL. It should look like this:
 
 ```nginx

--- a/docs/code-search/code-navigation/how-to/adding_lsif_to_workflows.mdx
+++ b/docs/code-search/code-navigation/how-to/adding_lsif_to_workflows.mdx
@@ -195,7 +195,7 @@ We recommend that you start with a CI job that runs on every commit (including b
 
 If you see too much load on your CI, your Sourcegraph instance, or a rapid decrease in free disk space on your Sourcegraph instance, you can instead index only the default branch, or set up a periodic job (e.g. daily) in CI that indexes your default branch.
 
-With periodic jobs, you should still receive precise code navigation on non-indexed commits on lines that are unchanged since the nearest indexed commit. This requires that the indexed commit be a direct ancestor or descendant no more than [100 commits](https://github.com/sourcegraph/sourcegraph/blob/e7803474dbac8021e93ae2af930269045aece079/lsif/src/shared/constants.ts#L25) away. If your commit frequency is too high and your index frequency is too low, you may find commits with no precise code navigation at all. In this case, we recommend you try to increase your index frequency if possible.
+With periodic jobs, you should still receive precise code navigation on non-indexed commits on lines that are unchanged since the nearest indexed commit. This requires that the indexed commit be a direct ancestor or descendant no more than [100 commits](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/e7803474dbac8021e93ae2af930269045aece079/lsif/src/shared/constants.ts#L25) away. If your commit frequency is too high and your index frequency is too low, you may find commits with no precise code navigation at all. In this case, we recommend you try to increase your index frequency if possible.
 
 ## Uploading indexes to Sourcegraph.com
 

--- a/docs/code-search/code-navigation/search_based_code_navigation.mdx
+++ b/docs/code-search/code-navigation/search_based_code_navigation.mdx
@@ -35,7 +35,7 @@ The symbols container recognizes these environment variables:
 | `ROCKSKIP_MIN_REPO_SIZE_MB`     | N/A                              | In combination with `USE_ROCKSKIP=true` all repos that are at least this big will be indexed using Rockskip                              |
 | `MAX_CONCURRENTLY_INDEXING`     | 4                              | Maximum number of repositories being indexed at a time by [Rockskip](/code-search/code-navigation/rockskip) (also limits ctags processes)                              |
 
-The default values for these environment variables come from [`config.go`](https://github.com/sourcegraph/sourcegraph/blob/eea895ae1a8acef08370a5cc6f24bdc7c66cb4ed/cmd/symbols/config.go#L42-L59).
+The default values for these environment variables come from [`config.go`](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/eea895ae1a8acef08370a5cc6f24bdc7c66cb4ed/cmd/symbols/config.go#L42-L59).
 
 <Callout type="tip">To enable precise code navigation for your repository, see our [docs here](/code-search/code-navigation/precise_code_navigation#setting-up-code-navigation-for-your-codebase).</Callout>
 

--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -41,18 +41,18 @@ These versions fall outside the release lifecycle and are not supported anymore:
 
 | **Release** | **General Availability Date** | **Supported** | **Release Notes**                                                               |
 |-------------|-------------------------------|---------------|---------------------------------------------------------------------------------|
-| 3.43        | August 2022                   | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3432) |
-| 3.42        | July 2022                     | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3422) |
-| 3.41        | June 2022                     | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3422) |
-| 3.40        | May 2022                      | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3402) |
-| 3.39        | April 2022                    | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3391) |
-| 3.38        | March 2022                    | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3391) |
-| 3.37        | February 2022                 | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3391) |
-| 3.36        | January 2022                  | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3363) |
-| 3.35        | December 2021                 | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3352) |
-| 3.34        | November 2021                 | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3352) |
-| 3.33        | October 2021                  | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3332) |
-| 3.32        | September 2021                | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3321) |
-| 3.31        | August 2021                   | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3321) |
-| 3.30        | July 2021                     | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3321) |
-| 3.29        | June 2021                     | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#3321) |
+| 3.43        | August 2022                   | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG.md#3432) |
+| 3.42        | July 2022                     | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG.md#3422) |
+| 3.41        | June 2022                     | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG.md#3422) |
+| 3.40        | May 2022                      | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG.md#3402) |
+| 3.39        | April 2022                    | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG.md#3391) |
+| 3.38        | March 2022                    | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG.md#3391) |
+| 3.37        | February 2022                 | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG.md#3391) |
+| 3.36        | January 2022                  | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG.md#3363) |
+| 3.35        | December 2021                 | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG.md#3352) |
+| 3.34        | November 2021                 | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG.md#3352) |
+| 3.33        | October 2021                  | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG.md#3332) |
+| 3.32        | September 2021                | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG.md#3321) |
+| 3.31        | August 2021                   | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG.md#3321) |
+| 3.30        | July 2021                     | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG.md#3321) |
+| 3.29        | June 2021                     | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG.md#3321) |


### PR DESCRIPTION
I noticed we still have lots of links to our private repository. These links won't work for people outside of the sourcegraph organisation, so we update them to point to the public snapshot repository.

Note: there are other types of links we should probably update, especially around mentioned issues. Those are not tackled in this commit.