### PR TITLE
Remove space in markdown link on cody concepts page

### DIFF
--- a/docs/cody/core-concepts/cody-gateway.mdx
+++ b/docs/cody/core-concepts/cody-gateway.mdx
@@ -8,7 +8,7 @@ Cody Gateway powers the default `"provider": "sourcegraph"` and Cody completions
 
 ## Supported Models
 
-For a full list of supported models and providers, read our [Supported LLMs] (/Cody/capabilities/supported-models) docs.
+For a full list of supported models and providers, read our [Supported LLMs](/Cody/capabilities/supported-models) docs.
 
 ## Setting up Cody Gateway in Sourcegraph Enterprise
 


### PR DESCRIPTION
Remove space causing markdown link to render improperly
![Screenshot 2024-11-25 at 2 52 15 PM](https://github.com/user-attachments/assets/f6ec3251-12a7-45a3-a81f-bdcbfee47d49)
