### PR TITLE
Specify the need for classic PAT for indexing outside org's private repos

### DIFF
--- a/docs/admin/code_hosts/github.mdx
+++ b/docs/admin/code_hosts/github.mdx
@@ -220,6 +220,8 @@ When creating your fine-grained access token, select the following permissions d
 
 To clone and search private repositories, we need [a GitHub access token](#github-api-access) with the required scopes and at least read access to the relevant private repositories.
 
+<Callout type="note">Due to GitHub limitations, non-admins of an outside organization must use a (Classic personal access token)[https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#types-of-personal-access-tokens] to provision the appropriate permissions for Sourcegraph to index that organization's private repositories.</Callout>
+
 For more details, see [GitHub API access](#github-api-access).
 
 ## Selecting repositories to sync


### PR DESCRIPTION
Follow up to (this ticket)[https://sourcegraph.zendesk.com/agent/tickets/20672]. We don't specify that the PAT needs to be Classic, so I added a <callout> to make it more clear.