### PR TITLE
feat(search): increase Algolia search results and externalize config

### DIFF
--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-
+import { searchMetadata } from '../../data/search';
 import { DocSearch } from './docsearch/DocSearch';
 import './docsearch/docsearch.css';
 
@@ -24,11 +24,12 @@ export const Search = () => {
 	}, []);
 
 	const initialQuery = getInitialQuery();
+	const { algoliaConfig } = searchMetadata;
 	return (
 		<DocSearch
-			appId="0EBA2NRQU3"
-			indexName="sourcegraph"
-			apiKey="1b6e51c1d4ef24bef0a5f1ab00dad80a"
+			appId={algoliaConfig.appId}
+			indexName={algoliaConfig.indexName}
+			apiKey={algoliaConfig.apiKey}
 			initialQuery={initialQuery}
 		/>
 	);

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -31,6 +31,7 @@ export const Search = () => {
 			indexName={algoliaConfig.indexName}
 			apiKey={algoliaConfig.apiKey}
 			initialQuery={initialQuery}
+			maxResultsPerGroup={algoliaConfig.maxResultsPerGroup}
 		/>
 	);
 };

--- a/src/data/search.ts
+++ b/src/data/search.ts
@@ -11,5 +11,6 @@ export const searchMetadata = {
       // Public API key: it is safe to commit it
       apiKey: '1b6e51c1d4ef24bef0a5f1ab00dad80a',
       indexName: 'sourcegraph',
+      maxResultsPerGroup:20
     },
 }


### PR DESCRIPTION
This PR makes two key improvements to our Algolia search implementation:

1. Increases Maximum Results
- Added maxResultsPerGroup parameter to Algolia search component
- Increased limit from default to 20 results per group
- Improves search experience by showing more relevant matches

2. Configuration Refactoring
- Moved Algolia credentials (appId, indexName, apiKey) to centralized searchMetadata config
- Improves maintainability by consolidating search settings in one location
- Makes configuration updates more manageable

### Testing

Manually after merge
