### PR TITLE
chore: remove references to public notebooks

### DIFF
--- a/docs/notebooks/notebook-sharing.mdx
+++ b/docs/notebooks/notebook-sharing.mdx
@@ -8,10 +8,6 @@ Notebooks support the following sharing scheme.
 
 This is the default permissions level for all new notebook. Only the creator can view and edit the notebook.
 
-### Public Notebooks
-
-Notebooks can be shared with everyone (public notebooks on [Sourcegraph.com](https://sourcegraph.com) are viewable by anyone and don't require a Sourcegraph account), or with your entire Sourcegraph instance.
-
 ## Sourcegraph organization namespace
 
 Find out more about Sourcegraph organizations and how to create and configure them on the [organizations docs page](/admin/organizations).

--- a/docs/notebooks/quickstart.mdx
+++ b/docs/notebooks/quickstart.mdx
@@ -69,7 +69,3 @@ repo:^github\.com/sourcegraph/sourcegraph$ lang:TypeScript extends React type:di
 
 - Your Notebook should now look like [this](https://sourcegraph.com/notebooks/Tm90ZWJvb2s6MTE4).
 - **Optional:** share you notebook by clicking "Private" at the top right of the screen and select "Public" to share your Notebook with the community!
-
-## Next steps
-
-Congratulations on creating your first Notebook! Next, get some inspiration from the Notebooks created by Sourcegraph team members and the wider community by [exploring public Notebooks](https://sourcegraph.com/notebooks?tab=explore).


### PR DESCRIPTION
Notebooks have been disabled on dotcom for over a year now. This removes references to public notebooks from our docs.