### PR TITLE
Changed regex example to use any github.com repo with regex search

### DIFF
--- a/docs/code-search/queries/examples.mdx
+++ b/docs/code-search/queries/examples.mdx
@@ -107,7 +107,7 @@ repo:^github\.com/Parsely/pykafka$ Not leader for partition
 
 Regex searches are also useful when searching boundaries that are not delimited by code structures:
 
-[Finding css classes with word boundary regex](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/.%2A%24+%5Cbbtn-secondary%5Cb&patternType=regexp)
+[Finding css classes with word boundary regex](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/+%5Cbbtn-secondary%5Cb&patternType=regexp)
 
 ```sgquery
 repo:^github\.com/.*$ \bbtn-secondary\b

--- a/docs/code-search/queries/examples.mdx
+++ b/docs/code-search/queries/examples.mdx
@@ -110,5 +110,5 @@ Regex searches are also useful when searching boundaries that are not delimited 
 [Finding css classes with word boundary regex](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/+%5Cbbtn-secondary%5Cb&patternType=regexp)
 
 ```sgquery
-repo:^github\.com/.*$ \bbtn-secondary\b
+repo:^github\.com/sourcegraph/ \bbtn-secondary\b
 ```

--- a/docs/code-search/queries/examples.mdx
+++ b/docs/code-search/queries/examples.mdx
@@ -107,8 +107,8 @@ repo:^github\.com/Parsely/pykafka$ Not leader for partition
 
 Regex searches are also useful when searching boundaries that are not delimited by code structures:
 
-[Finding css classes with word boundary regex](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%5Cbbtn-secondary%5Cb&patternType=regexp)
+[Finding css classes with word boundary regex](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/.%2A%24+%5Cbbtn-secondary%5Cb&patternType=regexp)
 
 ```sgquery
-repo:^github\.com/sourcegraph/sourcegraph$ \bbtn-secondary\b
+repo:^github\.com/.*$ \bbtn-secondary\b
 ```


### PR DESCRIPTION
Updated regex example to use another repo as sourcegraph/sourcegraph is no longer available in .com instance

<!-- Explain the changes introduced in your PR -->

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
