### PR TITLE
chore(rel): warning to skip 5.10.0 release

### DIFF
--- a/docs/admin/updates/docker_compose.mdx
+++ b/docs/admin/updates/docker_compose.mdx
@@ -13,10 +13,17 @@ For upgrade procedures or general info about sourcegraph versioning see the link
 
 ## Unreleased
 
+## v5.9.0 ➔ v5.10.1164
+
+- This release resolves an issue in the v5.10.0 release which prevented multiversion upgrades from working. You may now target `v5.10.1164` using migrator's `upgrade` command. Or use autoupgrade by setting the environment variable `SRC_AUTOUPGRADE_IGNORE_DRIFT=true` on the `frontend` container.
+
 ## v5.9.0 ➔ v5.10.0
 
-> Warning: This release updates the database container images from postgres 12 to postres 16, and begins using wolfi based images. See our [postgres 12 end of life](https://sourcegraph.com/docs/admin/postgres12_end_of_life_notice#postgres-12-end-of-life) notice!
-> Warning: `automatic` and migrator `upgrade` command will not work for this release, please upgrade to a 5.9 version and conduct a standard upgrade using migrator's default `up` command!
+> Warning: Admins are advised to upgrade directly to v5.10.1164 circumventing this release.
+>
+> Warning: This release updates the database container images from Postgres 12 to Postgres 16, and begins using Wolfi based images. Customers are advised to take a database backup before upgrading! See our [postgres 12 end of life](https://sourcegraph.com/docs/admin/postgres12_end_of_life_notice#postgres-12-end-of-life) notice!
+>
+> Warning: `automatic` and migrator `upgrade` command will not work for this release, please upgrade directly to `v5.10.1164`, or to a 5.9 version and conduct a standard upgrade using migrator's default `up` command!
 
 #### Notes:
 - The container image for pgsql and codeintel-db have been renamed from `postgres-12-alpine` and `codeintel-db` respectively to `postgresql-16`. The `codeinsights-db` container has been renamed to `postgresql-16-codeinsights`. 

--- a/docs/admin/updates/kubernetes.mdx
+++ b/docs/admin/updates/kubernetes.mdx
@@ -15,10 +15,17 @@ For upgrade procedures or general info about sourcegraph versioning see the link
 
 ## Unreleased
 
+## v5.9.0 ➔ v5.10.1164
+
+- This release resolves an issue in the v5.10.0 release which prevented multiversion upgrades from working. You may now target `v5.10.1164` using migrator's `upgrade` command. Or use autoupgrade by setting the environment variable `SRC_AUTOUPGRADE_IGNORE_DRIFT=true` on the `frontend` deployment.
+
 ## v5.9.0 ➔ v5.10.0
 
-> Warning: This release updates the database container images from postgres 12 to postres 16, and begins using wolfi based images. See our [postgres 12 end of life](https://sourcegraph.com/docs/admin/postgres12_end_of_life_notice#postgres-12-end-of-life) notice!
-> Warning: `automatic` and migrator `upgrade` command will not work for this release, please upgrade to a 5.9 version and conduct a standard upgrade using migrator's default `up` command!
+> Warning: Admins are advised to upgrade directly to v5.10.1164 circumventing this release.
+>
+> Warning: This release updates the database container images from Postgres 12 to Postgres 16, and begins using Wolfi based images. Customers are advised to take a database backup before upgrading! See our [postgres 12 end of life](https://sourcegraph.com/docs/admin/postgres12_end_of_life_notice#postgres-12-end-of-life) notice!
+>
+> Warning: `automatic` and migrator `upgrade` command will not work for this release, please upgrade directly to `v5.10.1164`, or to a 5.9 version and conduct a standard upgrade using migrator's default `up` command!
 
 #### Notes:
 - The container image for pgsql and codeintel-db have been renamed from `postgres-12-alpine` and `codeintel-db` respectively to `postgresql-16`. The `codeinsights-db` container has been renamed to `postgresql-16-codeinsights`. 

--- a/docs/admin/updates/server.mdx
+++ b/docs/admin/updates/server.mdx
@@ -14,12 +14,19 @@ For upgrade procedures or general info about sourcegraph versioning see the link
 
 ## Unreleased
 
+## v5.9.0 ➔ v5.10.1164
+
+- This release resolves an issue in the v5.10.0 release which prevented multiversion upgrades from working. You may now target `v5.10.1164` using migrator's `upgrade` command. Or use autoupgrade by setting the environment variable `SRC_AUTOUPGRADE_IGNORE_DRIFT=true` on the sourcegraph container.
+
 ## v5.9.0 -> v5.10.0
 
 #### Notes:
 
+> Warning: Admins are advised to upgrade directly to v5.10.1164 circumventing this release.
+>
 > Warning:   **In 5.10 the Sourcegraph database images are being updated from postgres 12 to postgres 16 to avoid postgres 12's end of life. This update will not yet be applied to Sourcegraph server's all in one database.**
-> Warning: `automatic` and migrator `upgrade` command will not work for this release, please upgrade to a 5.9 version and conduct a standard upgrade using migrator's default `up` command!
+>
+> Warning: `automatic` and migrator `upgrade` command will not work for this release, please upgrade directly to `v5.10.1164`, or to a 5.9 version and conduct a standard upgrade using migrator's default `up` command!
 
 **What does this mean for admins?**
 - During the postgres version upgrade `pg_upgrade` automatically makes some changes to the database schema. 

--- a/docs/technical-changelog.mdx
+++ b/docs/technical-changelog.mdx
@@ -6,9 +6,9 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 
 # 5.10 Patch 1
 
-> Warning: This release updates the database container images from Postgres 12 to Postgres 16, and begins using Wolfi based images. See our [Postgres 12 end of life](https://sourcegraph.com/docs/admin/postgres12_end_of_life_notice#postgres-12-end-of-life) notice!
+> Warning: This release updates the database container images from Postgres 12 to Postgres 16, and begins using Wolfi based images. Customers are advised to take a database backup before upgrading! See our [Postgres 12 end of life](https://sourcegraph.com/docs/admin/postgres12_end_of_life_notice#postgres-12-end-of-life) notice!
 >
-> Warning: `automatic` and migrator `upgrade` command will not work for this release, please upgrade to a 5.9 version and conduct a standard upgrade using migrator's default `up` command!
+> Warning: `automatic` upgrades will require setting the environment variable `SRC_AUTOUPGRADE_IGNORE_DRIFT=true` on the `sourcegraph-frontend` deployment/container.
 >
 > Also be sure to check your deployment type's [upgrade notes](http://sourcegraph.com/docs/admin/updates#instance-specific-procedures)!
 
@@ -49,9 +49,11 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 
 # 5.10 Patch 0
 
-> Warning: This release updates the database container images from Postgres 12 to Postgres 16, and begins using Wolfi based images. See our [postgres 12 end of life](https://sourcegraph.com/docs/admin/postgres12_end_of_life_notice#postgres-12-end-of-life) notice!
+> Warning: Admins are advised to upgrade directly to v5.10.1164 circumventing this release.
 >
-> Warning: `automatic` and migrator `upgrade` command will not work for this release, please upgrade to a 5.9 version and conduct a standard upgrade using migrator's default `up` command!
+> Warning: This release updates the database container images from Postgres 12 to Postgres 16, and begins using Wolfi based images. Customers are advised to have a database backup before upgrading! See our [postgres 12 end of life](https://sourcegraph.com/docs/admin/postgres12_end_of_life_notice#postgres-12-end-of-life) notice!
+>
+> Warning: `automatic` and migrator `upgrade` command will not work for this release, please upgrade directly to `v5.10.1164`, or to a 5.9 version and conduct a standard upgrade using migrator's default `up` command!
 >
 > Also be sure to check your deployment type's [upgrade notes](http://sourcegraph.com/docs/admin/updates#instance-specific-procedures)!
 


### PR DESCRIPTION
This is just a little embellishment on technical changelog and upgrade notes explaining the autoupgrade path workaround for db drift and also warning customers to skip past v5.10.0 release