### PR TITLE
Release Notes 5.10.0

### DIFF
--- a/docs/admin/updates/automatic.mdx
+++ b/docs/admin/updates/automatic.mdx
@@ -1,5 +1,7 @@
 # Automatic multi-version upgrades
 
+> Warning: Automatic upgrades in v5.10.0 will fail unless the postgres database is upgraded from postgres 12 to postgres 16. Or the environment variable `SRC_AUTOUPGRADE_IGNORE_DRIFT=true` is set on the `sourcegraph-frontend` container. 
+
 From **Sourcegraph 5.1 and later**, multi-version upgrades can be performed **automatically** as if they were a standard upgrade for the same deployment type. Automatic multi-version upgrades take the following general form:
 
 1. Determine if your instance is ready to Upgrade:

--- a/docs/admin/updates/docker_compose.mdx
+++ b/docs/admin/updates/docker_compose.mdx
@@ -13,53 +13,15 @@ For upgrade procedures or general info about sourcegraph versioning see the link
 
 ## Unreleased
 
-## v5.2.6 ➔ v5.2.7
+## v5.9.0 ➔ v5.10.0
+
+> Warning: This release updates the database container images from postgres 12 to postres 16, and beings using wolfi based images.
 
 #### Notes:
-
-## v5.2.5 ➔ v5.2.6
-
-#### Notes:
-
-## v5.2.4 ➔ v5.2.5
-
-#### Notes:
-
-## v5.2.3 ➔ v5.2.4
-
-#### Notes:
-
-## v5.2.2 ➔ v5.2.3
-
-#### Notes:
-
-## v5.2.1 ➔ v5.2.2
-
-#### Notes:
-
-## v5.2.0 ➔ v5.2.1
-
-#### Notes:
-
-## v5.1.9 ➔ v5.2.0
-
-#### Notes:
-
-## v5.1.8 ➔ v5.1.9
-
-#### Notes:
-
-## v5.1.7 ➔ v5.1.8
-
-#### Notes:
-
-## v5.1.6 ➔ v5.1.7
-
-#### Notes:
-
-## v5.1.5 ➔ v5.1.6
-
-#### Notes:
+- The container image for pgsql and codeintel-db have been renamed from `postgres-12-alpine` and `codeintel-db` respectively to `postgres16`. The `codeinsights-db` container has been renamed to `postgres-16-codeinsights`. 
+- **Admins using external dbs who have not yet upgraded from postgres 12 to postgres 16**, can expect to see database drift after upgrading to `5.10.0`. The new expected schema definition for Sourcegraph is based on postgres 16. The schema drift is the result of automatic changes made to the schema by pg_upgrade utils, and will not cause issues in the application.
+  - Admins should not run migrators suggested drift fixes, and should instead upgrade their database from postgres 12 to postgres 16.
+- The [Autoupgrade](https://sourcegraph.com/docs/admin/updates/automatic#pre-v500-automatic-multiversion-upgrades) upgrade method, will detect drift and exit before conducting the upgrade unless the env var `SRC_AUTOUPGRADE_IGNORE_DRIFT=true` is set in the server container.
 
 ## v5.1.4 ➔ v5.1.5
 
@@ -106,124 +68,72 @@ For upgrade procedures or general info about sourcegraph versioning see the link
 #### Notes:
 - See note under v5.1.5 release on issues with standard and multiversion upgrades to v5.1.5.
 
-## v5.0.2 ➔ v5.0.3
-
-#### Notes:
-
-## v5.0.1 ➔ v5.0.2
-
-#### Notes:
-
-## v5.0.0 ➔ v5.0.1
-
-#### Notes:
-
-## v4.5.1 ➔ v5.0.0
-
-#### Notes:
-
-## v4.5.0 ➔ v4.5.1
-
-#### Notes:
-
 ## v4.4.2 ➔ v4.5.0
 
 #### Notes:
 
 This release introduces a background job that will convert all LSIF data into SCIP. **This migration is irreversible** and a rollback from this version may result in loss of precise code intelligence data. Please see the [migration notes](/admin/how-to/lsif_scip_migration) for more details.
 
-## v4.4.1 ➔ v4.4.2
+## v4.3 ➔ v4.4.1
 
 #### Notes:
 
-## v4.3 ➔ v4.4.1
-
 - Users attempting a multi-version upgrade to v4.4.0 may be affected by a [known bug](https://github.com/sourcegraph/sourcegraph/pull/46969) in which an outdated schema migration is included in the upgrade process. _This issue is fixed in patch v4.4.2_
-
-  - The error will be encountered while running `upgrade`, and contains the following text: `"frontend": failed to apply migration 1648115472`.
-    - To resolve this issue run migrator with the args `'add-log', '-db=frontend', '-version=1648115472'`.
-    - If migrator was stopped while running `upgrade` the next run of upgrade will encounter drift, this drift should be disregarded by providing migrator with the `--skip-drift-check` flag.
-
-## v4.2 ➔ v4.3.1
-
-_No notes._
-
-## v4.2 ➔ v4.3.1
-
-_No notes._
+- The error will be encountered while running `upgrade`, and contains the following text: `"frontend": failed to apply migration 1648115472`.
+  - To resolve this issue run migrator with the args `'add-log', '-db=frontend', '-version=1648115472'`.
+  - If migrator was stopped while running `upgrade` the next run of upgrade will encounter drift, this drift should be disregarded by providing migrator with the `--skip-drift-check` flag.
 
 ## v4.1 ➔ v4.2.1
 
-This upgrade adds the [node-exporter](https://github.com/prometheus/node_exporter) deployment, which collects crucial machine-level metrics that help Sourcegraph scale your deployment.
+#### Notes:
 
-## v4.0 ➔ v4.1.3
-
-_No notes._
+- This upgrade adds the [node-exporter](https://github.com/prometheus/node_exporter) deployment, which collects crucial machine-level metrics that help Sourcegraph scale your deployment.
 
 ## v3.43 ➔ v4.0
 
-Target the tag [`v4.0.1`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v4.0.1/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
 
-**Patch releases**:
-
-- `v4.0.1`
-
-**Notes**:
-
+- Target the tag [`v4.0.1`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v4.0.1/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 - `jaeger` (deployed with the `jaeger-all-in-one` image) has been removed in favor of an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) DaemonSet + Deployment configuration. See [Configure a tracing backend](/admin/deploy/docker-compose/operations#configure-a-tracing-backend)
 - Exporting traces to an external observability backend is now available. Read the [documentation](/admin/deploy/docker-compose/operations#configure-a-tracing-backend) to configure.
 - The bundled Jaeger instance is now disabled by default. It can be [enabled](/admin/deploy/docker-compose/operations#enable-the-bundled-jaeger-deployment) if you do not wish to utilise your own external tracing backend.
 
 ## v3.42 ➔ v3.43
 
-Target the tag [`v3.43.2`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.43.2/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
 
-**Patch releases**:
-
-- `v3.43.1`
-- `v3.43.2`
+- Target the tag [`v3.43.2`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.43.2/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 
 ## v3.41 ➔ v3.42
 
-Target the tag [`v3.42.2`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.42.2/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
 
-**Patch releases**:
-
-- `v3.42.1`
-- `v3.42.2`
+- Target the tag [`v3.42.2`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.42.2/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 
 ## v3.40 ➔ v3.41
 
-Target the tag [`v3.41.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.41.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
 
-**Notes**:
-
+- Target the tag [`v3.41.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.41.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 - `caddy` is upgraded to version 2.5.1 and contains a breaking change from version 2.5.0. Incoming `X-Forwarded-*` headers will no longer be trusted automatically. In order to preserve existing product functionality, the Caddyfile was updated to trust all incoming `X-Forwarded-*` headers. [#828](https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/828)
 - The Postgres DBs `frontend` and `codeintel-db` are now given 1 hour to begin accepting connections before Kubernetes restarts the containers. [#4136](https://github.com/sourcegraph/deploy-sourcegraph/pull/4136)
 
 ## v3.39 ➔ v3.40
 
-Target the tag [`v3.40.2`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.40.2/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
 
-**Patch releases**:
-
-- `v3.40.1`
-- `v3.40.2`
-
-**Notes**:
-
+- Target the tag [`v3.40.2`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.40.2/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 - `cadvisor` now defaults to run in `privileged` mode. This allows `cadvisor` to collect out of memory events happening to containers which can be used to discover underprovisoned resources. [#804](https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/804)
 
 ## v3.38 ➔ v3.39
 
-Target the tag [`v3.39.1`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.39.1/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
 
-**Patch releases**:
+- Target the tag [`v3.39.1`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.39.1/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 
 - `v3.39.1`
 
-**Notes**:
-
+#### Notes:
 - We made a number of changes to our built-in postgres databases (the `pgsql`, `codeintel-db`, and `codeinsights-db` container)
   - **CAUTION**: Added the ability to customize postgres server configuration by mounting external configuration files. If you have customized the config in any way, you should copy your changes to the added `postgresql.conf` files [sourcegraph/deploy-sourcegraph-docker#792](https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/792).
   - Increased the minimal memory requirement of `pgsql` and `codeintel-db` from `2GB` to `4GB`.
@@ -231,193 +141,131 @@ Target the tag [`v3.39.1`](https://github.com/sourcegraph/deploy-sourcegraph-doc
 
 ## v3.37 ➔ v3.38
 
-Target the tag [`v3.38.1`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.38.1/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
 
-**Patch releases**:
+- Target the tag [`v3.38.1`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.38.1/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 
 - `v3.38.1`
 
-**Notes**:
-
+#### Notes:
 - **Minimum version of 1.29 for docker compose is required for this update**
 - This release adds the requirement that the environment variables `SRC_GIT_SERVERS`, `SEARCHER_URL`, `SYMBOLS_URL`, and `INDEXED_SEARCH_SERVERS` are set for the worker process.
 
 ## v3.36 ➔ v3.37
 
-Target the tag [`v3.37.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.37.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
 
-**Notes**:
-
+- Target the tag [`v3.37.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.37.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 - This release adds a new container that runs database migrations (`migrator`) independently of the frontend container. Confirm the environment variables on this new container match your database settings.
 - **If performing a multiversion upgrade from an instance prior to this version see our [upgrading early versions documentation](/admin/updates/migrator/upgrading-early-versions#before-v3370)**
 
 ## v3.35 ➔ v3.36
 
-Target the tag [`v3.36.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.36.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
+
+- Target the tag [`v3.36.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.36.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 
 ## v3.34 ➔ v3.35
 
-Target the tag [`v3.35.1`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.35.1/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
 
-**Patch releases**:
-
-- `v3.35.1`
-
-**Notes**:
-
+- Target the tag [`v3.35.1`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.35.1/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 - The `query-runner` service has been decommissioned in the 3.35 release and will be removed during the upgrade. To delete the `query-runner` service, specify `--remove-orphans` to your `docker-compose` command.
 - There is a [known issue](/code_insights/how-tos/Troubleshooting#oob-migration-has-made-progress-but-is-stuck-before-reaching-100) with the Code Insights out-of-band settings migration not reaching 100% complete when encountering deleted users or organizations.
 
 ## v3.33 ➔ v3.34
 
-Target the tag [`v3.34.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.34.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
+- Target the tag [`v3.34.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.34.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 
 ## v3.32 ➔ v3.33
 
-Target the tag [`v3.33.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.33.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
+- Target the tag [`v3.33.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.33.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 
 ## v3.31 ➔ v3.32
 
-Target the tag [`v3.32.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.32.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
+- Target the tag [`v3.32.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.32.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 
 ## v3.30 ➔ v3.31
 
 > WARNING: **This upgrade must originate from `v3.30.3`.**
 
-Target the tag [`v3.31.2`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.31.2/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
 
-**Patch releases**:
-
-- `v3.31.1`
-- `v3.31.2`
-
-**Notes**:
-
+- Target the tag [`v3.31.2`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.31.2/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 - The **built-in** main Postgres (`pgsql`) and codeintel (`codeintel-db`) databases have switched to an alpine-based Docker image. Upon upgrading, Sourcegraph will need to re-index the entire database. All users that use our bundled (built-in) database instances **must** read through the [3.31 upgrade guide](/admin/migration/3_31) _before_ upgrading.
 
 ## v3.29 ➔ v3.30
 
 > WARNING: **If you have already upgraded to 3.30.0, 3.30.1, or 3.30.2** please follow [this migration guide](/admin/migration/3_30).
 
-Target the tag [`v3.30.3`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.30.3/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
 
-**Patch releases**:
-
-- `v3.30.1`
-- `v3.30.2`
-- `v3.30.3`
+- Target the tag [`v3.30.3`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.30.3/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 
 ## v3.28 ➔ v3.29
 
-Target the tag [`v3.29.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.29.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
 
-**Notes**:
-
+- Target the tag [`v3.29.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.29.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 - This upgrade adds a new `worker` service that runs a number of background jobs that were previously run in the `frontend` service. See [notes on deploying workers](/admin/workers#deploying-workers) for additional details. Good initial values for CPU and memory resources allocated to this new service should match the `frontend` service.
 
 ## v3.27 ➔ v3.28
 
-Target the tag [`v3.28.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.28.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
 
-**Notes**:
-
+- Target the tag [`v3.28.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.28.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 - The memory requirements for `redis-cache` and `redis-store` have been increased by 1GB. See https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/373 for more context.
 
 ## v3.26 ➔ v3.27
 
 > WARNING: Sourcegraph 3.27 now requires **Postgres 12+**.
 
-Target the tag [`v3.27.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.27.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
 
-**Notes**:
-
+- Target the tag [`v3.27.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.27.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 - If you are using an external database, [upgrade your database](/admin/postgres#upgrading-external-postgresql-instances) to Postgres 12 or above prior to upgrading Sourcegraph. No action is required if you are using the supplied supplied database images.
 - **If performing a multiversion upgrade from an instance prior to this version see our [upgrading early versions documentation](/admin/updates/migrator/upgrading-early-versions#before-v3270)**
 
 ## v3.25 ➔ v3.26
 
-Target the tag [`v3.26.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.26.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
+
+- Target the tag [`v3.26.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.26.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 
 ## v3.24 ➔ v3.25
 
-Target the tag [`v3.25.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.25.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
 
-**Notes**:
-
+- Target the tag [`v3.25.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.25.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 - Go `1.15` introduced changes to SSL/TLS connection validation which requires certificates to include a `SAN`. This field was not included in older certificates and clients relied on the `CN` field. You might see an error like `x509: certificate relies on legacy Common Name field`. We recommend that customers using Sourcegraph with an external database and and connecting to it using SSL/TLS check whether the certificate is up to date.
     - AWS RDS customers please reference [AWS' documentation on updating the SSL/TLS certificate](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL-certificate-rotation.html) for steps to rotate your certificate.
 
 ## v3.23 ➔ v3.24
 
-Target the tag [`v3.24.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.24.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
+
+- Target the tag [`v3.24.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.24.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 
 ## v3.22 ➔ v3.23
 
-Target the tag [`v3.23.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.23.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
+
+- Target the tag [`v3.23.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.23.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 
 ## v3.21 ➔ v3.22
 
-Target the tag [`v3.22.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.22.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
 
-**Notes**:
-
+- Target the tag [`v3.22.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.22.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 - This upgrade removes the `code intel bundle manager`. This service has been deprecated and all references to it have been removed.
 - This upgrade also adds a MinIO container that doesn't require any custom configuration. You can find more detailed documentation [here](/admin/external_services/object_storage).
 
 ## v3.20 ➔ v3.21
 
-Target the tag [`v3.21.1`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.21.1/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
+#### Notes:
 
-**Patch releases**:
-
-- `v3.21.1`
-
-**Notes**:
-
+- Target the tag [`v3.21.1`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.21.1/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
 - This release introduces a second database instance, `codeintel-db`. If you have configured Sourcegraph with an external database, then update the `CODEINTEL_PG*` environment variables to point to a new external database as described in the [external database documentation](/admin/external_services/postgres). Again, these must not point to the same database or the Sourcegraph instance will refuse to start.
-
-## v3.19 ➔ v3.20
-
-Target the tag [`v3.20.1`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.20.1/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
-
-**Patch releases**:
-
-- `v3.20.1`
-
-## v3.18 ➔ v3.19
-
-Target the tag [`v3.19.2`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.19.2/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
-
-**Patch releases**:
-
-- `v3.19.1`
-- `v3.19.2`
-
-## v3.17 ➔ v3.18
-
-Target the tag [`v3.18.0-1`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/3.18/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
-
-**Patch releases**:
-
-- `v3.18.0-1`
-
-## v3.16 ➔ v3.17
-
-**Patch releases**:
-
-Target the tag [`v3.17.2`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.16.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
-
-- `v3.17.1`
-- `v3.17.2`
-
-## v3.15 ➔ v3.16
-
-Target the tag [`v3.16.0`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.16.0/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
-
-## v3.14 ➔ v3.15
-
-Target the tag [`v3.15.1`](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/v3.15.1/docker-compose) when fetching upstream from `deploy-sourcegraph-docker`.
-
-**Patch releases**:
-
-- `v3.15.1`

--- a/docs/admin/updates/kubernetes.mdx
+++ b/docs/admin/updates/kubernetes.mdx
@@ -15,21 +15,21 @@ For upgrade procedures or general info about sourcegraph versioning see the link
 
 ## Unreleased
 
-- The GitHub proxy service has been removed in 5.2 and is now removed from kubernetes deployment options. [#55290](https://github.com/sourcegraph/sourcegraph/issues/55290)
+## v5.9.0 ➔ v5.10.0
 
-#### Notes for 5.2:
+> Warning: This release updates the database container images from postgres 12 to postres 16, and beings using wolfi based images.
+
+#### Notes:
+- The container image for pgsql and codeintel-db have been renamed from `postgres-12-alpine` and `codeintel-db` respectively to `postgres16`. The `codeinsights-db` container has been renamed to `postgres-16-codeinsights`. 
+- **Admins using external dbs who have not yet upgraded from postgres 12 to postgres 16**, can expect to see database drift after upgrading to `5.10.0`. The new expected schema definition for Sourcegraph is based on postgres 16. The schema drift is the result of automatic changes made to the schema by pg_upgrade utils, and will not cause issues in the application.
+  - Admins should not run migrators suggested drift fixes, and should instead upgrade their database from postgres 12 to postgres 16.
+- The [Autoupgrade](https://sourcegraph.com/docs/admin/updates/automatic#pre-v500-automatic-multiversion-upgrades) upgrade method, will detect drift and exit before conducting the upgrade unless the env var `SRC_AUTOUPGRADE_IGNORE_DRIFT=true` is set in the server container.
+
+## v5.1.0 -> v5.2.0
+
+#### Notes:
 
 - The GitHub proxy service has been removed and is no longer required. You can safely remove it. [#55290](https://github.com/sourcegraph/sourcegraph/issues/55290)
-
-No applicable notes for unreleased versions.
-
-## v5.1.8 ➔ v5.1.9
-
-#### Notes:
-
-## v5.1.7 ➔ v5.1.8
-
-#### Notes:
 
 ## v5.1.6 ➔ v5.1.7
 
@@ -37,83 +37,11 @@ No applicable notes for unreleased versions.
 
 - v5.1.7 of the [`deploy-sourcegraph-helm`](https://github.com/sourcegraph/deploy-sourcegraph-helm) repo was initially released with the precise-code-intel worker service unable to write to `/tmp`. The release was [overwritten](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/343/files), users who have not yet upgraded will be unaffected. Users who have already upgraded may ammend this issue by pulling in the fix with `helm repo update` and rerunning `helm upgrade`.
 
-## v5.1.5 ➔ v5.1.6
-
-#### Notes:
-
 ## v5.1.4 ➔ v5.1.5
 
 #### Notes:
 
 - Upgrades from versions `v5.0.3`, `v5.0.4`, `v5.0.5`, and `v5.0.6` to `v5.1.5` are affected by an ordering error in the `frontend` databases migration tree. Learn more from the [PR which resolves this bug](https://github.com/sourcegraph/sourcegraph/pull/55650) in `v5.1.6`. **For admins who have already attempted an upgrade to this release from one of the effected versions, see this issue which provides a description of [how to manually fix the frontend db](https://github.com/sourcegraph/sourcegraph/issues/55658).**
-
-## v5.1.3 ➔ v5.1.4
-
-#### Notes:
-
-- Migrator images were built without the `v5.1.x` tag in this version, as such multiversion upgrades using this image version will fail to upgrade to versions in `v5.1.x`. See [this issue](https://github.com/sourcegraph/sourcegraph/issues/55048) for more details.
-
-## v5.1.2 ➔ v5.1.3
-
-#### Notes:
-
-- Migrator images were built without the `v5.1.x` tag in this version, as such multiversion upgrades using this image version will fail to upgrade to versions in `v5.1.x`. See [this issue](https://github.com/sourcegraph/sourcegraph/issues/55048) for more details.
-
-## v5.1.1 ➔ v5.1.2
-
-#### Notes:
-
-- Migrator images were built without the `v5.1.x` tag in this version, as such multiversion upgrades using this image version will fail to upgrade to versions in `v5.1.x`. See [this issue](https://github.com/sourcegraph/sourcegraph/issues/55048) for more details.
-
-## v5.1.0 ➔ v5.1.1
-
-#### Notes:
-
-- Migrator images were built without the `v5.1.x` tag in this version, as such multiversion upgrades using this image version will fail to upgrade to versions in `v5.1.x`. See [this issue](https://github.com/sourcegraph/sourcegraph/issues/55048) for more details.
-
-## v5.0.6 ➔ v5.1.0
-
-#### Notes:
-
-- See note under v5.1.5 release on issues with standard and multiversion upgrades to v5.1.5.
-
-## v5.0.5 ➔ v5.0.6
-
-#### Notes:
-
-- See note under v5.1.5 release on issues with standard and multiversion upgrades to v5.1.5.
-
-## v5.0.4 ➔ v5.0.5
-
-#### Notes:
-
-- See note under v5.1.5 release on issues with standard and multiversion upgrades to v5.1.5.
-
-## v5.0.3 ➔ v5.0.4
-
-#### Notes:
-
-- See note under v5.1.5 release on issues with standard and multiversion upgrades to v5.1.5.
-
-## v5.0.2 ➔ v5.0.3
-
-#### Notes:
-
-## v5.0.1 ➔ v5.0.2
-
-#### Notes:
-
-## v5.0.0 ➔ v5.0.1
-
-No upgrade notes.
-
-## v4.5.1 ➔ v5.0.0
-
-No upgrade notes.
-
-## v4.5.0 ➔ v4.5.1
-
-No upgrade notes.
 
 ## v4.4.2 ➔ v4.5.0
 
@@ -131,11 +59,9 @@ No upgrade notes.
 - An env var `CACHE_DIR` was renamed to `SYMBOLS_CACHE_DIR` in `sourcegraph/sourcegraph`. This change was missed in the Helm charts, which caused a permissions issue during some symbols searches. For more details, see the PR to fix the env var: [#258](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/258).
   - A revision to the 4.5.1 chart (`4.5.1-rev.1`) was released to address the above issue. Use this revision for upgrades to 4.5.1. (ex: `helm upgrade --install --version 4.5.1-rev.1`) [#259](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/259)
 
-## v4.4.1 ➔ v4.4.2
-
-No upgrade notes.
-
 ## v4.3 ➔ v4.4.1
+
+#### Notes:
 
 - Users attempting a multi-version upgrade to v4.4.0 may be affected by a [known bug](https://github.com/sourcegraph/sourcegraph/pull/46969) in which an outdated schema migration is included in the upgrade process. _This issue is fixed in patch v4.4.2_
 
@@ -143,19 +69,11 @@ No upgrade notes.
     - To resolve this issue run migrator with the args `'add-log', '-db=frontend', '-version=1648115472'`.
     - If migrator was stopped while running `upgrade` the next run of upgrade will encounter drift, this drift should be disregarded by providing migrator with the `--skip-drift-check` flag.
 
-## v4.2 ➔ v4.3.1
-
-No upgrade notes.
-
 ## v4.1 ➔ v4.2.1
 
-**Notes**:
+#### Notes:
 
 - The `worker-executors` Service object is now included in manifests generated using `kustomize`. This object was already introduced in the base manifest, but omitted from manifests generated using `kustomize`. Its purpose is to enable ingested executor metrics to be scraped by Prometheus. It should have no impact on behavior.
-
-
-**Notes**:
-
 - `minio` has been replaced with `blobstore`. Please see the update notes [here](/admin/how-to/blobstore_update_notes)
 - This upgrade adds a [node-exporter](https://github.com/prometheus/node_exporter) DaemonSet, which collects crucial machine-level metrics that help Sourcegraph scale your deployment.
   - **Note**: Similarly to `cadvisor`,  `node-exporter`:
@@ -165,50 +83,23 @@ No upgrade notes.
 
   For more information, see [deploy-sourcegraph-helm's Changelog](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/CHANGELOG) or contact customer support.
 
-## v4.0 ➔ v4.1.3
-
-No upgrade notes.
-
 ## v3.43 ➔ v4.0
 
-**Patch releases**:
-
-- `v4.0.1`
-
-**Notes**:
+#### Notes:
 
 - `jaeger-agent` sidecars have been removed in favor of an  [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) DaemonSet + Deployment configuration. See [Configure a tracing backend section.](#configure-a-tracing-backend)
 - Exporting traces to an external observability backend is now available. Read the [documentation](/admin/deploy/kubernetes/configure#configure-a-tracing-backend) to configure.
 - The bundled Jaeger instance is now disabled by default. It can be [enabled](/admin/deploy/kubernetes/configure#enable-the-bundled-jaeger-deployment) if you do not wish to utilise your own external tracing backend.
 
-## v3.42 ➔ v3.43
-
-**Patch releases**:
-
-- `3.43.1`
-- `3.43.2`
-
-## v3.41 ➔ v3.42
-
-**Patch releases**:
-
-- `3.42.1`
-- `3.42.2`
-
 ## v3.40 ➔ v3.41
 
-**Notes**:
+#### Notes:
 
 - The Postgres DBs `frontend` and `codeintel-db` are now given 1 hour to begin accepting connections before Kubernetes restarts the containers. [#4136](https://github.com/sourcegraph/deploy-sourcegraph/pull/4136)
 
 ## v3.39 ➔ v3.40
 
-**Patch releases**:
-
-- `v3.40.1`
-- `v3.40.2`
-
-**Notes**:
+#### Notes:
 
 - `cadvisor` now defaults to run in `privileged` mode. This allows `cadvisor` to collect out of memory events happening to containers which can be used to discover underprovisoned resources. This is disabled by default in `non-privileged` overlay. [#4126](https://github.com/sourcegraph/deploy-sourcegraph/pull/4126)
 - Updated the Nginx ingress controller to v1.2.0. Previously this image originated from quay.io, now it is pulled from the official k8s repository. A redeployment of the ingress
@@ -217,57 +108,37 @@ No upgrade notes.
 
 ## v3.38 ➔ v3.39
 
-**Notes**:
+#### Notes:
 
 - The`codeinsights-db` container no longer uses TimescaleDB and is now based on the standard Postgres image [sourcegraph/deploy-sourcegraph#4103](https://github.com/sourcegraph/deploy-sourcegraph/pull/4103). Metrics scraping is also enabled.
 - **CAUTION**: If you use a custom Code Insights postgres config, you must update the `shared_preload_libraries` list to remove timescaledb. The [above PR](https://github.com/sourcegraph/deploy-sourcegraph/pull/4103/files#diff-e5f8d6e46f8c9335c489c0d8e9ae9be4f4655f878f3ac569c73ebb3865b0eeeeL695-R688) demonstrates this change.
 
-## v3.37 ➔ v3.38
-
-No upgrade notes.
-
 ## v3.36 ➔ v3.37
 
-**Notes**:
+#### Notes:
 
 - This release adds a new `migrator` initContainer to the frontend deployment to run database migrations. Confirm the environment variables on this new container match your database settings. [Docs](/admin/deploy/kubernetes/#database-migrations)
 - **If performing a multiversion upgrade from an instance prior to this version see our [upgrading early versions documentation](/admin/updates/migrator/upgrading-early-versions#before-v3370)**
 
 ## v3.35 ➔ v3.36
 
-**Notes**:
+#### Notes:
 
 - The `backend` service has been removed, so if you deploy with a method other than `kubectl-apply-all.sh`, a manual removal of the service may be necessary.
 
 ## v3.34 ➔ v3.35
 
-**Patch releases**:
-
-- `v3.35.1`
-
-**Notes**:
+#### Notes:
 
 - The query-runner deployment has been removed, so if you deploy with a method other than the `kubectl-apply-all.sh`, a manual removal of the deployment may be necessary.
 Follow the [standard upgrade procedure](/admin/deploy/kubernetes/upgrade) to upgrade your deployment.
 - There is a [known issue](/code_insights/how-tos/Troubleshooting#oob-migration-has-made-progress-but-is-stuck-before-reaching-100) with the Code Insights out-of-band settings migration not reaching 100% complete when encountering deleted users or organizations.
 
-## v3.33 ➔ v3.34
-
-No upgrade notes.
-
-## v3.32 ➔ v3.33
-
-No upgrade notes.
-
-## v3.31 ➔ v3.32
-
-No upgrade notes.
-
 ## v3.30 ➔ v3.31
 
 > WARNING: **This upgrade must originate from `v3.30.3`.**
 
-**Notes**:
+#### Notes:
 
 - The **built-in** main Postgres (`pgsql`) and codeintel (`codeintel-db`) databases have switched to an alpine-based Docker image. Upon upgrading, Sourcegraph will need to re-index the entire database. All users that use our bundled (built-in) database instances **must** read through the [3.31 upgrade guide](/admin/migration/3_31) _before_ upgrading.
 
@@ -275,26 +146,20 @@ No upgrade notes.
 
 > WARNING: **If you have already upgraded to 3.30.0, 3.30.1, or 3.30.2** please follow [this migration guide](/admin/migration/3_30).
 
-**Patch releases**:
-
-- `v3.30.1`
-- `v3.30.2`
-- `v3.30.3`
-
-**Notes**:
+#### Notes:
 
 - This upgrade removes the `non-root` overlay, in favor of using only the `non-privileged` overlay for deploying Sourcegraph in secure environments. If you were
 previously deploying using the `non-root` overlay, you should now generate overlays using the `non-privileged` overlay.
 
 ## v3.28 ➔ v3.29
 
-**Notes**:
+#### Notes:
 
 - This upgrade adds a new `worker` service that runs a number of background jobs that were previously run in the `frontend` service. See [notes on deploying workers](/admin/workers#deploying-workers) for additional details. Good initial values for CPU and memory resources allocated to this new service should match the `frontend` service.
 
 ## v3.27 ➔ v3.28
 
-**Notes**:
+#### Notes:
 
 - All Sourcegraph images now have a registry prefix. [#2901](https://github.com/sourcegraph/deploy-sourcegraph/pull/2901)
 - The memory requirements for `redis-cache` and `redis-store` have been increased by 1GB. See https://github.com/sourcegraph/deploy-sourcegraph/pull/2898 for more context.
@@ -303,7 +168,7 @@ previously deploying using the `non-root` overlay, you should now generate overl
 
 > WARNING: Sourcegraph 3.27 now requires **Postgres 12+**.
 
-**Notes**:
+#### Notes:
 
 > WARNING: We have updated the default replicas for `sourcegraph-frontend` and `precise-code-intel-worker` to `2`. If you use a custom value, make sure you do not merge the replica change.
 
@@ -315,100 +180,28 @@ previously deploying using the `non-root` overlay, you should now generate overl
 - If you are using an external database, [upgrade your database](/admin/postgres#upgrading-external-postgresql-instances) to Postgres 12 or above prior to upgrading Sourcegraph. No action is required if you are using the supplied database images.
 - **If performing a multiversion upgrade from an instance prior to this version see our [upgrading early versions documentation](/admin/updates/migrator/upgrading-early-versions#before-v3270)**
 
-## v3.25 ➔ v3.26
-
-No upgrade notes.
-
 ## v3.24 ➔ v3.25
 
-**Notes**:
+#### Notes:
 
 - Go `1.15` introduced changes to SSL/TLS connection validation which requires certificates to include a `SAN`. This field was not included in older certificates and clients relied on the `CN` field. You might see an error like `x509: certificate relies on legacy Common Name field`. We recommend that customers using Sourcegraph with an external database and and connecting to it using SSL/TLS check whether the certificate is up to date.
   - AWS RDS customers please reference [AWS' documentation on updating the SSL/TLS certificate](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL-certificate-rotation.html) for steps to rotate your certificate.
 
-## v3.23 ➔ v3.24
-
-No upgrade notes.
-
-## v3.22 ➔ v3.23
-
-No upgrade notes.
-
 ## v3.21 ➔ v3.22
 
-**Notes**:
+#### Notes:
 
 - This upgrade removes the `code intel bundle manager`. This service has been deprecated and all references to it have been removed.
 - This upgrade also adds a MinIO container that doesn't require any custom configuration. You can find more detailed documentation in [here](/admin/external_services/object_storage).
 
 ## v3.20 ➔ v3.21
 
-**Notes**:
+#### Notes:
 
 - This release introduces a second database instance, `codeintel-db`. If you have configured Sourcegraph with an external database, then update the `CODEINTEL_PG*` environment variables to point to a new external database as described in the [external database documentation](/admin/external_services/postgres). Again, these must not point to the same database or the Sourcegraph instance will refuse to start.
 
-## v3.19 ➔ v3.20
-
-No upgrade notes.
-
 ## v3.18 ➔ v3.19
 
-**Notes**:
+#### Notes:
 
 - **WARNING**: If you use an overlay that does not reference one of the provided overlays, please add `- /admin/bases/pvcs` as an additional base to your `kustomization.yaml` file. Otherwise the PVCs could be pruned if `kubectl apply -prune` is used.
-
-## v3.17 ➔ v3.18
-
-No upgrade notes.
-
-## v3.16 ➔ v3.17
-
-No upgrade notes.
-
-## v3.15 ➔ v3.16
-
-**Notes**:
-
-- The following deployments have had their `strategy` changed from `rolling` to `recreate`. This change was made to avoid two pods writing to the same volume and causing corruption. No special action is needed to apply the change.
-  - redis-cache
-  - redis-store
-  - pgsql
-  - precise-code-intel-bundle-manager
-  - prometheus
-
-## v3.14 ➔ v3.15
-
-**Prometheus and Grafana resource requirements increase**
-
-Resource _requests and limits_ for Grafana and Prometheus are now equal to the following:
-
-- Grafana 100Mi -> 512Mi
-- Prometheus: 500M -> 3G
-
-This change was made to ensure that even if another Sourcegraph service starts consuming more memory than expected and the Kubernetes node has been over-provisioned, that Sourcegraph's monitoring will still have enough memory to run and monitor / send alerts to the site admin. For additional information see [#638](https://github.com/sourcegraph/deploy-sourcegraph/pull/638)
-
-You may run the following commands to remove the now unused resources:
-
-```shell script
-kubectl delete svc lsif-server
-kubectl delete deployment lsif-server
-kubectl delete pvc lsif-server
-```
-
-**Configuration**
-
-In Sourcegraph 3.0 all site configuration has been moved out of the `config-file.ConfigMap.yaml` and into the PostgreSQL database. We have an automatic migration if you use version 3.2 or before. Please do not upgrade directly from 2.x to 3.3 or higher.
-
-After running 3.0, you should visit the configuration page (`/site-admin/configuration`) and the management console and ensure that your configuration is as expected. In some rare cases, automatic migration may not be able to properly carry over some settings and you may need to reconfigure them.
-
-**A new `sourcegraph-frontend` service type**
-
-The type of the `sourcegraph-frontend` service ([base/frontend/sourcegraph-frontend.Service.yaml](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/base/frontend/sourcegraph-frontend.Service.yaml)) has changed
-from `NodePort` to `ClusterIP`. Directly applying this change [will
-fail](https://github.com/kubernetes/kubernetes/issues/42282). Instead, you must delete the old
-service and then create the new one (this will result in a few seconds of downtime):
-
-```shell
-kubectl delete svc sourcegraph-frontend
-kubectl apply -f base/frontend/sourcegraph-frontend.Service.yaml
-```

--- a/docs/admin/updates/server.mdx
+++ b/docs/admin/updates/server.mdx
@@ -18,10 +18,15 @@ For upgrade procedures or general info about sourcegraph versioning see the link
 
 #### Notes:
 
-- **In 5.10 the Sourcegraph database images are being updated from postgres 12 to postgres 16 to avoid postgres 12's end of life. This update will not yet be applied to Sourcegraph server's all in one database.** During the postgres version upgrade `pg_upgrade` automatically makes some changes to the database schema. What does this mean for admins?
-  - The new canonical database schema is now based on postgres 16, the drift detection tool will report drift between the old and new database schema. This is expected and is a result of the postgres upgrade.
-  - Until the database is upgraded migrator will require the `--skip-drift-check` flag to proceed with upgrades.
-  - Admins should not run migrators suggested drift fixes until the database is upgraded.
+> WARNING:   **In 5.10 the Sourcegraph database images are being updated from postgres 12 to postgres 16 to avoid postgres 12's end of life. This update will not yet be applied to Sourcegraph server's all in one database.**
+
+**What does this mean for admins?**
+- During the postgres version upgrade `pg_upgrade` automatically makes some changes to the database schema. 
+- The new canonical database schema is now based on postgres 16, the drift detection tool will report drift between the old and new database schema. This is expected and is a result of the postgres upgrade.
+- Until the database is upgraded migrator will require the `--skip-drift-check` flag to proceed with upgrades.
+- Admins should not run migrators suggested drift fixes until the database is upgraded.
+- The [Autoupgrade](https://sourcegraph.com/docs/admin/updates/automatic#pre-v500-automatic-multiversion-upgrades) upgrade method, will detect drift and exit before conducting the upgrade unless the env var `SRC_AUTOUPGRADE_IGNORE_DRIFT=true` is set in the server container.
+  
 
 ## v5.0.6 ➔ v5.1.0
 

--- a/docs/admin/updates/server.mdx
+++ b/docs/admin/updates/server.mdx
@@ -14,113 +14,20 @@ For upgrade procedures or general info about sourcegraph versioning see the link
 
 ## Unreleased
 
-## v5.2.6 ➔ v5.2.7
+## v5.9.0 -> v5.10.0
 
 #### Notes:
 
-## v5.2.5 ➔ v5.2.6
-
-#### Notes:
-
-## v5.2.4 ➔ v5.2.5
-
-#### Notes:
-
-## v5.2.3 ➔ v5.2.4
-
-#### Notes:
-
-## v5.2.2 ➔ v5.2.3
-
-#### Notes:
-
-## v5.2.1 ➔ v5.2.2
-
-#### Notes:
-
-## v5.2.0 ➔ v5.2.1
-
-#### Notes:
-
-## v5.1.9 ➔ v5.2.0
-
-#### Notes:
-
-## v5.1.8 ➔ v5.1.9
-
-#### Notes:
-
-## v5.1.7 ➔ v5.1.8
-
-#### Notes:
-
-## v5.1.6 ➔ v5.1.7
-
-#### Notes:
-
-## v5.1.5 ➔ v5.1.6
-
-#### Notes:
-
-## v5.1.4 ➔ v5.1.5
-
-#### Notes:
-
-## v5.1.3 ➔ v5.1.4
-
-#### Notes:
-
-## v5.1.2 ➔ v5.1.3
-
-#### Notes:
-
-## v5.1.1 ➔ v5.1.2
-
-#### Notes:
-
-## v5.1.0 ➔ v5.1.1
-
-#### Notes:
+- **In 5.10 the Sourcegraph database images are being updated from postgres 12 to postgres 16 to avoid postgres 12's end of life. This update will not yet be applied to Sourcegraph server's all in one database.** During the postgres version upgrade `pg_upgrade` automatically makes some changes to the database schema. What does this mean for admins?
+  - The new canonical database schema is now based on postgres 16, the drift detection tool will report drift between the old and new database schema. This is expected and is a result of the postgres upgrade.
+  - Until the database is upgraded migrator will require the `--skip-drift-check` flag to proceed with upgrades.
+  - Admins should not run migrators suggested drift fixes until the database is upgraded.
 
 ## v5.0.6 ➔ v5.1.0
 
 #### Notes:
 
-#### Notes:
-
 - The Docker Single Container Deployment image has switched to a Wolfi-based container image. Upon upgrading, Sourcegraph will need to re-index the entire database. All users **must** read through the [5.1 upgrade guide](/admin/migration/5_1) _before_ upgrading.
-
-## v5.0.5 ➔ v5.0.6
-
-#### Notes:
-
-## v5.0.4 ➔ v5.0.5
-
-#### Notes:
-
-## v5.0.3 ➔ v5.0.4
-
-#### Notes:
-
-## v5.0.2 ➔ v5.0.3
-
-#### Notes:
-
-## v5.0.1 ➔ v5.0.2
-
-#### Notes:
-
-## v5.0.0 ➔ v5.0.1
-
-#### Notes:
-
-## v4.5.1 ➔ v5.0.0
-
-#### Notes:
-
-## v4.5.0 ➔ v4.5.1
-
-#### Notes:
 
 ## v4.4.2 ➔ v4.5.0
 
@@ -128,104 +35,17 @@ For upgrade procedures or general info about sourcegraph versioning see the link
 
 - This release introduces a background job that will convert all LSIF data into SCIP. **This migration is irreversible** and a rollback from this version may result in loss of precise code intelligence data. Please see the [migration notes](/admin/how-to/lsif_scip_migration) for more details.
 
-## v4.4.1 ➔ v4.4.2
+## v3.34 ➔ v3.35
 
 #### Notes:
 
-## v4.3 ➔ v4.4.1
-
-_No notes._
-
-## v4.2 ➔ v4.3.1
-
-_No notes._
-
-## v4.1 ➔ v4.2.1
-
-_No notes._
-
-## v4.0 ➔ v4.1.3
-
-_No notes._
-
-## v3.43 ➔ v4.0
-
-**Patch releases**:
-
-- `v4.0.1`
-
-## v3.42 ➔ v3.43
-
-**Patch releases**:
-
-- `v3.43.1`
-- `v3.43.2`
-
-## v3.41 ➔ v3.42
-
-**Patch releases**:
-
-- `v3.42.1`
-- `v3.42.2`
-
-## v3.40 ➔ v3.41
-
-No upgrade notes.
-
-## v3.39 ➔ v3.40
-
-**Patch releases**:
-
-- `v3.40.1`
-- `v3.40.2`
-
-## v3.38 ➔ v3.39
-
-**Patched releases**:
-
-- `v3.39.1`
-
-## v3.37 ➔ v3.38
-
-**Patch releases**:
-
-- `v3.38.1`
-
-## v3.36 ➔ v3.37
-
-No upgrade notes.
-
-## v3.35 ➔ v3.36
-
-No upgrade notes.
-
-## v3.34 ➔ v3.35
-
-**Patch releases**:
-
-- `v3.35.1`
-
-**Notes**:
-
 - There is a [known issue](/code_insights/how-tos/Troubleshooting#oob-migration-has-made-progress-but-is-stuck-before-reaching-100) with the Code Insights out-of-band settings migration not reaching 100% complete when encountering deleted users or organizations.
-
-## v3.33 ➔ v3.34
-
-No upgrade notes.
-
-## v3.32 ➔ v3.33
-
-No upgrade notes.
-
-## v3.31 ➔ v3.32
-
-No upgrade notes.
 
 ## v3.30 ➔ v3.31
 
 > WARNING: **This upgrade must originate from `v3.30.3`.**
 
-**Notes**:
+#### Notes:
 
 - The **built-in** main Postgres (`pgsql`) and codeintel (`codeintel-db`) databases have switched to an alpine-based Docker image. Upon upgrading, Sourcegraph will need to re-index the entire database. All users that use our bundled (built-in) database instances **must** read through the [3.31 upgrade guide](/admin/migration/3_31) _before_ upgrading.
 
@@ -233,47 +53,21 @@ No upgrade notes.
 
 > WARNING: **If you have already upgraded to 3.30.0, 3.30.1, or 3.30.2** please follow [this migration guide](/admin/migration/3_30).
 
-**Patch releases**:
-
-- `v3.30.1`
-- `v3.30.2`
-- `v3.30.3`
-
-## v3.28 ➔ v3.29
-
-No upgrade notes.
-
-## v3.27 ➔ v3.28
-
-No upgrade notes.
-
 ## v3.26 ➔ v3.27
 
 > WARNING: Sourcegraph 3.27 now requires **Postgres 12+**.
 
-**Notes**:
+#### Notes:
 
 - If you are using an external database, [upgrade your database](/admin/postgres#upgrading-external-postgresql-instances) to Postgres 12 or above prior to upgrading Sourcegraph. If you are using the embedded database, [prepare your data for migration](/admin/postgres#upgrading-single-node-docker-deployments) prior to upgrading Sourcegraph.
 
-## v3.25 ➔ v3.26
-
-No upgrade notes.
-
 ## v3.24 ➔ v3.25
 
-No upgrade notes.
-
-**Notes**:
+#### Notes:
 
 - Go `1.15` introduced changes to SSL/TLS connection validation which requires certificates to include a `SAN`. This field was not included in older certificates and clients relied on the `CN` field. You might see an error like `x509: certificate relies on legacy Common Name field`. We recommend that customers using Sourcegraph with an external database and and connecting to it using SSL/TLS check whether the certificate is up to date.
   - AWS RDS customers please reference [AWS' documentation on updating the SSL/TLS certificate](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL-certificate-rotation.html) for steps to rotate your certificate.
 
-## v3.23 ➔ v3.24
-
-No upgrade notes.
-## v3.22 ➔ v3.23
-
-No upgrade notes.
 ## v3.21 ➔ v3.22
 
 > WARNING: **This upgrade must originate from `v3.20.1`.**
@@ -283,32 +77,8 @@ No upgrade notes.
 
 > WARNING: **This upgrade must originate from `v3.17.2`** due to a [patched](https://github.com/sourcegraph/sourcegraph/pull/11633) [bug](https://github.com/sourcegraph/sourcegraph/issues/11618) in our release.
 
-**Notes**:
+#### Notes:
 
 - This release introduces a second database instance, `codeintel-db`. If you have configured Sourcegraph with an external database, then update the `CODEINTEL_PG*` environment variables to point to a new external database as described in the [external database documentation](/admin/external_services/postgres). Again, these must not point to the same database or the Sourcegraph instance will refuse to start.
 - **Turn off database secrets encryption**. In Sourcegraph version 3.20, we would automatically generate a secret key file (`/var/lib/sourcegraph/token`) inside the container for encrypting secrets stored in the database. However, it is not yet ready for general use and format of the secret key file might change. Therefore, it is best to delete the secret key file (`/var/lib/sourcegraph/token`) and turn off the database secrets encryption.
 
-## v3.19 ➔ v3.20
-
-No upgrade notes.
-
-## v3.18 ➔ v3.19
-
-No upgrade notes.
-
-## v3.17 ➔ v3.18
-
-No upgrade notes.
-
-## v3.16 ➔ v3.17
-
-**Patch releases**:
-
-- `v3.17.2`
-
-## v3.15 ➔ v3.16
-
-No upgrade notes.
-## v3.14 ➔ v3.15
-
-No upgrade notes.


### PR DESCRIPTION
This PR updates and reformats the Release Notes for the deployment repos. Adding warnings about the v5.10.0 postgres version upgrades and its impact on database upgrades, and reformating and cleaning up the old version release notes.

## Pull Request approval

@Chickensoupwithrice
