### PR TITLE
Warn customers not to use auto or upgrade upgrade paths with 5.10.0

### DIFF
--- a/docs/admin/updates/automatic.mdx
+++ b/docs/admin/updates/automatic.mdx
@@ -1,6 +1,6 @@
 # Automatic multi-version upgrades
 
-> Warning: Automatic upgrades in v5.10.0 will fail unless the postgres database is upgraded from postgres 12 to postgres 16. Or the environment variable `SRC_AUTOUPGRADE_IGNORE_DRIFT=true` is set on the `sourcegraph-frontend` container. See our [postgres 12 end of life](https://sourcegraph.com/docs/admin/postgres12_end_of_life_notice#postgres-12-end-of-life) notice!
+> Warning: Automatic upgrades to v5.10.0 will fail please upgrade to a v5.9.x version and perform a standard upgrade instead! See our [postgres 12 end of life](https://sourcegraph.com/docs/admin/postgres12_end_of_life_notice#postgres-12-end-of-life) notice!
 
 From **Sourcegraph 5.1 and later**, multi-version upgrades can be performed **automatically** as if they were a standard upgrade for the same deployment type. Automatic multi-version upgrades take the following general form:
 

--- a/docs/admin/updates/docker_compose.mdx
+++ b/docs/admin/updates/docker_compose.mdx
@@ -16,6 +16,7 @@ For upgrade procedures or general info about sourcegraph versioning see the link
 ## v5.9.0 ➔ v5.10.0
 
 > Warning: This release updates the database container images from postgres 12 to postres 16, and begins using wolfi based images. See our [postgres 12 end of life](https://sourcegraph.com/docs/admin/postgres12_end_of_life_notice#postgres-12-end-of-life) notice!
+> Warning:`automatic` and migrator cli `upgrade` upgrades will not work for this release, please upgrade to a 5.9 version and conduct a standard upgrade using migrator's default `up` command!
 
 #### Notes:
 - The container image for pgsql and codeintel-db have been renamed from `postgres-12-alpine` and `codeintel-db` respectively to `postgres16`. The `codeinsights-db` container has been renamed to `postgres-16-codeinsights`. 

--- a/docs/admin/updates/kubernetes.mdx
+++ b/docs/admin/updates/kubernetes.mdx
@@ -18,12 +18,12 @@ For upgrade procedures or general info about sourcegraph versioning see the link
 ## v5.9.0 ➔ v5.10.0
 
 > Warning: This release updates the database container images from postgres 12 to postres 16, and begins using wolfi based images. See our [postgres 12 end of life](https://sourcegraph.com/docs/admin/postgres12_end_of_life_notice#postgres-12-end-of-life) notice!
+> Warning:`automatic` and migrator cli `upgrade` upgrades will not work for this release, please upgrade to a 5.9 version and conduct a standard upgrade using migrator's default `up` command!
 
 #### Notes:
 - The container image for pgsql and codeintel-db have been renamed from `postgres-12-alpine` and `codeintel-db` respectively to `postgres16`. The `codeinsights-db` container has been renamed to `postgres-16-codeinsights`. 
 - **Admins using external dbs who have not yet upgraded from postgres 12 to postgres 16**, can expect to see database drift after upgrading to `5.10.0`. The new expected schema definition for Sourcegraph is based on postgres 16. The schema drift is the result of automatic changes made to the schema by pg_upgrade utils, and will not cause issues in the application.
   - Admins should not run migrators suggested drift fixes, and should instead upgrade their database from postgres 12 to postgres 16.
-- The [Autoupgrade](https://sourcegraph.com/docs/admin/updates/automatic#pre-v500-automatic-multiversion-upgrades) upgrade method, will detect drift and exit before conducting the upgrade unless the env var `SRC_AUTOUPGRADE_IGNORE_DRIFT=true` is set in the server container.
 
 ## v5.1.0 -> v5.2.0
 

--- a/docs/admin/updates/server.mdx
+++ b/docs/admin/updates/server.mdx
@@ -18,14 +18,13 @@ For upgrade procedures or general info about sourcegraph versioning see the link
 
 #### Notes:
 
-> WARNING:   **In 5.10 the Sourcegraph database images are being updated from postgres 12 to postgres 16 to avoid postgres 12's end of life. This update will not yet be applied to Sourcegraph server's all in one database.**
+> Warning:   **In 5.10 the Sourcegraph database images are being updated from postgres 12 to postgres 16 to avoid postgres 12's end of life. This update will not yet be applied to Sourcegraph server's all in one database.**
+> Warning:`automatic` and migrator cli `upgrade` upgrades will not work for this release, please upgrade to a 5.9 version and conduct a standard upgrade using migrator's default `up` command!
 
 **What does this mean for admins?**
 - During the postgres version upgrade `pg_upgrade` automatically makes some changes to the database schema. 
 - The new canonical database schema is now based on postgres 16, the drift detection tool will report drift between the old and new database schema. This is expected and is a result of the postgres upgrade.
-- Until the database is upgraded migrator will require the `--skip-drift-check` flag to proceed with upgrades.
 - Admins should not run migrators suggested drift fixes until the database is upgraded.
-- The [Autoupgrade](https://sourcegraph.com/docs/admin/updates/automatic#pre-v500-automatic-multiversion-upgrades) upgrade method, will detect drift and exit before conducting the upgrade unless the env var `SRC_AUTOUPGRADE_IGNORE_DRIFT=true` is set in the server container.
   
 
 ## v5.0.6 ➔ v5.1.0

--- a/docs/technical-changelog.mdx
+++ b/docs/technical-changelog.mdx
@@ -8,6 +8,8 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 
 > Warning: This release updates the database container images from postgres 12 to postres 16, and begins using wolfi based images. See our [postgres 12 end of life](https://sourcegraph.com/docs/admin/postgres12_end_of_life_notice#postgres-12-end-of-life) notice!
 >
+> Warning: `automatic` and migrator cli `upgrade` upgrade paths will not work for this release, please upgrade to a 5.9 version and conduct a standard upgrade using migrator's default `up` command!
+>
 > Also be sure to check your deployment type's [upgrade notes](http://sourcegraph.com/docs/admin/updates#instance-specific-procedures)!
 
 ## v5.10.0


### PR DESCRIPTION
This PR removes references for workarounds for the expected pg12 -> pg16 schema drift and instead just tells customers the only valid upgrade path is by use of v5.9.x standard to v5.10.0

In reality what we're actually dodging is a failure to run OOB migrations -- therefore in this case the schema drift prevents migrator from encountering a worse bug
