### PR TITLE
Clarify changelog entry for PR 1863

### DIFF
--- a/docs/technical-changelog.mdx
+++ b/docs/technical-changelog.mdx
@@ -346,6 +346,8 @@ This page documents all notable changes to Sourcegraph. For more detailed change
   - We sometimes would emit `patternType:regex` instead of `patternType:regexp`. We now always do regexp as well as treating regex as an alias for regexp.
   Backport a095b39ac39cfcbe3526ecf85ed6d50cb5fa3d9d from #1808
 - Executors on Kubernetes: propagate user and group from Executor env vars to batch change job pod [#1863](https://github.com/sourcegraph/sourcegraph/pull/1863)
+  - The environment variables `KUBERNETES_RUN_AS_USER` and `KUBERNETES_RUN_AS_GROUP` contribute to the Job `PodSpec`'s `SecurityContext`.
+  - The default value for those variables is `-1`, which could cause errors with some Kubernetes clusters.
 - (new web app) Only update user activity data once on load [#1797](https://github.com/sourcegraph/sourcegraph/pull/1797)
 - (new web ui) Respect 'window.context.disableFeedbackSurvey' flag [#1778](https://github.com/sourcegraph/sourcegraph/pull/1778)
 - (search input) Treat not, and, or as keywords regardless of case [#1733](https://github.com/sourcegraph/sourcegraph/pull/1733)


### PR DESCRIPTION
Customer feedback shows that the changelog entry for [1863](https://github.com/sourcegraph/sourcegraph/pull/1863) was not sufficient, so added more to it.