### PR TITLE
Remove all sourcegraph/sourcegraph PR links from the technical changelog

### DIFF
--- a/docs/technical-changelog.mdx
+++ b/docs/technical-changelog.mdx
@@ -26,12 +26,12 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 
 #### Database
 
-- remove 5.10 deprecation dates on out of band migrations `#1996`
+- remove 5.10 deprecation dates on out of band migrations `(PR #1996)`
   - We are removing the deprecation dates on out of band migrations which deprecated in 5.10. This is to unblock MVU and autoupgrades which are encountering a bug with deprecated out of band migrations.  Backport f654dcc9200e2dda2deddc8f98bcd972e6a873fd from #1995
 
 #### Search
 
-- disable zoekt go-git optimization by default `#2051`
+- disable zoekt go-git optimization by default `(PR #2051)`
   - Disabled an indexed search optimization which would skip files accidentally (`ZOEKT_DISABLE_GOGIT_OPTIMIZATION=true`).  Backport 34ada948bdcee3d75499c98f4db5c32986943e88 from #2050
 
 ### Reverts
@@ -42,7 +42,7 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 
 #### Others
 
-- [Backport 5.10.x] oob: Actually run for all tenants `#1994`
+- [Backport 5.10.x] oob: Actually run for all tenants `(PR #1994)`
 
 {/* RSS={"version":"v5.10.1164", "releasedAt": "2024-12-03"} */}
 
@@ -71,632 +71,632 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 
 #### Autoedit
 
-- add autoedit model to use chat completions end point `#1809`
+- add autoedit model to use chat completions end point `(PR #1809)`
 
 #### Ci
 
-- move rules_pkg to MODULE.bazel `#1660`
+- move rules_pkg to MODULE.bazel `(PR #1660)`
 
 #### Cody
 
-- fix ootb prompt details page `#1902`
-- update cody web to 0.14.0 version `#1895`
-- add support for out-of-the-box prompts `#1726`
-- support openai predicted outputs `#1625`
+- fix ootb prompt details page `(PR #1902)`
+- update cody web to 0.14.0 version `(PR #1895)`
+- add support for out-of-the-box prompts `(PR #1726)`
+- support openai predicted outputs `(PR #1625)`
   - Cody Gateway: add support for OpeanAI predicted outputs
-- added `systemPreInstruction` (CODY-4032) `#1402`
+- added `systemPreInstruction` (CODY-4032) `(PR #1402)`
   - adds `systemPreInstruction` to the `modelConfiguration` key in site admin config that allows injecting a prelude prompt into every chat request for an enterprise
 
 #### Cody-Gateway
 
-- add gpt-4o-mini model `#1591`
+- add gpt-4o-mini model `(PR #1591)`
   - Cody Gateway: add `gpt-4o-mini` to Cody Gateway allow list
   - Cody Gateway: add `gpt-4o-mini` to DotCom models list
 
 #### Conf/Deploy
 
-- add 'workspace' deploy type `#1710`
+- add 'workspace' deploy type `(PR #1710)`
 
 #### Dev
 
-- use svelte-dev for multi-tenant `#1843`
-- add alias 'sg bz cf' for 'sg bz configure' `#1827`
-- add '-open=false' option for 'sg sams login' `#1498`
-- Adding sg command to request Entitle bundles `#1370`
+- use svelte-dev for multi-tenant `(PR #1843)`
+- add alias 'sg bz cf' for 'sg bz configure' `(PR #1827)`
+- add '-open=false' option for 'sg sams login' `(PR #1498)`
+- Adding sg command to request Entitle bundles `(PR #1370)`
 
 #### Gateway
 
-- Add `/models.json` endpoint (PRIME-601) `#1728`
-- Disable flagged model blocking for enterprise (PRIME-602, PRIME-605) `#1659`
+- Add `/models.json` endpoint (PRIME-601) `(PR #1728)`
+- Disable flagged model blocking for enterprise (PRIME-602, PRIME-605) `(PR #1659)`
 
 #### Github
 
-- add client ID support for GitHub App authentication `#1622`
+- add client ID support for GitHub App authentication `(PR #1622)`
   - The GitHub app authentication package now supports authenticating a GitHub app via the OAuth client ID following the announcement of [https://github.blog/changelog/2024-05-01-github-apps-can-now-use-the-client-id-to-fetch-installation-tokens/](https://github.blog/changelog/2024-05-01-github-apps-can-now-use-the-client-id-to-fetch-installation-tokens/)
 
 #### Graphql
 
-- add support for reading GitHub App Installation repos from GitHub REST API `#1711`
+- add support for reading GitHub App Installation repos from GitHub REST API `(PR #1711)`
   - A new GraphQL query, `GithubAppRepositoriesForInstallation`, has been added that provides a paginated list of all the GitHub repositories that are accessible to the GitHub app with the provided installation id.
-- add endpoint for getting github app installations scoped by user `#1606`
+- add endpoint for getting github app installations scoped by user `(PR #1606)`
   - A new graphql endpoint has been added, GithubAppInstallationsForUser, that returns installation information for the global GitHub multi tenant app when running in multitenant mode.
 
 #### Internal/Github
 
-- add pagination support and test for GetUserInstallations `#1572`
+- add pagination support and test for GetUserInstallations `(PR #1572)`
   - The Github API client's [GetUserInstallations](https://docs.github.com/en/rest/reference/apps#list-app-installations-accessible-to-the-user-access-token) route, which lists of GitHub App installations the user has access to, now has pagination support.
 
 #### Lib/Cloudapi
 
-- add support for workload identity to auth roundtripper `#1623`
+- add support for workload identity to auth roundtripper `(PR #1623)`
 
 #### Local
 
-- add bazel mod tidy to `sg bazel configure` step `#1656`
+- add bazel mod tidy to `sg bazel configure` step `(PR #1656)`
 
 #### Msp
 
-- apply default max DB conns of 8*CPU `#1394`
+- apply default max DB conns of 8*CPU `(PR #1394)`
 
 #### Msp/Cloudsql
 
-- annotate cloudsql trace spans with target database `#1398`
+- annotate cloudsql trace spans with target database `(PR #1398)`
 
 #### Mt-Router
 
-- add support for SOAP redirect `#1510`
+- add support for SOAP redirect `(PR #1510)`
 
 #### Multi-Tenant
 
-- redirect to workspaces/join on user-not-found `#1604`
+- redirect to workspaces/join on user-not-found `(PR #1604)`
 
 #### Multitenant
 
-- Rework GraphQL resolvers and add back App installation link `#1819`
-- Add temporary UI for workspace repository management `#1791`
-- add helper routine for instantiating github app from multitenant credentials `#1758`
+- Rework GraphQL resolvers and add back App installation link `(PR #1819)`
+- Add temporary UI for workspace repository management `(PR #1791)`
+- add helper routine for instantiating github app from multitenant credentials `(PR #1758)`
   - A simple helper routine to the multitenantenv package that automatically populates a github app struct with the provided validated credentials.
-- use default cookie for github app oauth login `#1571`
+- use default cookie for github app oauth login `(PR #1571)`
   - The routing logic for multitenant mode now has a new route that uses the "last seen tenant" cookie to route github app login authorization callbacks to the appropriate tenant.
 
 #### Release
 
-- add pg16 and pg16 codeinsights to published images `#1731`
+- add pg16 and pg16 codeinsights to published images `(PR #1731)`
   - feat(rel): Add Postgresql 16 and Postgresql 16 codeinsights images to published image list.
-- add pg 16 codeinsights entrypoint and tests `#1730`
+- add pg 16 codeinsights entrypoint and tests `(PR #1730)`
   - feat(rel): Add self updating to Postgres 16 codeinsights db image.
-- add pg 16 entrypoint and tests `#1718`
+- add pg 16 entrypoint and tests `(PR #1718)`
   - feat(rel): Add self updating to Postgres 16 container image.
-- Add wolfi postgres 16 codeinsights-db base image `#1619`
+- Add wolfi postgres 16 codeinsights-db base image `(PR #1619)`
   - feat(rel): Add Postgres 16 CodeInsights Wolfi image
-- Add wolfi postgres 16 base image `#1617`
+- Add wolfi postgres 16 base image `(PR #1617)`
   - feat(rel): Add Postgres 16 Wolfi image
 
 #### Release
 
-- Handle postgres version upgrades in upgrade test `#1918`
+- Handle postgres version upgrades in upgrade test `(PR #1918)`
   - refactor upgradetest
   - introduce proper handling of the postgres version upgrade
  Backport 9ccdf4200e3e08cea56bffe5779ca8a6cda2909c from #1894
 
 #### Search
 
-- include file paths in reranker items `#1866`
+- include file paths in reranker items `(PR #1866)`
   - Cody context now incorporates filename information in reranking, improving context quality when the reranker is enabled.
-- (new web ui) Add 'open in code host' button to repo root and folder pages `#1776`
-- (new web ui) Copy URL to clipboard when clicking 'Permalink' `#1774`
-- (new web ui) Show file/folder name in title instead of full path `#1735`
-- (new web ui) Add survey toast `#1453`
-- (new web ui) Show loading indicator when navigating up the file tree `#1465`
+- (new web ui) Add 'open in code host' button to repo root and folder pages `(PR #1776)`
+- (new web ui) Copy URL to clipboard when clicking 'Permalink' `(PR #1774)`
+- (new web ui) Show file/folder name in title instead of full path `(PR #1735)`
+- (new web ui) Add survey toast `(PR #1453)`
+- (new web ui) Show loading indicator when navigating up the file tree `(PR #1465)`
 
 #### Sg
 
-- add workspaces common operations `#1845`
+- add workspaces common operations `(PR #1845)`
   - support `get`, `list`, and `delete` workspaces to `sg`
 
 #### Source
 
-- Allow GitHub code host connections to specify an external account as the authenticator `#1842`
-- multitenant: add worker job for inserting github multitenant app credentials `#1668`
+- Allow GitHub code host connections to specify an external account as the authenticator `(PR #1842)`
+- multitenant: add worker job for inserting github multitenant app credentials `(PR #1668)`
   - A new worker job has been added that updates the database with the credentials for the global github app when running in multitenant mode.
 
 #### Telemetry
 
-- Add request client name and version to telemetry gateway payload `#1607`
+- Add request client name and version to telemetry gateway payload `(PR #1607)`
 
 #### Tenant/Reconciler
 
-- report backpressure when tenants > 0.85*targetMaxTenants `#1719`
-- exclude DESTROY_SUCCESS from global reconcile `#1534`
+- report backpressure when tenants > 0.85*targetMaxTenants `(PR #1719)`
+- exclude DESTROY_SUCCESS from global reconcile `(PR #1534)`
 
 #### Workspaces
 
-- check basic email validity to create invite `#1849`
-- always set displayName=name if displayName is not set `#1838`
-- email all workspace admins when a user joins a workspace `#1824`
-- add CheckWorkspaceName RPC `#1822`
-- Initial iteration of new creation flow `#1806`
-- check billing seats when joining and inviting `#1770`
-- always apply DEFAULT_WORKSPACE_INSTANCE_CLASS on workspace create `#1763`
-- accept instance class `#1752`
-- list eligible-to-join workspaces in UI `#1672`
-- explicit invites POC `#1624`
-- error-log illegal state transitions for Sentry `#1616`
-- list includes workpsaces a user can join via open invite `#1586`
-- make membership limits configurable `#1584`
-- name, display name, and open invite email domain blocklists `#1539`
-- free up assigned workspace slot when workspace is DESTROY_SUCCESS `#1535`
-- prevent management API from reading workspaces in deletion state `#1508`
-- prune iam store on deletion `#1504`
-- implement router pruning, add 'pruned_router_at', 'pruned_iam_at' `#1480`
-- delete and reconcile routes `#1440`
+- check basic email validity to create invite `(PR #1849)`
+- always set displayName=name if displayName is not set `(PR #1838)`
+- email all workspace admins when a user joins a workspace `(PR #1824)`
+- add CheckWorkspaceName RPC `(PR #1822)`
+- Initial iteration of new creation flow `(PR #1806)`
+- check billing seats when joining and inviting `(PR #1770)`
+- always apply DEFAULT_WORKSPACE_INSTANCE_CLASS on workspace create `(PR #1763)`
+- accept instance class `(PR #1752)`
+- list eligible-to-join workspaces in UI `(PR #1672)`
+- explicit invites POC `(PR #1624)`
+- error-log illegal state transitions for Sentry `(PR #1616)`
+- list includes workpsaces a user can join via open invite `(PR #1586)`
+- make membership limits configurable `(PR #1584)`
+- name, display name, and open invite email domain blocklists `(PR #1539)`
+- free up assigned workspace slot when workspace is DESTROY_SUCCESS `(PR #1535)`
+- prevent management API from reading workspaces in deletion state `(PR #1508)`
+- prune iam store on deletion `(PR #1504)`
+- implement router pruning, add 'pruned_router_at', 'pruned_iam_at' `(PR #1480)`
+- delete and reconcile routes `(PR #1440)`
 
 #### Workspaces/Blocklists
 
-- improve heuristics and errors `#1801`
+- improve heuristics and errors `(PR #1801)`
 
 #### Workspaces/Instances
 
-- add UNAVAILABLE, CAPACITY_PRESSURE states `#1712`
+- add UNAVAILABLE, CAPACITY_PRESSURE states `(PR #1712)`
 
 #### Workspaces/Integrations
 
-- provide workspace uri `#1477`
+- provide workspace uri `(PR #1477)`
 
 #### Workspaces/Web
 
-- as-you-type name validation POC `#1858`
+- as-you-type name validation POC `(PR #1858)`
 
 #### Others
 
-- switch to buildkite for nightly release pipeline `#1690`
+- switch to buildkite for nightly release pipeline `(PR #1690)`
   - N/A
-- add new telemetry v2 events for server side batch changes `#1666`
-- add events for interactions with search input toggle buttons `#1469`
-- add events for codenav actions `#1441`
-- make filters sidebar collapsible `#1437`
+- add new telemetry v2 events for server side batch changes `(PR #1666)`
+- add events for interactions with search input toggle buttons `(PR #1469)`
+- add events for codenav actions `(PR #1441)`
+- make filters sidebar collapsible `(PR #1437)`
   - Search filters sidebar is now collapsible
-- add dynamic filters and aggregation for repo metadata and topics `#1420`
+- add dynamic filters and aggregation for repo metadata and topics `(PR #1420)`
   - Added dynamic filters and the ability to aggregate by repo metadata and repo topic
-- render mdx as markdown `#1392`
+- render mdx as markdown `(PR #1392)`
   - Render .mdx files as markdown
 
 ### Fix
 
 #### Batch Changes
 
-- titles now break over multiple lines if they are too long `#1582`
+- titles now break over multiple lines if they are too long `(PR #1582)`
   - fix(batches): titles now break over multiple lines if they are too long
-- do not ignore bool env var parsing error `#1537`
+- do not ignore bool env var parsing error `(PR #1537)`
 
 #### Client
 
-- address pnpm lint:js:web issues and add job in CI `#1520`
+- address pnpm lint:js:web issues and add job in CI `(PR #1520)`
 
 #### Code Intelligence
 
-- Align repo batch settings between syntactic and precise indexing `#1663`
-- Fix wrong offset in policy iteration `#1546`
+- Align repo batch settings between syntactic and precise indexing `(PR #1663)`
+- Fix wrong offset in policy iteration `(PR #1546)`
 
 #### Cody
 
-- use models from model config for PLG chat `#1870`
-- sync allowed models in dotcom user rate limits with models.json `#1864`
+- use models from model config for PLG chat `(PR #1870)`
+- sync allowed models in dotcom user rate limits with models.json `(PR #1864)`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
-- filter allowed models based on subscription tier `#1636`
+- filter allowed models based on subscription tier `(PR #1636)`
 
 #### Database
 
-- drop unique slug contraint from github app table `#1689`
+- drop unique slug contraint from github app table `(PR #1689)`
   - The github_apps table has removed an erroneous unique constraint that accidentally incorporated an app's slug (which is mutable) as part of the unique identifier for an app.
 
 #### Database
 
-- update generated squash and schemas `#1917`
+- update generated squash and schemas `(PR #1917)`
 
 #### Dev
 
-- fix kill pubsubemulator `#1850`
-- correctly pick up error message from 'sg sams login' `#1482`
+- fix kill pubsubemulator `(PR #1850)`
+- correctly pick up error message from 'sg sams login' `(PR #1482)`
 
 #### Enterpriseportal
 
-- allow list to accept display name query of 2 characters `#1603`
+- allow list to accept display name query of 2 characters `(PR #1603)`
 
 #### Gateway
 
-- add blocked phrase if request was blocked due to flagged models list (PRIME-603) `#1670`
-- Make model cost a pointer (CODY-4007) `#1427`
+- add blocked phrase if request was blocked due to flagged models list (PRIME-603) `(PR #1670)`
+- Make model cost a pointer (CODY-4007) `(PR #1427)`
 
 #### Graphql
 
-- refactor getGithubAppFromEnvvar to use multitenantEnv.Config.AsGithubApp `#1767`
+- refactor getGithubAppFromEnvvar to use multitenantEnv.Config.AsGithubApp `(PR #1767)`
   - The logic in the new multitenant GraphQL resolvers has been reworked to use the new helper methods introduced in the Multitenant GitHub app configuration logic introduced in [https://app.graphite.dev/github/pr/sourcegraph/sourcegraph/1758/](https://app.graphite.dev/github/pr/sourcegraph/sourcegraph/1758/).
 
 #### Insights
 
-- Fix incorrect line counts in non-default config `#1517`
+- Fix incorrect line counts in non-default config `(PR #1517)`
   - Code insights should show correct line counts when enhanced language detection is turned off (note: this setting is on by default).
 
 #### Local
 
-- display external env overrides when displaying environment variables `#1595`
-- sg - fix images query to point to correct rule `#1430`
+- display external env overrides when displaying environment variables `(PR #1595)`
+- sg - fix images query to point to correct rule `(PR #1430)`
 
 #### Release
 
-- fix oob migrations hanging `#1959`
+- fix oob migrations hanging `(PR #1959)`
   - NA
   Backport a943412a99852332f921b52a0ee3179dc3331d20 from #1958
-- add vacuum after reindex in Postgres upgrade script `#1779`
+- add vacuum after reindex in Postgres upgrade script `(PR #1779)`
   - fix(rel): Add vacuum to Postgres upgrade process
-- install `sg` in the nightly pipeline GHA `#1675`
+- install `sg` in the nightly pipeline GHA `(PR #1675)`
   - N/A
 
 #### Release
 
-- correct views drift in postgres 16 `#1878`
+- correct views drift in postgres 16 `(PR #1878)`
   - add migrations to handle database drift caused during postgres 12 to postgres 16 upgrade
-- fix drift check in local upgradetest `#1832`
+- fix drift check in local upgradetest `(PR #1832)`
   - Fix bug in local upgrade test preventing final stage drift check via private monorepo
 
 #### Search
 
-- consistently marshal SearchTypeRegex as regexp `#1919`
+- consistently marshal SearchTypeRegex as regexp `(PR #1919)`
   - We sometimes would emit `patternType:regex` instead of `patternType:regexp`. We now always do regexp as well as treating regex as an alias for regexp.
   Backport a095b39ac39cfcbe3526ecf85ed6d50cb5fa3d9d from #1808
-- Executors on Kubernetes: propagate user and group from Executor env vars to batch change job pod `#1863`
+- Executors on Kubernetes: propagate user and group from Executor env vars to batch change job pod `(PR #1863)`
   - The environment variables `KUBERNETES_RUN_AS_USER` and `KUBERNETES_RUN_AS_GROUP` contribute to the Job `PodSpec`'s `SecurityContext`.
   - The default value for those variables is `-1`, which could cause errors with some Kubernetes clusters.
-- (new web app) Only update user activity data once on load `#1797`
-- (new web ui) Respect 'window.context.disableFeedbackSurvey' flag `#1778`
-- (search input) Treat not, and, or as keywords regardless of case `#1733`
-- (new web ui) Fix dimensions of line selection marker `#1417`
-- (new web ui) Add rollover effect to RadioButtonGroup `#1416`
-- (new web ui) Fix duplicate lint suggestion insertion `#1413`
-- (new web ui) Remove unintentional vertical scrollbars `#1411`
-- (new web ui) Only show specific repo menu items when features are enabled `#1401`
+- (new web app) Only update user activity data once on load `(PR #1797)`
+- (new web ui) Respect 'window.context.disableFeedbackSurvey' flag `(PR #1778)`
+- (search input) Treat not, and, or as keywords regardless of case `(PR #1733)`
+- (new web ui) Fix dimensions of line selection marker `(PR #1417)`
+- (new web ui) Add rollover effect to RadioButtonGroup `(PR #1416)`
+- (new web ui) Fix duplicate lint suggestion insertion `(PR #1413)`
+- (new web ui) Remove unintentional vertical scrollbars `(PR #1411)`
+- (new web ui) Only show specific repo menu items when features are enabled `(PR #1401)`
 
 #### Security
 
-- Do not expand env vars in executor logs `#1811`
+- Do not expand env vars in executor logs `(PR #1811)`
   - This change reduces the risk of secrets being emitted in executor logs even if there are bugs in the secret redaction logic.
 
 #### Sg
 
-- remove noop -d declaration for psql `#1455`
-- specify postgres database for psql commands `#1450`
+- remove noop -d declaration for psql `(PR #1455)`
+- specify postgres database for psql commands `(PR #1450)`
 
 #### Source
 
-- p4-fusion now decodes encode file paths from Perforce `#1347`
+- p4-fusion now decodes encode file paths from Perforce `(PR #1347)`
   - When cloning Perforce depots, Sourcegraph will now decode encoded paths correctly (paths that include characters like `@` and `#`)
 
 #### Tenant/Reconciler
 
-- do not check dormancy if still in PROVISION states, only check if needed `#1605`
-- on getTenantErr, report destroy state if in destroy state `#1563`
+- do not check dormancy if still in PROVISION states, only check if needed `(PR #1605)`
+- on getTenantErr, report destroy state if in destroy state `(PR #1563)`
 
 #### Workspaces
 
-- properly represent workspace state to management API `#1816`
-- fix DESTROY_PENDING proto adapter, improve handling of unknown states `#1814`
-- improve CreateWorkspace resilience `#1773`
-- remove broken down-migration statements `#1754`
-- support creating workspaces over API `#1714`
-- do not list all workspaces if user has no memberships `#1671`
-- tidy up email-disabled error log `#1667`
+- properly represent workspace state to management API `(PR #1816)`
+- fix DESTROY_PENDING proto adapter, improve handling of unknown states `(PR #1814)`
+- improve CreateWorkspace resilience `(PR #1773)`
+- remove broken down-migration statements `(PR #1754)`
+- support creating workspaces over API `(PR #1714)`
+- do not list all workspaces if user has no memberships `(PR #1671)`
+- tidy up email-disabled error log `(PR #1667)`
 
 #### Workspacesreconciler
 
-- fix double-counting of checked workspaces `#1753`
+- fix double-counting of checked workspaces `(PR #1753)`
 
 #### Others
 
-- Prompt page tweaks `#1899`
-- revision picker growth `#1875`
-- more contrast updates `#1871`
-- Reranker: recreate from config on every call `#1865`
-- prompt library visual updates `#1852`
-- Use standard protojson library for reducing memory `#1846`
-- Increase contrast everywhere `#1840`
-- make owner nullable in prompts `#1746`
-- only retry queries `#1706`
-- Reranker: listen to config changes, do not mutate config `#1705`
-- retry graphql on 502 errors `#1683`
+- Prompt page tweaks `(PR #1899)`
+- revision picker growth `(PR #1875)`
+- more contrast updates `(PR #1871)`
+- Reranker: recreate from config on every call `(PR #1865)`
+- prompt library visual updates `(PR #1852)`
+- Use standard protojson library for reducing memory `(PR #1846)`
+- Increase contrast everywhere `(PR #1840)`
+- make owner nullable in prompts `(PR #1746)`
+- only retry queries `(PR #1706)`
+- Reranker: listen to config changes, do not mutate config `(PR #1705)`
+- retry graphql on 502 errors `(PR #1683)`
   - fix(web): retry graphql requests on network errors
-- styling changes to explore panel and badges `#1528`
-- increase contrast of highlighted code background and line numbers in selected area `#508`
+- styling changes to explore panel and badges `(PR #1528)`
+- increase contrast of highlighted code background and line numbers in selected area `(PR #508)`
 
 ### Chore
 
 #### Ci
 
-- container structure test bzlmod migration `#1818`
-- migrate protobuf and rules_proto rules to bzlmod `#1749`
-- move buildifier prebuilt to bzlmod `#1709`
-- increase buildifier timeout to 6m `#1658`
-- move bazel_skylib to bzlmod `#1654`
-- bazel - remove build_tests_only flag for db tests `#1610`
-- bazel - add config settings to switch between pg-12 and pg-16 binaries `#1601`
-- refactor bazel migrations `#1583`
-- update github workflow for pg-12 and pg-16 package variants `#1580`
-- upgrade aspect bazel lib `#1425`
-- Upgrade to latest rules proto grpc `#1424`
-- enable db tests task to run on ci agents with postgres 16 `#1293`
-- upgrade rules_pkg `#976`
-- upgrade aspect cli `#975`
+- container structure test bzlmod migration `(PR #1818)`
+- migrate protobuf and rules_proto rules to bzlmod `(PR #1749)`
+- move buildifier prebuilt to bzlmod `(PR #1709)`
+- increase buildifier timeout to 6m `(PR #1658)`
+- move bazel_skylib to bzlmod `(PR #1654)`
+- bazel - remove build_tests_only flag for db tests `(PR #1610)`
+- bazel - add config settings to switch between pg-12 and pg-16 binaries `(PR #1601)`
+- refactor bazel migrations `(PR #1583)`
+- update github workflow for pg-12 and pg-16 package variants `(PR #1580)`
+- upgrade aspect bazel lib `(PR #1425)`
+- Upgrade to latest rules proto grpc `(PR #1424)`
+- enable db tests task to run on ci agents with postgres 16 `(PR #1293)`
+- upgrade rules_pkg `(PR #976)`
+- upgrade aspect cli `(PR #975)`
 
 #### Code Intelligence
 
-- Remove unused return value & pass TraceLogger `#1551`
-- Enable exhaustruct for more subfolders (part 2) `#1547`
-- Document why RepositoryID field is nil `#1545`
-- Add helper types for relationships `#1542`
+- Remove unused return value & pass TraceLogger `(PR #1551)`
+- Enable exhaustruct for more subfolders (part 2) `(PR #1547)`
+- Document why RepositoryID field is nil `(PR #1545)`
+- Add helper types for relationships `(PR #1542)`
 
 #### Dev
 
-- Delete tracking-issue package `#1556`
-- Add iterator helper for pagination `#1555`
-- Fix links to sg monorepo in Markdown `#1554`
-- Add more helper functions to iterext `#1549`
-- Enable exhaustruct for more subfolders `#1544`
-- Add helper package for property-based testing `#1540`
-- Introduce helper package for iter.Seq `#1522`
-- Fix links to sg monorepo `#1519`
-- Simplify language detection code in inventory `#1518`
-- Flip polarity of boolean for language detection `#1516`
-- Use a lazyFile type to consolidate lazy file content fetching `#1515`
-- Rename functions for clarity `#1514`
-- Remove direct usages of enry.IsVendor `#1513`
-- Simplify sorting logic `#1512`
-- Rename type Lang -> LanguageStats `#1511`
-- Migrate from sync.WaitGroup to conc APIs `#1495`
-- Fix warning about missing integrity field `#1494`
-- Update for loops for newer syntax `#1488`
-- Factor out offset & limit logic `#1486`
-- Switch to alternate orderedmap library `#1414`
-- Clarify docs & naming in debugserver code `#1384`
+- Delete tracking-issue package `(PR #1556)`
+- Add iterator helper for pagination `(PR #1555)`
+- Fix links to sg monorepo in Markdown `(PR #1554)`
+- Add more helper functions to iterext `(PR #1549)`
+- Enable exhaustruct for more subfolders `(PR #1544)`
+- Add helper package for property-based testing `(PR #1540)`
+- Introduce helper package for iter.Seq `(PR #1522)`
+- Fix links to sg monorepo `(PR #1519)`
+- Simplify language detection code in inventory `(PR #1518)`
+- Flip polarity of boolean for language detection `(PR #1516)`
+- Use a lazyFile type to consolidate lazy file content fetching `(PR #1515)`
+- Rename functions for clarity `(PR #1514)`
+- Remove direct usages of enry.IsVendor `(PR #1513)`
+- Simplify sorting logic `(PR #1512)`
+- Rename type Lang -> LanguageStats `(PR #1511)`
+- Migrate from sync.WaitGroup to conc APIs `(PR #1495)`
+- Fix warning about missing integrity field `(PR #1494)`
+- Update for loops for newer syntax `(PR #1488)`
+- Factor out offset & limit logic `(PR #1486)`
+- Switch to alternate orderedmap library `(PR #1414)`
+- Clarify docs & naming in debugserver code `(PR #1384)`
 
 #### Dev/Mt-Router
 
-- silence cache miss on default `#1565`
+- silence cache miss on default `(PR #1565)`
 
 #### Dotcom
 
-- rename 'cody services' to just 'cody gateway' `#1466`
+- rename 'cody services' to just 'cody gateway' `(PR #1466)`
 
 #### Frontend
 
-- Store model config in global var `#1805`
+- Store model config in global var `(PR #1805)`
 
 #### Gateway
 
-- A few small docs fixes `#1751`
-- Make provider type more specific `#1750`
+- A few small docs fixes `(PR #1751)`
+- Make provider type more specific `(PR #1750)`
 
 #### Local
 
-- small improvements to sg entitle `#1794`
+- small improvements to sg entitle `(PR #1794)`
 
 #### Msp/Iam
 
-- suggest standard IAM_MAX_DB_CONNS as env var `#1499`
+- suggest standard IAM_MAX_DB_CONNS as env var `(PR #1499)`
 
 #### Release
 
-- remove postgres-12 wolfi from published images `#1737`
+- remove postgres-12 wolfi from published images `(PR #1737)`
   - chore(rel): remove unused Postgres 12 images
-- remove appliance from published images and codebase `#1732`
+- remove appliance from published images and codebase `(PR #1732)`
   - chore(rel): remove appliance from published images
 
 #### Release
 
-- remove check against latest full version in `--post-release-version` code path `#1585`
+- remove check against latest full version in `--post-release-version` code path `(PR #1585)`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 
 #### Search
 
-- (new web ui) Improve search home page SG logo rendering `#1813`
-- add NodeJS 20 to the Bundled Executor image `#1569`
-- Update search web app title and description for SEO on dotcom `#1509`
-- Add JDK 17 and 21 to the Bundled Executor image `#1502`
-- (new web ui) Remove beta badge from search progress popover `#1418`
-- update CPU and MEM panels for zoekt `#1368`
+- (new web ui) Improve search home page SG logo rendering `(PR #1813)`
+- add NodeJS 20 to the Bundled Executor image `(PR #1569)`
+- Update search web app title and description for SEO on dotcom `(PR #1509)`
+- Add JDK 17 and 21 to the Bundled Executor image `(PR #1502)`
+- (new web ui) Remove beta badge from search progress popover `(PR #1418)`
+- update CPU and MEM panels for zoekt `(PR #1368)`
   - We have updated the CPU and MEM monitoring panels for Zoekt on Grafana. The new panels reduce redundancy and provide more insight into MEM distribution.
 
 #### Source
 
-- simplify oauth middleware `#1876`
-- Update the gitserver image lockfile to contain the latest p4-fusion `#1410`
-- Default perforce changelist mapping to enabled `#1376`
+- simplify oauth middleware `(PR #1876)`
+- Update the gitserver image lockfile to contain the latest p4-fusion `(PR #1410)`
+- Default perforce changelist mapping to enabled `(PR #1376)`
 
 #### Telemetry
 
-- align billing metadata values with 'sourcegraph/cody' `#1396`
+- align billing metadata values with 'sourcegraph/cody' `(PR #1396)`
 
 #### Telemetry/Geolocation
 
-- update DB-IP Lite database `#1468`
+- update DB-IP Lite database `(PR #1468)`
   - The local geolocation inference database used in telemetry and audit logs has been updated.
 
 #### Telemetrygateway
 
-- bump slow-request threshold `#1647`
+- bump slow-request threshold `(PR #1647)`
 
 #### Tenant/Reconciler
 
-- add some additional diagnostics `#1795`
+- add some additional diagnostics `(PR #1795)`
 
 #### Workspaces
 
-- include longer s&p500 names for fuzzy matching `#1844`
-- make unexpected errors more friendly `#1821`
-- add spans on write interactions `#1807`
-- instantiate large blocklists once in store `#1562`
+- include longer s&p500 names for fuzzy matching `(PR #1844)`
+- make unexpected errors more friendly `(PR #1821)`
+- add spans on write interactions `(PR #1807)`
+- instantiate large blocklists once in store `(PR #1562)`
 
 #### Workspaces/Web
 
-- use unified client constructor `#1828`
+- use unified client constructor `(PR #1828)`
 
 #### Others
 
-- Rename method to indicate lack of redaction clearly `#1790`
-- Reorder fields in executor Config `#1785`
-- Remove custom Set type `#1742`
-- Rename Set.Values() -> ValuesNonDet() for clarity `#1741`
-- Avoid materializing Set Values() just for length `#1739`
-- Add env var to disable precise & syntactic `#1707`
-- Bump autoindexing image SHAs `#1703`
-- Move CodyGatewayRateLimit calculation to where it's used `#1693`
-- remove env lock mechanism `#1593`
+- Rename method to indicate lack of redaction clearly `(PR #1790)`
+- Reorder fields in executor Config `(PR #1785)`
+- Remove custom Set type `(PR #1742)`
+- Rename Set.Values() -> ValuesNonDet() for clarity `(PR #1741)`
+- Avoid materializing Set Values() just for length `(PR #1739)`
+- Add env var to disable precise & syntactic `(PR #1707)`
+- Bump autoindexing image SHAs `(PR #1703)`
+- Move CodyGatewayRateLimit calculation to where it's used `(PR #1693)`
+- remove env lock mechanism `(PR #1593)`
   - fix(dev): remove env.Get lock that could cause a runtime panic
-- update event names `#1500`
-- remove robert from many CODENOTIFYs `#1421`
-- update new search events to make them easier to use `#1395`
+- update event names `(PR #1500)`
+- remove robert from many CODENOTIFYs `(PR #1421)`
+- update new search events to make them easier to use `(PR #1395)`
 
 ### Refactor
 
 #### Local
 
-- move reset-pg to internal/db `#1573`
+- move reset-pg to internal/db `(PR #1573)`
 
 ### Reverts
 
-- Revert "chore/dev: upgrade aspect_bazel_lib to 2.9.4 (#1713)" `#1713`
+- Revert "chore/dev: upgrade aspect_bazel_lib to 2.9.4 (#1713)" `(PR #1713)`
 
 ### Uncategorized
 
 #### Others
 
-- [Backport 5.10.x] Revert "chore(source): simplify oauth middleware" `#1928`
-- githubapp: Expose monolith GitHub app ClientID `#1904`
-- pnpm: Remove leftover appliance links in workspace `#1900`
-- core: Fixup pnpm lockfile `#1886`
-- tenant: Hide unlink button for SAMS external accounts `#1885`
-- auth: Hide unlink button for external accounts that cannot be unlinked `#1884`
-- svelte: Correctly hide navbar entries `#1883`
-- svelte: Add back settings link `#1882`
-- workspaces/billing: attach metadata and context without cancel whenever possible `#1881`
-- web: respect `expanded` in the search results URL `#1880`
+- [Backport 5.10.x] Revert "chore(source): simplify oauth middleware" `(PR #1928)`
+- githubapp: Expose monolith GitHub app ClientID `(PR #1904)`
+- pnpm: Remove leftover appliance links in workspace `(PR #1900)`
+- core: Fixup pnpm lockfile `(PR #1886)`
+- tenant: Hide unlink button for SAMS external accounts `(PR #1885)`
+- auth: Hide unlink button for external accounts that cannot be unlinked `(PR #1884)`
+- svelte: Correctly hide navbar entries `(PR #1883)`
+- svelte: Add back settings link `(PR #1882)`
+- workspaces/billing: attach metadata and context without cancel whenever possible `(PR #1881)`
+- web: respect `expanded` in the search results URL `(PR #1880)`
   - Fixed an issue where searches from saved URLs may now show aggregations by default
-- add timeout to gateway calls `#1879`
-- workspaces: Align styling for join page `#1860`
-- workspaces: Add tables for listing workspaces `#1857`
+- add timeout to gateway calls `(PR #1879)`
+- workspaces: Align styling for join page `(PR #1860)`
+- workspaces: Add tables for listing workspaces `(PR #1857)`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
-- workspaces: Slightly tweak style `#1851`
-- workspaces: Directly link to installation target `#1848`
-- tenant: Suppress some irrelevant missing_context pprof traces `#1847`
-- Workspaces: Fix workspace picker rendering in React `#1841`
+- workspaces: Slightly tweak style `(PR #1851)`
+- workspaces: Directly link to installation target `(PR #1848)`
+- tenant: Suppress some irrelevant missing_context pprof traces `(PR #1847)`
+- Workspaces: Fix workspace picker rendering in React `(PR #1841)`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
-- fix permissions connection resolver ordering `#1839`
-- workspaces: Add seat selector on plan page `#1835`
-- workspaces/billing: create RPC for purchasing seats `#1831`
-- workspaces/billing: extract subscription attribute computation into a `Plan` helper `#1830`
-- workspaces: Add updated workspace pickers for tenant `#1829`
+- fix permissions connection resolver ordering `(PR #1839)`
+- workspaces: Add seat selector on plan page `(PR #1835)`
+- workspaces/billing: create RPC for purchasing seats `(PR #1831)`
+- workspaces/billing: extract subscription attribute computation into a `Plan` helper `(PR #1830)`
+- workspaces: Add updated workspace pickers for tenant `(PR #1829)`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
-- workspaces: Add field to pre-purchase extra seats `#1826`
-- workspaces/billing: implement periodic workers for subscription renewal `#1823`
-- auth: Fix background contexts in validate authz provider `#1802`
-- redispool: support more configuration options `#1799`
-- workspaces/billing: add tests to `cmd/workspaces/internal/billing` `#1786`
-- workspaces/billing: update test for `ManagementService.CreateWorkspace` `#1784`
-- workspaces/billing: add database tests for customers `#1783`
-- workspaces/billing: add database tests for transactions `#1782`
-- Require `X-Requested-With` for Cody API (CODY-4209) `#1781`
+- workspaces: Add field to pre-purchase extra seats `(PR #1826)`
+- workspaces/billing: implement periodic workers for subscription renewal `(PR #1823)`
+- auth: Fix background contexts in validate authz provider `(PR #1802)`
+- redispool: support more configuration options `(PR #1799)`
+- workspaces/billing: add tests to `cmd/workspaces/internal/billing` `(PR #1786)`
+- workspaces/billing: update test for `ManagementService.CreateWorkspace` `(PR #1784)`
+- workspaces/billing: add database tests for customers `(PR #1783)`
+- workspaces/billing: add database tests for transactions `(PR #1782)`
+- Require `X-Requested-With` for Cody API (CODY-4209) `(PR #1781)`
   - `X-Requested-With` is now a required HTTP header for Cody API calls
-- Context: narrow down stopwords list `#1780`
-- workspaces/billing: ignore invoices that are not for the current instance `#1777`
-- workspaces/billing: support soft-deleting subscriptions `#1772`
-- feature/internal: upsert github credentials on tenant creation `#1769`
+- Context: narrow down stopwords list `(PR #1780)`
+- workspaces/billing: ignore invoices that are not for the current instance `(PR #1777)`
+- workspaces/billing: support soft-deleting subscriptions `(PR #1772)`
+- feature/internal: upsert github credentials on tenant creation `(PR #1769)`
   - The multitenant reconciler now proactively inserts the credentials for the shared multitenant GitHub app whenever a new tenant is created.
-- lib/cloudapi: add mt instance type `#1766`
-- tenant: Add configuration for MT GitHub App to localdev `#1756`
-- Seed builtin prompts `#1755`
+- lib/cloudapi: add mt instance type `(PR #1766)`
+- tenant: Add configuration for MT GitHub App to localdev `(PR #1756)`
+- Seed builtin prompts `(PR #1755)`
   - Prompts including "Document Code", "Explain Code", "Generate Unit Tests", "Find Code Smells"
-- tenant: Enable onebox on tenant creation `#1748`
-- Onebox: introduce 'nls' patterntype `#1744`
-- workspaces/billing: implement Stripe webhook handler `#1740`
-- cody-gateway: update deployment id for model `#1729`
-- workspaces/billing: implement seat purchase and consumption `#1723`
-- localdev: Disable precise, syntactic codeintel in multitenant mode `#1720`
-- workspaces/billing: use the "correct" way to list customer payment methods `#1717`
-- `sg start sveltekit-minimal` for quickly running the new UI `#1702`
-- conf: Move more types to conftypes `#1692`
-- Remove experimental admin onboarding v2 `#1691`
-- telemetry: Implement telemetry exports for workspaces `#1677`
-- autoedit: add speculative decoding `#1673`
+- tenant: Enable onebox on tenant creation `(PR #1748)`
+- Onebox: introduce 'nls' patterntype `(PR #1744)`
+- workspaces/billing: implement Stripe webhook handler `(PR #1740)`
+- cody-gateway: update deployment id for model `(PR #1729)`
+- workspaces/billing: implement seat purchase and consumption `(PR #1723)`
+- localdev: Disable precise, syntactic codeintel in multitenant mode `(PR #1720)`
+- workspaces/billing: use the "correct" way to list customer payment methods `(PR #1717)`
+- `sg start sveltekit-minimal` for quickly running the new UI `(PR #1702)`
+- conf: Move more types to conftypes `(PR #1692)`
+- Remove experimental admin onboarding v2 `(PR #1691)`
+- telemetry: Implement telemetry exports for workspaces `(PR #1677)`
+- autoedit: add speculative decoding `(PR #1673)`
   - autoedit: Add speculative decoding support from fireworks
-- fix `marketingTracking` sending null `#1669`
+- fix `marketingTracking` sending null `(PR #1669)`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
-- Prompts: fix prompt name validation and prompts migration  `#1664`
-- Add GraphQL resolvers to read and set a list of repositories for a GH App installation ID `#1657`
-- fixup: remove Git conflict marks in `sg.config.yaml` `#1649`
-- Require prompt field before successful submission `#1639`
-- Add builtin prompts field to prompts `#1633`
+- Prompts: fix prompt name validation and prompts migration  `(PR #1664)`
+- Add GraphQL resolvers to read and set a list of repositories for a GH App installation ID `(PR #1657)`
+- fixup: remove Git conflict marks in `sg.config.yaml` `(PR #1649)`
+- Require prompt field before successful submission `(PR #1639)`
+- Add builtin prompts field to prompts `(PR #1633)`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
-- Zoekt: refactor memory dashboards `#1618`
-- workspaces: add billing prototype for subscription creation `#1611`
-- admin: Update report an issue link `#1608`
-- change default autoedit model `#1589`
-- feat(cloud) sg cloud eph deploy: support ms env `#1581`
-- add Cody.promptLibrary telemetry `#1568`
+- Zoekt: refactor memory dashboards `(PR #1618)`
+- workspaces: add billing prototype for subscription creation `(PR #1611)`
+- admin: Update report an issue link `(PR #1608)`
+- change default autoedit model `(PR #1589)`
+- feat(cloud) sg cloud eph deploy: support ms env `(PR #1581)`
+- add Cody.promptLibrary telemetry `(PR #1568)`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
-- worker: Group tasks by purpose `#1566`
-- Improve policy iterator tests to not rely on SQL for insertion `#1560`
-- repoupdater: Fix slow scheduling of cloned->uncloned repos `#1552`
-- repoupdater: Fix reporting of background routines `#1550`
-- Update Prompts Library UI (list page) `#1548`
-- Update prompt detail header UI `#1538`
-- Context: remove experimental intent routing `#1536`
-- Add 'recommended' checkbox to new creation UI. `#1531`
-- dormancy: Also fall asleep tenants that never see traffic `#1530`
-- Fix reranker not being applied `#1529`
-- sg: Fix local dev pguser setup `#1506`
-- Context: ensure we propagate timeouts and missing repos `#1505`
-- Make Visual Studio Experimental `#1503`
+- worker: Group tasks by purpose `(PR #1566)`
+- Improve policy iterator tests to not rely on SQL for insertion `(PR #1560)`
+- repoupdater: Fix slow scheduling of cloned->uncloned repos `(PR #1552)`
+- repoupdater: Fix reporting of background routines `(PR #1550)`
+- Update Prompts Library UI (list page) `(PR #1548)`
+- Update prompt detail header UI `(PR #1538)`
+- Context: remove experimental intent routing `(PR #1536)`
+- Add 'recommended' checkbox to new creation UI. `(PR #1531)`
+- dormancy: Also fall asleep tenants that never see traffic `(PR #1530)`
+- Fix reranker not being applied `(PR #1529)`
+- sg: Fix local dev pguser setup `(PR #1506)`
+- Context: ensure we propagate timeouts and missing repos `(PR #1505)`
+- Make Visual Studio Experimental `(PR #1503)`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
-- Context: always use more items for reranker `#1476`
-- Remove insert prompt mode `#1475`
-- Add missing Cody Web Alert CSS variable override `#1474`
-- repoupdater: Fix no rows returned error `#1472`
-- add autoedits to cody gateway `#1459`
-- ci: bump go-mod-tidy step timeout `#1452`
-- Add commands to prompts migration `#1449`
-- repoupdater: Speed up repo_update_job dequeues `#1448`
-- repoupdater: Clean up metrics `#1447`
-- repoupdater: Speed up and simplify not fetched metric `#1446`
-- migration: Checkpoint new repo_update_jobs migration `#1445`
-- gomod: bump Zoekt for query perf fix `#1438`
-- Implement prompt detail page re-design `#1423`
+- Context: always use more items for reranker `(PR #1476)`
+- Remove insert prompt mode `(PR #1475)`
+- Add missing Cody Web Alert CSS variable override `(PR #1474)`
+- repoupdater: Fix no rows returned error `(PR #1472)`
+- add autoedits to cody gateway `(PR #1459)`
+- ci: bump go-mod-tidy step timeout `(PR #1452)`
+- Add commands to prompts migration `(PR #1449)`
+- repoupdater: Speed up repo_update_job dequeues `(PR #1448)`
+- repoupdater: Clean up metrics `(PR #1447)`
+- repoupdater: Speed up and simplify not fetched metric `(PR #1446)`
+- migration: Checkpoint new repo_update_jobs migration `(PR #1445)`
+- gomod: bump Zoekt for query perf fix `(PR #1438)`
+- Implement prompt detail page re-design `(PR #1423)`
   - Re-designed prompt detail page.
-- Add page faults to Zoekt memory metrics `#1422`
-- chore/source Update src-cli version to 5.8.2 `#1415`
+- Add page faults to Zoekt memory metrics `(PR #1422)`
+- chore/source Update src-cli version to 5.8.2 `(PR #1415)`
   - chore/source Update src-cli version to 5.8.2
-- siteadmin: Reset pagination cursors after filter change `#1404`
-- bugfix: fix settings link `#1393`
-- gomod: bump Zoekt for go-git optimization `#1391`
-- Update Marketing URLs in the site footer links `#1390`
-- Soft delete prompts `#1386`
-- Widen blocked phrases, but only confine blocked phrases to expensive (aka flagged) models `#1344`
+- siteadmin: Reset pagination cursors after filter change `(PR #1404)`
+- bugfix: fix settings link `(PR #1393)`
+- gomod: bump Zoekt for go-git optimization `(PR #1391)`
+- Update Marketing URLs in the site footer links `(PR #1390)`
+- Soft delete prompts `(PR #1386)`
+- Widen blocked phrases, but only confine blocked phrases to expensive (aka flagged) models `(PR #1344)`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
-- repoupdater: Drop support for gitUpdateInterval `#1339`
+- repoupdater: Drop support for gitUpdateInterval `(PR #1339)`
   - The site config setting `gitUpdateInterval` has been deprecated and removed. We are removing it in favor of smarter heuristics like webhooks, user traffic, and repo staleness.
-- repoupdater: Remove total from schedule and update queue state `#1338`
-- Add system workspace admin role `#1327`
-- Add syntactic worker to images so it gets updated in helm charts `#1323`
-- feature/source: adjust exclude definition in github schema to disallow using name, id with other filter conditions `#1250`
+- repoupdater: Remove total from schedule and update queue state `(PR #1338)`
+- Add system workspace admin role `(PR #1327)`
+- Add syntactic worker to images so it gets updated in helm charts `(PR #1323)`
+- feature/source: adjust exclude definition in github schema to disallow using name, id with other filter conditions `(PR #1250)`
   - The github code host connection schema for `exclude` has been updated to enforce that the name and id fields can't be combined with any other fields.
-- Add gitSSHCipher for git code hosts `#1175`
-- RFC: Dormancy and tenant states `#756`
-- web telemetry: update `marketingTracking` to retrieve latest cookies set on web `#460`
+- Add gitSSHCipher for git code hosts `(PR #1175)`
+- RFC: Dormancy and tenant states `(PR #756)`
+- web telemetry: update `marketingTracking` to retrieve latest cookies set on web `(PR #460)`
 
 ### Untracked
 
 The following PRs were merged onto the previous release branch but could not be automatically mapped to a corresponding commit in this release:
 
-- Fix wrong offset in policy iteration `#1559`
-- Release: Prep stitched migration graph for release (#1388) `#1389`
+- Fix wrong offset in policy iteration `(PR #1559)`
+- Release: Prep stitched migration graph for release (#1388) `(PR #1389)`
   - n/a
 
 {/* RSS={"version":"v5.10.0", "releasedAt": "2024-11-27"} */}
@@ -718,23 +718,23 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Code Intelligence
 
-- Fix wrong offset in policy iteration `#1559`
+- Fix wrong offset in policy iteration `(PR #1559)`
 
 #### Cody
 
-- fix broken homepage redirect for cody only plans `#1626`
+- fix broken homepage redirect for cody only plans `(PR #1626)`
   - When using an instance with a Cody-only license, accessing the home page now correctly redirects you to /cody/dashboard, instead of a non-existent /cody page.
   Backport a4cb5a0723bad18e1c215d81231db457d1abfbdb from #1621
 
 #### Search
 
-- (new web ui) Disable persistence for history/explore panel `#1614`
+- (new web ui) Disable persistence for history/explore panel `(PR #1614)`
 
 ### Chore
 
 #### Release
 
-- remove extra v identifier for version in artifact exporter `#1594`
+- remove extra v identifier for version in artifact exporter `(PR #1594)`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
   Backport c4b838103ce2f71e7591ade720e8bdf17f9a5b39 from #1490
 
@@ -746,7 +746,7 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Others
 
-- [Backport 5.9.x] azure: Add support for repositoryPathPattern `#1629`
+- [Backport 5.9.x] azure: Add support for repositoryPathPattern `(PR #1629)`
   - Added support for the `repositoryPathPattern` property to Azure DevOps code host connections.
   - Fixed an issue where Azure DevOps repo names included a port number - aligning with other code host connection implementations  Backport 762bd89a12825ff05de98d9c2d8adfcf1ef5bf4a from #1543
 
@@ -769,7 +769,7 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Dev
 
-- hoist env vars init to avoid repo-updater panic `#1527`
+- hoist env vars init to avoid repo-updater panic `(PR #1527)`
 
 ### Reverts
 
@@ -798,7 +798,7 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Others
 
-- "Add syntactic worker to images so it gets updated in helm charts"" `#1483`
+- "Add syntactic worker to images so it gets updated in helm charts"" `(PR #1483)`
 
 {/* RSS={"version":"v5.9.45", "releasedAt": "2024-11-05"} */}
 
@@ -819,68 +819,68 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Api
 
-- Added a better error message for 429 errors for `/.api/cody/completions` (CODY-4097) `#1380`
+- Added a better error message for 429 errors for `/.api/cody/completions` (CODY-4097) `(PR #1380)`
 
 #### Audit
 
-- add tenant to audit logs, fix log stack `#960`
+- add tenant to audit logs, fix log stack `(PR #960)`
 
 #### Batch Changes
 
-- show name of additional fields that cause errors `#799`
+- show name of additional fields that cause errors `(PR #799)`
   - feat(batches): show name of additional fields that cause errors
 
 #### Ci
 
-- generate frozen files as part of stich_migration_graph generation `#957`
-- record Test infrastructure failures `#884`
+- generate frozen files as part of stich_migration_graph generation `(PR #957)`
+- record Test infrastructure failures `(PR #884)`
   - add library that writes to TEST_INFRASTRUCTURE_FAILURE_FILE if it is defined for test failures
 
 #### Cloud
 
-- allow monolithsams instances to have no conf auth providers `#1247`
-- add support to override target managed service endpoints `#1238`
-- add support to override license generation public key from cloud site config `#1193`
+- allow monolithsams instances to have no conf auth providers `(PR #1247)`
+- add support to override target managed service endpoints `(PR #1238)`
+- add support to override license generation public key from cloud site config `(PR #1193)`
 
 #### Code Intelligence
 
-- Syntactic indexing grafana monitoring dashboard `#1263`
+- Syntactic indexing grafana monitoring dashboard `(PR #1263)`
 
 #### Cody
 
-- add more API docs content `#1378`
-- add CLI tool to compute PCW `#1349`
-- Add Claude 3.5 Sonnet (Latest) & Claude 3 Opus (Latest) `#1244`
-- add Cody Audit Log `#1232`
-- add cody audit log table and store `#1182`
-- Expose token usage in the LLM API `#1070`
+- add more API docs content `(PR #1378)`
+- add CLI tool to compute PCW `(PR #1349)`
+- Add Claude 3.5 Sonnet (Latest) & Claude 3 Opus (Latest) `(PR #1244)`
+- add Cody Audit Log `(PR #1232)`
+- add cody audit log table and store `(PR #1182)`
+- Expose token usage in the LLM API `(PR #1070)`
   - The `/.api/completions/stream` API now includes used input/output tokens and the upstream model name in the response body when using the query parameter `api-version=5` or higher. Does not apply to: Vertex Anthropic, Azure OpenAI (mo model name, and no token usage in streaming response), Gemini (no model name in streaming response)
   - LLM chat completions now support `stream: false` when using Azure OpenAI and OpenAI-compatible providers.
-- update telemetry feature prefix for Cody API `#1023`
-- add embedded API docs via OpenAPI/Redocly `#1014`
+- update telemetry feature prefix for Cody API `(PR #1023)`
+- add embedded API docs via OpenAPI/Redocly `(PR #1014)`
   - New OpenAPI API docs within the instance at the URL `$SRC_ENDPOINT/api/openapi/public`. Alternatively, reach the page at "User > Settings > OpenAPI Reference".
-- add basic telemetry recording for Cody API `#943`
-- add support to format raw API responses for Cody `#877`
+- add basic telemetry recording for Cody API `(PR #943)`
+- add support to format raw API responses for Cody `(PR #877)`
   - The raw HTTP API now accepts the query paramter `format=cody` or header `Accept: application/cody` to render files and directories as context items for Cody. Example request path: `/github.com/sourcegraph/cody/-/raw/agent/src/index.ts?format=cody`.
 
 #### Cody-Gateway
 
-- add new claude-3-5-haiku-latest model `#1471`
+- add new claude-3-5-haiku-latest model `(PR #1471)`
 Cody Gateway: add new claude-3-5-haiku-latest dotcom models list  Backport 11e7481ba3c810ae5b47d32b8cf32066e2f0b2bb from #1470
-- deprecate old claude 3.5 sonnet `#1248`
+- deprecate old claude 3.5 sonnet `(PR #1248)`
 
 #### Dev
 
-- add externalSecret support for commandsets `#1027`
-- sg sams login and cookie-less workspace creation `#913`
+- add externalSecret support for commandsets `(PR #1027)`
+- sg sams login and cookie-less workspace creation `(PR #913)`
 
 #### Graphql
 
-- upload graphql schemas to GCS bucket `#1245`
+- upload graphql schemas to GCS bucket `(PR #1245)`
 
 #### Internal/Requestclient
 
-- have HTTP middleware populate all response headers with observed X-Forwarded-For and calculated IP for debugging purposes `#524`
+- have HTTP middleware populate all response headers with observed X-Forwarded-For and calculated IP for debugging purposes `(PR #524)`
   - All of Sourcegraph's HTTP responses now contain two new headers for easier debugging purposes.
 - `Observed-X-Forwarded-For`: echos the `X-Forwarded-For` header
 that we observed on the user's incoming request
@@ -888,560 +888,560 @@ that we observed on the user's incoming request
 
 #### Local
 
-- use pending spinner for build waiting in cloud ephemeral `#1039`
-- add format for displaying env `#918`
+- use pending spinner for build waiting in cloud ephemeral `(PR #1039)`
+- add format for displaying env `(PR #918)`
 
 #### Monitoring
 
-- set decimals to 1 for standard heatmap `#1361`
+- set decimals to 1 for standard heatmap `(PR #1361)`
 
 #### Monolithsams
 
-- load SAMS provider and creds from env `#1024`
+- load SAMS provider and creds from env `(PR #1024)`
 
 #### Msp
 
-- package 'auditlog' `#1223`
+- package 'auditlog' `(PR #1223)`
 
 #### Msp/Pg
 
-- updated o11y for pool acquire, add overrides for pgxpool.Config `#1375`
+- updated o11y for pool acquire, add overrides for pgxpool.Config `(PR #1375)`
 
 #### Search
 
-- (new web ui) Show loading feedback for hovercards `#1239`
-- (new web ui) Add ability so switch search scope in fuzzy finder `#1201`
-- (new web ui) Make view modes available when opening a file at a commit `#1090`
-- (new web ui) Render relative images in rich text documents `#841`
+- (new web ui) Show loading feedback for hovercards `(PR #1239)`
+- (new web ui) Add ability so switch search scope in fuzzy finder `(PR #1201)`
+- (new web ui) Make view modes available when opening a file at a commit `(PR #1090)`
+- (new web ui) Render relative images in rich text documents `(PR #841)`
 
 #### Sg
 
-- make workspaces endpoint configurable `#998`
-- implement show-env flag `#883`
+- make workspaces endpoint configurable `(PR #998)`
+- implement show-env flag `(PR #883)`
 
 #### Site Admin
 
-- site config 'telemetry: \{ disableLocalEventLogs \}' to disable event_logs `#1275`
+- site config 'telemetry: \{ disableLocalEventLogs \}' to disable event_logs `(PR #1275)`
   - Long-term local retention of user telemetry as 'event logs' can now be disabled entirely via the `telemetry: { disableLocalEventLogs }` site configuration.
 
 #### Sub_repo_perms
 
-- add conditional logging for seeing if sub_repo_permisisons are working `#673`
+- add conditional logging for seeing if sub_repo_permisisons are working `(PR #673)`
   - The sub repository permissions implementation now emits logs that describe the rules that were evaluated for a given request whenever tracing is enabled. (We limit these logs for only when tracing is enabled since they can be quite verbose).
 
 #### Telemetry
 
-- Log estimated LLM cost telemetry (CODY-4007) `#1312`
+- Log estimated LLM cost telemetry (CODY-4007) `(PR #1312)`
   - Adds cost estimates to the ModelConfiguration returned by `.api/llm/supported-models.json`
   - Adds `llmTokenUsageCostEstimate` telemetry value with estimates of each requests LLM cost in pennies
-- Add check for PGDATASOURCE `#1281`
-- Add source.server.server_client.user_agent to telemetry payload `#1120`
+- Add check for PGDATASOURCE `(PR #1281)`
+- Add source.server.server_client.user_agent to telemetry payload `(PR #1120)`
   - Add the sourcegraph API client user-agent to telemetry payload types under `source.server.server_client.user_agent`.
-- check for external dbs `#1083`
-- propagate new x-sourcegraph-api-client-* headers to request clients `#1025`
+- check for external dbs `(PR #1083)`
+- propagate new x-sourcegraph-api-client-* headers to request clients `(PR #1025)`
   - Propagates new X-Sourcegraph-API-Client-Name and X-Sourcegraph-API-Client-Version headers to request clients
 
 #### Telemetry-Gateway
 
-- improve logging on processing done `#1252`
+- improve logging on processing done `(PR #1252)`
 
 #### Telemetrygateway
 
-- implement publishusermetadata RPC `#1095`
-- spec PublishInstanceUserMetadata and pubsub format `#1053`
+- implement publishusermetadata RPC `(PR #1095)`
+- spec PublishInstanceUserMetadata and pubsub format `(PR #1053)`
 
 #### Telemetrygatewayexporter
 
-- log export duration, use better duration buckets `#1305`
+- log export duration, use better duration buckets `(PR #1305)`
 
 #### Tenant/Reconciler
 
-- full membership reconcile `#953`
-- handle tenant-exists, new-tenant, and error combination paths `#895`
+- full membership reconcile `(PR #953)`
+- handle tenant-exists, new-tenant, and error combination paths `(PR #895)`
 
 #### Worker
 
-- delete legacy event_logs exporter `#859`
+- delete legacy event_logs exporter `(PR #859)`
 
 #### Worker/Telemetrygatewayexporter
 
-- opt-in user metadata exporter `#1096`
+- opt-in user metadata exporter `(PR #1096)`
 
 #### Workspaces
 
-- notify user state updates `#1316`
-- allow join-by-email to be provided on creation `#1280`
-- add management GetWorkspace that allows view-by-email-domain `#1277`
-- guard against excessive join-workspaces `#1251`
-- restrict memberships/admins before allowing workspace creation `#1212`
-- join by email domain POC `#1162`
-- configure join by email domains `#1158`
-- only recently seen instances are candidates for hosting workspace `#1031`
-- ban 'default' as a workspace name `#992`
-- forbid 'src-'-prefix workspace names `#920`
-- refactor workspace states with reconcile and dormancy `#819`
+- notify user state updates `(PR #1316)`
+- allow join-by-email to be provided on creation `(PR #1280)`
+- add management GetWorkspace that allows view-by-email-domain `(PR #1277)`
+- guard against excessive join-workspaces `(PR #1251)`
+- restrict memberships/admins before allowing workspace creation `(PR #1212)`
+- join by email domain POC `(PR #1162)`
+- configure join by email domains `(PR #1158)`
+- only recently seen instances are candidates for hosting workspace `(PR #1031)`
+- ban 'default' as a workspace name `(PR #992)`
+- forbid 'src-'-prefix workspace names `(PR #920)`
+- refactor workspace states with reconcile and dormancy `(PR #819)`
 
 #### Workspaces/Management
 
-- always return roles `#1358`
-- provide workspace URI `#1055`
+- always return roles `(PR #1358)`
+- provide workspace URI `(PR #1055)`
 
 #### Workspacesreconciler
 
-- add WORKSPACESRECONCILER_INSTANCE_STATE_OVERRIDE and 'AT_CAPACITY' state `#1297`
-- global periodic reconciler `#997`
+- add WORKSPACESRECONCILER_INSTANCE_STATE_OVERRIDE and 'AT_CAPACITY' state `(PR #1297)`
+- global periodic reconciler `(PR #997)`
 
 #### Others
 
-- surface result precision in the explore panel `#1359`
-- more complete search backend events `#1257`
-- add embedded file snippet page `#1196`
+- surface result precision in the explore panel `(PR #1359)`
+- more complete search backend events `(PR #1257)`
+- add embedded file snippet page `(PR #1196)`
   - Added embeddable page for file snippets
-- add embedded file snippet component `#1122`
-- add search aggregations to svelte webapp `#1093`
+- add embedded file snippet component `(PR #1122)`
+- add search aggregations to svelte webapp `(PR #1093)`
 
 ### Fix
 
 #### Api-Docs
 
-- Added OpenAPI Urls to static page info `#1379`
+- Added OpenAPI Urls to static page info `(PR #1379)`
 
 #### Batch Changes
 
-- enable request splitting by default `#1229`
+- enable request splitting by default `(PR #1229)`
   - fix(batches): enable request splitting by default
-- handle spec being nil for suffix salt `#1228`
+- handle spec being nil for suffix salt `(PR #1228)`
   - fix(batches): handle spec being nil for suffix salt
-- enable GQL request splitting via BATCH_CHANGES_REQUEST_SPLITTING `#1150`
+- enable GQL request splitting via BATCH_CHANGES_REQUEST_SPLITTING `(PR #1150)`
   - fix(batches): enable GQL request splitting via BATCH_CHANGES_REQUEST_SPLITTING
-- display "Deleted Namespace" instead of throwing an error `#778`
+- display "Deleted Namespace" instead of throwing an error `(PR #778)`
   - fix(batches): display "Deleted Namespace" instead of throwing an error
 
 #### Ci
 
-- remove dependsOn key for PG16 step `#1295`
-- disable db test task temporarily `#1292`
-- generate coreos iptable BUILD.bazel file `#1230`
-- cap branch names in image tags `#1103`
+- remove dependsOn key for PG16 step `(PR #1295)`
+- disable db test task temporarily `(PR #1292)`
+- generate coreos iptable BUILD.bazel file `(PR #1230)`
+- cap branch names in image tags `(PR #1103)`
 
 #### Code Monitor
 
-- fail monitors with missing/unverified primary email address `#938`
+- fail monitors with missing/unverified primary email address `(PR #938)`
   - fix(code-monitor): fail monitors with missing/unverified primary email address
 
 #### Code Intelligence
 
-- Add more limits in auto-indexing inference code `#1170`
+- Add more limits in auto-indexing inference code `(PR #1170)`
   - Introduces new limits for auto-indexing inference to reduce the risk of continuously growing auto-indexing queues.
   - The number of jobs spawned per round of auto-indexing inference per repo is capped (default: 100) to reduce risk of clogging of auto-indexing queues. Excess jobs will be discarded.
   - The number of paths inspected for a single round of auto-indexing inference per repo is capped (default: 500) to reduce risk of timeouts. Excess paths will be discarded.
-- Handle annotated tag hashes passed as 'commit' for uploads `#1135`
+- Handle annotated tag hashes passed as 'commit' for uploads `(PR #1135)`
   - Fixes handling of SCIP uploads when the hash passed to the `-commit` flag of `src-cli` corresponds to the hash of an annotated tag instead of the hash of a commit. Previously, these uploads were not accessible for code navigation.
-- Propagate error collector to fix retention tab GraphQL API call `#847`
+- Propagate error collector to fix retention tab GraphQL API call `(PR #847)`
   - Fixes a bug where the retention tab for precise indexes would show
 a nil pointer exception instead of retention information.
 
 #### Code Nav
 
-- Trigger hovers for all programming languages `#1076`
+- Trigger hovers for all programming languages `(PR #1076)`
   - Fixes a bug where hovers were not triggered for less mainstream languages like F#,
 Standard ML, Visual Basic, Pkl, Hack, MATLAB etc.
 
 #### Cody
 
-- convert nil message content parts for OpenAI compatability `#1467`
-- guard against completion usage missing (CODY-4135) `#1218`
-- API telemetry `#1026`
-- reset usage when rate limit value or interval decreased `#1015`
-- fix CodyLLMConfiguration resolver `#839`
+- convert nil message content parts for OpenAI compatability `(PR #1467)`
+- guard against completion usage missing (CODY-4135) `(PR #1218)`
+- API telemetry `(PR #1026)`
+- reset usage when rate limit value or interval decreased `(PR #1015)`
+- fix CodyLLMConfiguration resolver `(PR #839)`
 
 #### Codyapi
 
-- Restrict audit log retrieval to site admins only `#1285`
-- Add usage to completions/chat (CODY-3498) `#1131`
+- Restrict audit log retrieval to site admins only `(PR #1285)`
+- Add usage to completions/chat (CODY-3498) `(PR #1131)`
   - Added token usage information to `.api/llm/chat/completions`
 
 #### Completions
 
-- clear out usage information on the completions API when version < 5 (CODY-4114) `#1153`
+- clear out usage information on the completions API when version < 5 (CODY-4114) `(PR #1153)`
 
 #### Dev
 
-- Correctly propagate error key-value pairs `#1258`
+- Correctly propagate error key-value pairs `(PR #1258)`
   - Fixes a bug where logs and traces were sometimes missing key-value pairs recorded alongside errors.
-- fix sg db reset-pg PGUSER overwrite `#1220`
-- fix secrets deadlock `#1032`
-- fix workspaces client in local dev `#1028`
-- (new web ui) Properly initialize local dev defaults `#961`
-- remove removed table from MT migration `#910`
-- report warning if workspace creation failed `#909`
-- fix workspaces flakey test `#862`
+- fix sg db reset-pg PGUSER overwrite `(PR #1220)`
+- fix secrets deadlock `(PR #1032)`
+- fix workspaces client in local dev `(PR #1028)`
+- (new web ui) Properly initialize local dev defaults `(PR #961)`
+- remove removed table from MT migration `(PR #910)`
+- report warning if workspace creation failed `(PR #909)`
+- fix workspaces flakey test `(PR #862)`
 
 #### Frontend
 
-- place requestclient as one of the first middleware `#1215`
+- place requestclient as one of the first middleware `(PR #1215)`
 
 #### Local
 
-- move env into correct grouping `#1332`
-- specify default database when checking psql version in `sg setup` `#924`
-- fix issue with sg start monitoring ignoring dockerCommands `#848`
+- move env into correct grouping `(PR #1332)`
+- specify default database when checking psql version in `sg setup` `(PR #924)`
+- fix issue with sg start monitoring ignoring dockerCommands `(PR #848)`
 
 #### Mt-Router
 
-- prevent infinite oauth redirect `#1118`
+- prevent infinite oauth redirect `(PR #1118)`
 
 #### Release
 
-- rename generated changelog file `#1136`
-- Add stitched migration graph override (#935) `#941`
+- rename generated changelog file `(PR #1136)`
+- Add stitched migration graph override (#935) `(PR #941)`
   - NA
 
 #### Search
 
-- disable hybrid search with index:no `#1462`
-  - `index:no` will now avoid the index completely. Previously it would still consult the index via a process called hybrid search. Search jobs always uses `index:no`, so if you notice a performance problem please reach out to Sourcegraph support. Setting `SRC_DISABLE_RESPECT_INDEX_FIELD` environment variable on the frontend and worker pods will disable this new behaviour in 5.9.x only.Stacked on `#1456`Closes [https://linear.app/sourcegraph/issue/SPLF-663/disable-hybrid-search-for-search-jobs](https://linear.app/sourcegraph/issue/SPLF-663/disable-hybrid-search-for-search-jobs)  Backport 7aced46a7bc3526695a77e492ee69ad2cfa7bb17 from #1460
-- (new web ui) Render submodules differently in file trees `#1377`
-- Fix document highlights in certain situations `#1343`
-- (new web ui) Fix relative links to folders `#1331`
-- (new web ui) Fix file tree sidebar not staying at top level directory `#1328`
-- (new web ui) Show informative message when repo has no README or description `#1240`
-- (new web ui) Fix linkifying files `#1236`
-- (new web ui) Make blob view readonly `#1234`
+- disable hybrid search with index:no `(PR #1462)`
+  - `index:no` will now avoid the index completely. Previously it would still consult the index via a process called hybrid search. Search jobs always uses `index:no`, so if you notice a performance problem please reach out to Sourcegraph support. Setting `SRC_DISABLE_RESPECT_INDEX_FIELD` environment variable on the frontend and worker pods will disable this new behaviour in 5.9.x only.Stacked on `(PR #1456)` Closes [https://linear.app/sourcegraph/issue/SPLF-663/disable-hybrid-search-for-search-jobs](https://linear.app/sourcegraph/issue/SPLF-663/disable-hybrid-search-for-search-jobs)  Backport 7aced46a7bc3526695a77e492ee69ad2cfa7bb17 from #1460
+- (new web ui) Render submodules differently in file trees `(PR #1377)`
+- Fix document highlights in certain situations `(PR #1343)`
+- (new web ui) Fix relative links to folders `(PR #1331)`
+- (new web ui) Fix file tree sidebar not staying at top level directory `(PR #1328)`
+- (new web ui) Show informative message when repo has no README or description `(PR #1240)`
+- (new web ui) Fix linkifying files `(PR #1236)`
+- (new web ui) Make blob view readonly `(PR #1234)`
   - Prevents default browser shortcuts from modifying the file content locally.
-- (new web ui) Prevent uncaught error when navigating back to file page `#1199`
-- (new web ui) Show helpful message for root commit/change list page `#1138`
-- (new web ui) Do not show loading spinner for empty commit ranges on compare page `#1126`
-- (new web ui) Fix search aggregation styles `#1125`
-- exclude content filters from phrase boosting `#1038`
+- (new web ui) Prevent uncaught error when navigating back to file page `(PR #1199)`
+- (new web ui) Show helpful message for root commit/change list page `(PR #1138)`
+- (new web ui) Do not show loading spinner for empty commit ranges on compare page `(PR #1126)`
+- (new web ui) Fix search aggregation styles `(PR #1125)`
+- exclude content filters from phrase boosting `(PR #1038)`
   - This fixes a bug where we would apply a phrase boost if a `content:` filter was specified with keyword search enabled. This led to inconsistent behavior (regexp vs keyword search) and it also rendered the `content:` filter ineffective, because we ran a general text search instead of a just a content search.
-- (new web ui) 'File not found' when quickly navigating between files `#959`
-- (new web ui) Blame view not visible for files that use `\r` as line separators `#929`
-- (new web ui) Show settings link to site admins when repo error occurs `#817`
+- (new web ui) 'File not found' when quickly navigating between files `(PR #959)`
+- (new web ui) Blame view not visible for files that use `\r` as line separators `(PR #929)`
+- (new web ui) Show settings link to site admins when repo error occurs `(PR #817)`
 
 #### Sg
 
-- workaround dangling dev resources `#1048`
+- workaround dangling dev resources `(PR #1048)`
 
 #### Source
 
-- correct Name() documentation for gitserver's ReadDirIterator `#1278`
+- correct Name() documentation for gitserver's ReadDirIterator `(PR #1278)`
   - The documentation for gitserver's ReadDir method has been clarified to reflect that the return iterator's Name() method returns the full path of the file, as opposed to just the basename.
-- multiple GitHub external accounts to the same URL now refresh correctly `#1260`
+- multiple GitHub external accounts to the same URL now refresh correctly `(PR #1260)`
   - When there are multiple auth providers configured that point to the same GitHub URL, as can be the case when using private GitHub Apps, user external account tokens will now refresh correctly.
-- clarify exclude docs in github connection schema to say that individual expressions within block are `and`-ed together `#1249`
+- clarify exclude docs in github connection schema to say that individual expressions within block are `and`-ed together `(PR #1249)`
   - The documentation for the "exclude" section in the github code host connection schema has been clarified to explain that each block is OR'd together, and the expressions within each block are AND'd together.
-- Fix Azure Devops OnPrem connection editing and repo name `#1184`
-- The sync of a GitHub repositoryQuery failing will no longer cause repos to be deleted `#1177`
+- Fix Azure Devops OnPrem connection editing and repo name `(PR #1184)`
+- The sync of a GitHub repositoryQuery failing will no longer cause repos to be deleted `(PR #1177)`
   - GitHub code host connections using `repositoryQuery` will no longer delete repositories if the sync fails for reasons like a GitHub outage or a token expiring.
 
 #### Sourcegraphaccounts
 
-- use native openidconnect provider `#1030`
+- use native openidconnect provider `(PR #1030)`
 
 #### Telemetry
 
-- only log Cody API events to a remote data store, do n… `#1304`
+- only log Cody API events to a remote data store, do n… `(PR #1304)`
 
 #### Telemetry-Gateway
 
-- fix configuration `#1129`
+- fix configuration `(PR #1129)`
 
 #### Tenant/Reconciler
 
-- avoid illegal state transitions `#1133`
-- double-check assigned instance ID `#1092`
-- try to audit log after tenant context creation `#1051`
+- avoid illegal state transitions `(PR #1133)`
+- double-check assigned instance ID `(PR #1092)`
+- try to audit log after tenant context creation `(PR #1051)`
 
 #### Workspaces
 
-- build full redirect_to URL `#1315`
-- apply 'secure headers' to SPA `#1313`
+- build full redirect_to URL `(PR #1315)`
+- apply 'secure headers' to SPA `(PR #1313)`
 
 #### Others
 
-- copy changes to prompt settings `#1286`
-- remove call to possibly nil error `#973`
+- copy changes to prompt settings `(PR #1286)`
+- remove call to possibly nil error `(PR #973)`
 
 ### Chore
 
 #### Ci
 
-- add TAG_DB_TEST to all go_tests that depends on dbtest `#1288`
-- add test task in workflows for dbtest to run on postgres 16 agents `#1287`
-- use bazel 7.4.0 `#1284`
-- nix - update pg-utils for patch renames `#1172`
-- Move //client/svelte:e2e_test to Integration/E2E_test step `#1148`
-- upgrade platform rules `#1020`
-- move rustfmt flags to ci bazelrc `#1017`
-- upgrade rules_ts and rules_js `#1006`
-- upgrade aspect rules swc `#988`
-- update rules rust v0.52.2 `#985`
-- set test label prefix for backcompat tests `#984`
-- upgrade rules_buf `#974`
-- skip check if author is sg teammate `#969`
-- bazel skylib 1.7.1 `#936`
-- Upgrade rules_go, gazelle, buildifier_prebuilt & rules_proto `#791`
+- add TAG_DB_TEST to all go_tests that depends on dbtest `(PR #1288)`
+- add test task in workflows for dbtest to run on postgres 16 agents `(PR #1287)`
+- use bazel 7.4.0 `(PR #1284)`
+- nix - update pg-utils for patch renames `(PR #1172)`
+- Move //client/svelte:e2e_test to Integration/E2E_test step `(PR #1148)`
+- upgrade platform rules `(PR #1020)`
+- move rustfmt flags to ci bazelrc `(PR #1017)`
+- upgrade rules_ts and rules_js `(PR #1006)`
+- upgrade aspect rules swc `(PR #988)`
+- update rules rust v0.52.2 `(PR #985)`
+- set test label prefix for backcompat tests `(PR #984)`
+- upgrade rules_buf `(PR #974)`
+- skip check if author is sg teammate `(PR #969)`
+- bazel skylib 1.7.1 `(PR #936)`
+- Upgrade rules_go, gazelle, buildifier_prebuilt & rules_proto `(PR #791)`
 
 #### Code Intelligence
 
-- Remove unused parameter `#1204`
-- Rename flag -update -> -update-jobs-snapshots `#1203`
-- Use HTTPError type in uploadhandler code paths `#1174`
-- Remove unused parameters `#1166`
-- Introduce new FileContentsMap type for clarity `#828`
-- Use consistent casing for op strings `#789`
-- Clarify state transitions in GetUsages `#755`
+- Remove unused parameter `(PR #1204)`
+- Rename flag -update -> -update-jobs-snapshots `(PR #1203)`
+- Use HTTPError type in uploadhandler code paths `(PR #1174)`
+- Remove unused parameters `(PR #1166)`
+- Introduce new FileContentsMap type for clarity `(PR #828)`
+- Use consistent casing for op strings `(PR #789)`
+- Clarify state transitions in GetUsages `(PR #755)`
 
 #### Database
 
-- remove residual event_logs export stuff `#864`
-- drop product_licenses and product_subscriptions `#264`
+- remove residual event_logs export stuff `(PR #864)`
+- drop product_licenses and product_subscriptions `(PR #264)`
 
 #### Database
 
-- OOB migration for setting non-null columns via page `#885`
+- OOB migration for setting non-null columns via page `(PR #885)`
   - An out of band migration is introduced to set slowly set the value of a new column on all tables. If you have a large postgres database for Sourcegraph (1tb+) please ensure you deploy 5.9 instead of doing a multi-version upgrade past it.
 
 #### Dev
 
-- Use clearer names in health server initialization `#1383`
-- Make syntactic-code-intel-worker config uniform `#1382`
-- Enable metrics for precise-code-intel-worker in dev `#1365`
-- Merge fileutil package into fsext `#1351`
-- Migrate gitserver APIs from fs.FileInfo to fsext.FileInfo `#1318`
-- Introduce new package with FileInfo type `#1317`
-- Document footguns around escaping trace data writers `#1291`
-- Rename errors.ErrCollector -> errors.Collector `#1265`
-- Introduce new o11y-friendly RichError interface `#1264`
-- Replace WithErrors -> With for simplicity `#1261`
-- Generalize 'observation.With' for custom errors `#1233`
+- Use clearer names in health server initialization `(PR #1383)`
+- Make syntactic-code-intel-worker config uniform `(PR #1382)`
+- Enable metrics for precise-code-intel-worker in dev `(PR #1365)`
+- Merge fileutil package into fsext `(PR #1351)`
+- Migrate gitserver APIs from fs.FileInfo to fsext.FileInfo `(PR #1318)`
+- Introduce new package with FileInfo type `(PR #1317)`
+- Document footguns around escaping trace data writers `(PR #1291)`
+- Rename errors.ErrCollector -> errors.Collector `(PR #1265)`
+- Introduce new o11y-friendly RichError interface `(PR #1264)`
+- Replace WithErrors -> With for simplicity `(PR #1261)`
+- Generalize 'observation.With' for custom errors `(PR #1233)`
 
 #### Gitserver
 
-- Inline one-liner for error checking `#1108`
+- Inline one-liner for error checking `(PR #1108)`
 
 #### Msp
 
-- upgrade openfga dependency `#1357`
+- upgrade openfga dependency `(PR #1357)`
 
 #### Mt-Router
 
-- disable proxy for s2 `#1186`
-- use bazel to run generator `#1065`
-- setup sentry for stage environment `#1064`
-- add scripts to interact with local kv `#1056`
+- disable proxy for s2 `(PR #1186)`
+- use bazel to run generator `(PR #1065)`
+- setup sentry for stage environment `(PR #1064)`
+- add scripts to interact with local kv `(PR #1056)`
 
 #### Search
 
-- (new web ui) Enable new web UI by default `#1373`
-- fix description for KUBERNETES_JOB_STEP_IMAGE `#1360`
-- Remove all non-single job pod code from Executors on Kubernetes. `#1163`
+- (new web ui) Enable new web UI by default `(PR #1373)`
+- fix description for KUBERNETES_JOB_STEP_IMAGE `(PR #1360)`
+- Remove all non-single job pod code from Executors on Kubernetes. `(PR #1163)`
   - The environment variable `KUBERNETES_SINGLE_JOB_STEP_IMAGE` is now `KUBERNETES_JOB_STEP_IMAGE`.
   - Both environment variables are read, with preference given to `KUBERNETES_JOB_STEP_IMAGE`, to preserve backward compatibility, but reading of `KUBERNETES_SINGLE_JOB_STEP_IMAGE` may be removed in a future version.
-- (new web ui) Improve search input CSS `#962`
+- (new web ui) Improve search input CSS `(PR #962)`
 
 #### Security
 
-- Update rules_apko and fix issues with sg wolfi v2 `#901`
+- Update rules_apko and fix issues with sg wolfi v2 `(PR #901)`
   - Build containers using latest version of apko and rules_apko
 
 #### Telemetry
 
-- report token usage per request to telemetry `#1165`
+- report token usage per request to telemetry `(PR #1165)`
   - Added LLM token usage telemetry
 
 #### Telemetrygatewayexporter
 
-- bump default TELEMETRY_GATEWAY_EXPORTER_EXPORT_INTERVAL `#1303`
+- bump default TELEMETRY_GATEWAY_EXPORTER_EXPORT_INTERVAL `(PR #1303)`
 
 #### Telemetrytest
 
-- add working example `#1274`
+- add working example `(PR #1274)`
 
 #### Others
 
-- fix storybook `#1335`
-- add searchSource to new search events `#1306`
-- make core-services internal/telemetry codeowners `#1272`
-- upgrade Mocha from 8.3.4 to ^10 `#1246`
-- move web app into child layout group to make room for embedded pages `#1128`
-- run prettier `#906`
-- Upgrade hermetic cc toolchain `#844`
-- upgrade rules_oci `#818`
+- fix storybook `(PR #1335)`
+- add searchSource to new search events `(PR #1306)`
+- make core-services internal/telemetry codeowners `(PR #1272)`
+- upgrade Mocha from 8.3.4 to ^10 `(PR #1246)`
+- move web app into child layout group to make room for embedded pages `(PR #1128)`
+- run prettier `(PR #906)`
+- Upgrade hermetic cc toolchain `(PR #844)`
+- upgrade rules_oci `(PR #818)`
 
 ### Test
 
 #### Others
 
-- implement structure for e2e tests `#108`
+- implement structure for e2e tests `(PR #108)`
 
 ### Refactor
 
 #### Cody-Gateway
 
-- support max_completion_tokens for o1 models `#947`
+- support max_completion_tokens for o1 models `(PR #947)`
   - refactor(cody-gateway): support max_completion_tokens for o1 models
 
 #### Search
 
-- (new web ui) Update folder page table styling `#1221`
+- (new web ui) Update folder page table styling `(PR #1221)`
 
 #### Others
 
-- move all business logic out of context resolvers `#821`
+- move all business logic out of context resolvers `(PR #821)`
 
 ### Reverts
 
-- revert filtering out deprecated models on server `#1267`
+- revert filtering out deprecated models on server `(PR #1276)`
 
 ### Uncategorized
 
 #### Others
 
-- [Backport 5.9.x] oob: Run without tenant iterator for older versions `#1429`
-- Release: Prep stitched migration graph for release (#1388) `#1389`
+- [Backport 5.9.x] oob: Run without tenant iterator for older versions `(PR #1429)`
+- Release: Prep stitched migration graph for release (#1388) `(PR #1389)`
   - n/a
-- Move cody.serverSideContext out of experimentalFeatures in site config `#1385`
-- bugfix: add key to search result file header `#1374`
-- gitserver: Parse LastChanged, LastFetched as nulltime `#1372`
-- add code llama 7B model for ab test `#1371`
+- Move cody.serverSideContext out of experimentalFeatures in site config `(PR #1385)`
+- bugfix: add key to search result file header `(PR #1374)`
+- gitserver: Parse LastChanged, LastFetched as nulltime `(PR #1372)`
+- add code llama 7B model for ab test `(PR #1371)`
   - adding code llama 7B for completions
-- Hide auto submit checkbox and add promoted badge `#1367`
-- Enable reranker by default if Gateway is enabled `#1366`
+- Hide auto submit checkbox and add promoted badge `(PR #1367)`
+- Enable reranker by default if Gateway is enabled `(PR #1366)`
   - Cody Chat: the context engine now uses the reranker by default everywhere where Cody Gateway is enabled.
-- db: Set default permissions to RLS user as well `#1362`
-- Remove promote-to-public dependency on bazel-push-images step `#1356`
-- release: Only fail SBOM step if all uploads fail `#1355`
-- source: Fix code host connection editor validation `#1354`
-- bugfix: fix symbol tree hover selector `#1353`
-- dev: Exclude generated code from prettier `#1341`
-- Prompt library: fix input description for prompt name `#1337`
-- workspaces: Various mini fixes and a landing page `#1336`
-- tenant: Fix gRPC in local dev `#1334`
-- Reapply "worker: Fix configuration error reporting" `#1311`
-- Search: document choice for ZoektScoreBoost `#1310`
-- bugfix: escape file paths `#1308`
-- Change clickable elements to buttons `#1298`
-- Allow users to insert chips according to cursor position `#1296`
-- Change prompt creation flow feature flag name `#1294`
-- Pass Context to scip-syntax invocation to propagate cancellation `#1290`
-- gomod: bump Zoekt for metrics improvement `#1276`
-- Redis: rename RedisWrapper `#1273`
-- connectutil: UnexpectedError handler `#1271`
-- Add recommended flag to Prompt Templates `#1268`
+- db: Set default permissions to RLS user as well `(PR #1362)`
+- Remove promote-to-public dependency on bazel-push-images step `(PR #1356)`
+- release: Only fail SBOM step if all uploads fail `(PR #1355)`
+- source: Fix code host connection editor validation `(PR #1354)`
+- bugfix: fix symbol tree hover selector `(PR #1353)`
+- dev: Exclude generated code from prettier `(PR #1341)`
+- Prompt library: fix input description for prompt name `(PR #1337)`
+- workspaces: Various mini fixes and a landing page `(PR #1336)`
+- tenant: Fix gRPC in local dev `(PR #1334)`
+- Reapply "worker: Fix configuration error reporting" `(PR #1311)`
+- Search: document choice for ZoektScoreBoost `(PR #1310)`
+- bugfix: escape file paths `(PR #1308)`
+- Change clickable elements to buttons `(PR #1298)`
+- Allow users to insert chips according to cursor position `(PR #1296)`
+- Change prompt creation flow feature flag name `(PR #1294)`
+- Pass Context to scip-syntax invocation to propagate cancellation `(PR #1290)`
+- gomod: bump Zoekt for metrics improvement `(PR #1276)`
+- Redis: rename RedisWrapper `(PR #1273)`
+- connectutil: UnexpectedError handler `(PR #1271)`
+- Add recommended flag to Prompt Templates `(PR #1268)`
   - Adds ability to mark prompts as recommended and then sort the recommended prompts at the top.
-- bugfix: remove possibility of infinite recursion from the symbol tree `#1256`
-- Update cody web to 0.10.0 `#1254`
-- bugfix: use short OID for file popover `#1242`
-- Remove outdated install instructions for sg `#1227`
-- site: Fix missing unredaction in site config `#1226`
-- Update the sg docs link `#1225`
-- multi-tenant: support synchronized user sign-out `#1222`
-- sg: Fix db reset with default local settings `#1217`
-- db: Improve error message for failed version update `#1216`
-- Only push final images on specific default runtypes `#1211`
-- OpenaI completions response type fixing for gpt-3.5-turbo-instruct and gpt-4o-mini `#1207`
-- sg: Always run with lower privileges in dev `#1197`
-- tenant: Deactivate OOB migrations `#1192`
-- Update Enterprise footer link on dotcom `#1191`
-- bugfix: escape spaces in repo filter names `#1187`
+- bugfix: remove possibility of infinite recursion from the symbol tree `(PR #1256)`
+- Update cody web to 0.10.0 `(PR #1254)`
+- bugfix: use short OID for file popover `(PR #1242)`
+- Remove outdated install instructions for sg `(PR #1227)`
+- site: Fix missing unredaction in site config `(PR #1226)`
+- Update the sg docs link `(PR #1225)`
+- multi-tenant: support synchronized user sign-out `(PR #1222)`
+- sg: Fix db reset with default local settings `(PR #1217)`
+- db: Improve error message for failed version update `(PR #1216)`
+- Only push final images on specific default runtypes `(PR #1211)`
+- OpenaI completions response type fixing for gpt-3.5-turbo-instruct and gpt-4o-mini `(PR #1207)`
+- sg: Always run with lower privileges in dev `(PR #1197)`
+- tenant: Deactivate OOB migrations `(PR #1192)`
+- Update Enterprise footer link on dotcom `(PR #1191)`
+- bugfix: escape spaces in repo filter names `(PR #1187)`
   - Fixed a bug that would cause filters added from the search sidebar to not be correctly escaped
-- Attempt to fix flaky database test `#1181`
-- chore/search - Remove runner.Spec.Image and use command.Spec.Image instead `#1161`
-- dev: Disable otel in MT dev `#1157`
-- bug(release): remove semver check for release branch in `sg backport`  `#1156`
-- Make GetCodyContextAlternatives usable for evals `#1152`
-- multi-tenant: list workspaces for the authenticated user `#1146`
-- saml: Prevent logspam from context cancel `#1143`
-- sg: Update localdev migration `#1132`
-- tenant: Exclude product subscription tables from OOB migrator `#1124`
-- Add prompt mode `#1123`
+- Attempt to fix flaky database test `(PR #1181)`
+- chore/search - Remove runner.Spec.Image and use command.Spec.Image instead `(PR #1161)`
+- dev: Disable otel in MT dev `(PR #1157)`
+- bug(release): remove semver check for release branch in `sg backport`  `(PR #1156)`
+- Make GetCodyContextAlternatives usable for evals `(PR #1152)`
+- multi-tenant: list workspaces for the authenticated user `(PR #1146)`
+- saml: Prevent logspam from context cancel `(PR #1143)`
+- sg: Update localdev migration `(PR #1132)`
+- tenant: Exclude product subscription tables from OOB migrator `(PR #1124)`
+- Add prompt mode `(PR #1123)`
   - Adds mode (CHAT, EDIT, INSERT) to prompt.
-- gitserver: Clarify annotated tags behavior in ResolveRevision `#1107`
-- Rate limit: rename GlobalLimiter to DistributedLimiter `#1100`
-- Rate limit: make GlobalLimiter tenant-aware `#1099`
-- saml: Fix nil panic `#1098`
-- tenant: Disable migrator for ranking tables `#1097`
-- Rate limit: avoid using KeyValue within GlobalLimiter `#1082`
-- Rate limit: simplify inMemoryLimiter `#1081`
-- tenant: Use frozen schema for OOB migration `#1077`
-- Make user emails soft-deletable `#1071`
-- Fix prompt duplication name `#1067`
-- sg: Add no-open flag to workspaces create `#1057`
-- Creating/Editing Prompts Re-design `#1054`
+- gitserver: Clarify annotated tags behavior in ResolveRevision `(PR #1107)`
+- Rate limit: rename GlobalLimiter to DistributedLimiter `(PR #1100)`
+- Rate limit: make GlobalLimiter tenant-aware `(PR #1099)`
+- saml: Fix nil panic `(PR #1098)`
+- tenant: Disable migrator for ranking tables `(PR #1097)`
+- Rate limit: avoid using KeyValue within GlobalLimiter `(PR #1082)`
+- Rate limit: simplify inMemoryLimiter `(PR #1081)`
+- tenant: Use frozen schema for OOB migration `(PR #1077)`
+- Make user emails soft-deletable `(PR #1071)`
+- Fix prompt duplication name `(PR #1067)`
+- sg: Add no-open flag to workspaces create `(PR #1057)`
+- Creating/Editing Prompts Re-design `(PR #1054)`
   - The prompt creation/edit page has been redesigned.
-- GraphQL: remove anonymous rate limiter `#1052`
-- oob: Make out of band migration runner tenant-aware `#1047`
-- Fix the CTA to point to chat `#1044`
-- Fix bug where text pushed buttons out of the container `#1043`
-- dev: Implement wrangler router provider `#1035`
-- router: Ensure HTTPS protocol on auth redirect `#1034`
-- workspaces: Fix race condition registering state listener `#1033`
-- dev: Introduce devDNS helper to resolve testdomains `#1029`
-- Add ability to duplicate existing prompts `#1022`
+- GraphQL: remove anonymous rate limiter `(PR #1052)`
+- oob: Make out of band migration runner tenant-aware `(PR #1047)`
+- Fix the CTA to point to chat `(PR #1044)`
+- Fix bug where text pushed buttons out of the container `(PR #1043)`
+- dev: Implement wrangler router provider `(PR #1035)`
+- router: Ensure HTTPS protocol on auth redirect `(PR #1034)`
+- workspaces: Fix race condition registering state listener `(PR #1033)`
+- dev: Introduce devDNS helper to resolve testdomains `(PR #1029)`
+- Add ability to duplicate existing prompts `(PR #1022)`
   - Users can now duplicate existing prompts.
-- GraphQL: simplify rate limit interface `#1021`
-- Add autoSubmit & includeViewerDrafts to Cody prompts `#1003`
+- GraphQL: simplify rate limit interface `(PR #1021)`
+- Add autoSubmit & includeViewerDrafts to Cody prompts `(PR #1003)`
   - Adds options to set prompts to "Auto Submit", which would automatically execute the prompts in one-click.
-- vsce: patch release v2.2.19 `#1002`
-- workspacesreconciler: fix grpc tls transport `#1000`
-- tenant: Move externalhttp to separate package `#996`
-- goroutine: reenable recording when multitenancy is enabled `#995`
-- Rename globaldbtenant to servicetenant `#994`
-- ci/mt-router: add bazel build `#990`
-- Search: populate rev in select repo `#989`
-- Search: correct has.commit.after query example `#987`
-- mt-router: import repo `#986`
-- tenant: add mt-router to local dev `#968`
-- tenant: Remove tenant auth redirect in monolith `#967`
-- Do not fail if link parsing fails in relative fix processing `#966`
-- dev/msp: improve tfc creation error message `#964`
-- goroutine: remove unused support for concurrency `#963`
-- ci: Bump backcompat test target to 5.8.0 `#954`
-- tenant: Mark tenant as initialized in db `#950`
-- bug(release): workspace cash time dance `#948`
-- tenant: Fix missing tenant in auth check `#933`
-- db: Use non-superuser in DB tests `#930`
-- db: Migrator can provision RLS user permissions `#919`
-- ci: Bump backcompat target to 5.7 `#916`
-- sg: Add default tenant to hosts `#915`
-- remove "Don't commit private code yet" from PR template `#908`
-- "Prompt Library" in navbar (capitalize the L for consistency) `#907`
-- Blob View: Ensure copy button copies full path and not displayed path `#903`
+- vsce: patch release v2.2.19 `(PR #1002)`
+- workspacesreconciler: fix grpc tls transport `(PR #1000)`
+- tenant: Move externalhttp to separate package `(PR #996)`
+- goroutine: reenable recording when multitenancy is enabled `(PR #995)`
+- Rename globaldbtenant to servicetenant `(PR #994)`
+- ci/mt-router: add bazel build `(PR #990)`
+- Search: populate rev in select repo `(PR #989)`
+- Search: correct has.commit.after query example `(PR #987)`
+- mt-router: import repo `(PR #986)`
+- tenant: add mt-router to local dev `(PR #968)`
+- tenant: Remove tenant auth redirect in monolith `(PR #967)`
+- Do not fail if link parsing fails in relative fix processing `(PR #966)`
+- dev/msp: improve tfc creation error message `(PR #964)`
+- goroutine: remove unused support for concurrency `(PR #963)`
+- ci: Bump backcompat test target to 5.8.0 `(PR #954)`
+- tenant: Mark tenant as initialized in db `(PR #950)`
+- bug(release): workspace cash time dance `(PR #948)`
+- tenant: Fix missing tenant in auth check `(PR #933)`
+- db: Use non-superuser in DB tests `(PR #930)`
+- db: Migrator can provision RLS user permissions `(PR #919)`
+- ci: Bump backcompat target to 5.7 `(PR #916)`
+- sg: Add default tenant to hosts `(PR #915)`
+- remove "Don't commit private code yet" from PR template `(PR #908)`
+- "Prompt Library" in navbar (capitalize the L for consistency) `(PR #907)`
+- Blob View: Ensure copy button copies full path and not displayed path `(PR #903)`
   - Fixes a bug where certain copy path buttons were only copying the visible path and not the full path of a file.
-- sg: Fix reference to deleted table in localdev MT migration `#898`
-- tenant: Separate store package and create tenant1, tenant2 via workspaces `#897`
-- Tenant: skip some global Prometheus metrics `#892`
-- sg: Fix startup of workspaces service `#891`
-- ci: do not run executors e2e for eph `#886`
-- Perforce IP enforcement integration test `#876`
-- goroutine: Make iterator required `#875`
-- dev/msp: add project id validation `#874`
-- db: Drop unused user_public_repos table `#873`
-- Deprecate long-running OOB migrations `#872`
-- lib/cloudapi: add support for multi tenant mode `#871`
-- event_logs: add new `aggregatedMetrics` ping `#869`
-- Redis: refactor rcache interface `#860`
-- Add extra reranker metrics to Gateway events `#838`
-- Sourcegraph teammate approval GH action `#824`
-- Redis: remove KEYS call in completions token usage `#820`
-- tenant: Properly initialize RBAC `#754`
-- sg: Provision RLS user during setup `#749`
-- tenant: Add database migration to enable RLS policies `#743`
-- tenant: Add workspace ID and display name `#741`
-- tenant: Check that all tables have RLS policy set `#734`
-- tenant: Simplify dev migration `#726`
-- db: Mark tenant_id columns as non-nullable `#707`
-- feature: add internal/tracelog: a log.Logger that only logs if tracing is enabled `#634`
+- sg: Fix reference to deleted table in localdev MT migration `(PR #898)`
+- tenant: Separate store package and create tenant1, tenant2 via workspaces `(PR #897)`
+- Tenant: skip some global Prometheus metrics `(PR #892)`
+- sg: Fix startup of workspaces service `(PR #891)`
+- ci: do not run executors e2e for eph `(PR #886)`
+- Perforce IP enforcement integration test `(PR #876)`
+- goroutine: Make iterator required `(PR #875)`
+- dev/msp: add project id validation `(PR #874)`
+- db: Drop unused user_public_repos table `(PR #873)`
+- Deprecate long-running OOB migrations `(PR #872)`
+- lib/cloudapi: add support for multi tenant mode `(PR #871)`
+- event_logs: add new `aggregatedMetrics` ping `(PR #869)`
+- Redis: refactor rcache interface `(PR #860)`
+- Add extra reranker metrics to Gateway events `(PR #838)`
+- Sourcegraph teammate approval GH action `(PR #824)`
+- Redis: remove KEYS call in completions token usage `(PR #820)`
+- tenant: Properly initialize RBAC `(PR #754)`
+- sg: Provision RLS user during setup `(PR #749)`
+- tenant: Add database migration to enable RLS policies `(PR #743)`
+- tenant: Add workspace ID and display name `(PR #741)`
+- tenant: Check that all tables have RLS policy set `(PR #734)`
+- tenant: Simplify dev migration `(PR #726)`
+- db: Mark tenant_id columns as non-nullable `(PR #707)`
+- feature: add internal/tracelog: a log.Logger that only logs if tracing is enabled `(PR #634)`
   - Added a new `internal/tracelog` package that provides a conditional logger for tracing. This logger only logs when tracing is enabled, improving performance by reducing unnecessary logging.
-- Hackathon: SBOMs feat. bazel `#566`
+- Hackathon: SBOMs feat. bazel `(PR #566)`
   - feature(security): Publish SBOMs for Sourcegraph releases
-- tenant: Unique constraint migration `#430`
-- security: Auto-update package lockfiles for Sourcegraph base images `#246`
-- (feature): site-config: add ipParseCacheSize to schema for enforce IP restrictions schema `#220`
+- tenant: Unique constraint migration `(PR #430)`
+- security: Auto-update package lockfiles for Sourcegraph base images `(PR #246)`
+- (feature): site-config: add ipParseCacheSize to schema for enforce IP restrictions schema `(PR #220)`
   - Added a new `ipParseCacheSize` configuration option for sub-repo permissions to control the caching of Perforce "Host" to IP address translations.
-- feature/source: implement core logic for parsing / evaluating Perforce IP addresses for sub repo permissions `#46`
+- feature/source: implement core logic for parsing / evaluating Perforce IP addresses for sub repo permissions `(PR #46)`
   - For the Perforce IP permissions implementation, this PR introduces machinery that implements the ability to parse the [IP address expressions from the perforce protections table](https://www.perforce.com/manuals/p4sag/Content/P4SAG/protections.set.html#IP_address) and compare them against the user's IP address (that's advertised from the incoming X-FORWARDED-FOR header.Namely, this PR:
   - Introduced parsePerforceIPString, which parses Perforce IP strings (e.g., CIDR expressions, specific IP addresses) into an ipMatcher for IP validation.
   - Implemented multiple ipMatcher types, including:
@@ -1451,17 +1451,17 @@ Standard ML, Visual Basic, Pkl, Hack, MATLAB etc.
   - Added toggleableIPMatcher, which either enables or disables IP enforcement based on site configuration settings.
   - Created matcherCache for caching recent IP string to ipMatcher translations, improving efficiency.
   - Updated NewRequestClientIPSource to properly derive IP from the x-forwarded-for header.
-- feature/site-config: add site configuration setting for enforcing IP restrictions `#45`
+- feature/site-config: add site configuration setting for enforcing IP restrictions `(PR #45)`
   - Added enforceIPRestrictions setting to the SubRepoPermissions section in site configuration, allowing IP-based enforcement using the X-FORWARDED-FOR header.Updated JSON schema to require SubRepoPermissions to be enabled when enforceIPRestrictions is enabled.Added validation in Perforce external service configuration to ensure IgnoreRulesWithHost and enforceIPRestrictions cannot be enabled simultaneously.Updated internal implementation to associate each Perforce rule with an IPMatcher for IP-based rule enforcement.
-- feature/plumbing: sub_repo_perms: do pumbling to thread comparing IP addresses alongside paths `#23`
+- feature/plumbing: sub_repo_perms: do pumbling to thread comparing IP addresses alongside paths `(PR #23)`
   -
 
 ### Untracked
 
 The following PRs were merged onto the previous release branch but could not be automatically mapped to a corresponding commit in this release:
 
-- check for external dbs (#1083) `#1121`
-- bug(release): workspace cash time dance (#948) `#949`
+- check for external dbs (#1083) `(PR #1121)`
+- bug(release): workspace cash time dance (#948) `(PR #949)`
 
 {/* RSS={"version":"v5.9.0", "releasedAt": "2024-11-04"} */}
 
@@ -1479,23 +1479,23 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Telemetry
 
-- check for external dbs (#1083) `#1121`
+- check for external dbs (#1083) `(PR #1121)`
 
 ### Fix
 
 #### Search
 
-- Fix Apollo related error in Safari `#1016`
+- Fix Apollo related error in Safari `(PR #1016)`
 
 #### Others
 
-- Fix OOB migration for batch changes table `#1113`
+- Fix OOB migration for batch changes table `(PR #1113)`
 
 ### Chore
 
 #### Security
 
-- upgrade src-cli version to address CVE `#1117`
+- upgrade src-cli version to address CVE `(PR #1117)`
   - Upgrade src-cli version to 5.8.1 to address CVE-2024-24788, CVE-2024-24790, CVE-2024-34156 Backport b8da20f6fa148f30fe97d9267a536bd5a84502f1 from #1112
 
 ### Reverts
@@ -1506,9 +1506,9 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Others
 
-- Backport 566 to 5.8.x: SBOMs with Bazel `#1089`
+- Backport 566 to 5.8.x: SBOMs with Bazel `(PR #1089)`
   - feature(security): Publish SBOMs for Sourcegraph releases
-- [Backport 5.8.x] Update src-cli MinimumVersion from 5.5.0 to 5.8.1 `#1087`
+- [Backport 5.8.x] Update src-cli MinimumVersion from 5.5.0 to 5.8.1 `(PR #1087)`
   - chore(release): Update minimum supported version of src-cli to 5.8.1 Backport 8f039bdcb5425071dd6e4dfddfb2cb436e124b05 from #1079
 
 {/* RSS={"version":"sourcegraph 5 Release 8 Patch 1", "releasedAt": "2024-10-16"} */}
@@ -1525,598 +1525,598 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Accessrequests
 
-- Allow to file another request when original one has been processed `#416`
+- Allow to file another request when original one has been processed `(PR #416)`
 
 #### Appliance
 
-- refactor install flow, status, state, stage `#352`
+- refactor install flow, status, state, stage `(PR #352)`
 
 #### Batch Changes
 
-- verbose error logging for batch syncer with BATCH_CHANGES_SYNCER_VERBOSE_ERROR_LOGGING `#639`
+- verbose error logging for batch syncer with BATCH_CHANGES_SYNCER_VERBOSE_ERROR_LOGGING `(PR #639)`
   - feat(batches): verbose error logging for batch syncer with BATCH_CHANGES_SYNCER_VERBOSE_ERROR_LOGGING
-- add experimental feature to add a fork name suffix to avoid name collisions `#230`
+- add experimental feature to add a fork name suffix to avoid name collisions `(PR #230)`
   - feat(batches): add experimental feature to add a fork name suffix to avoid name collisions
 
 #### Ci
 
-- enable workflows telemetry `#774`
+- enable workflows telemetry `(PR #774)`
   - enable aspect workflows ci telemetry
-- convert onconflict gen to bazel `#486`
+- convert onconflict gen to bazel `(PR #486)`
   - generate `constraints.go` using bazel for onconflict linter
 
 #### Search
 
-- (new web ui) Prefill search input with selected text when pressing '/' `#577`
+- (new web ui) Prefill search input with selected text when pressing '/' `(PR #577)`
 
 #### Code Intelligence
 
-- Updates the autoindexing images for TypeScript and Ruby `#805`
+- Updates the autoindexing images for TypeScript and Ruby `(PR #805)`
   - TypeScript: Fixes references to object properties in various places
   - Ruby: Fixes references to `Opus::` in Ruby tests
-- Syntactic indexing go evaluation suite and fix tests on CI in general `#482`
+- Syntactic indexing go evaluation suite and fix tests on CI in general `(PR #482)`
 
 #### Cody
 
-- update public OpenAPI spec `#796`
-- add basic support for server-rendered prompts `#723`
+- update public OpenAPI spec `(PR #796)`
+- add basic support for server-rendered prompts `(PR #723)`
   - `/.api/completions/stream` endpoint now accepts `"file"` and `"repo"` parts alongside `"text"` and `"image_url"`
-- add vision support `#546``/.api/completions/stream` now supports vision using the OpenAI-compatible base64 encoding of images. Example `"content": [{"type": "image_url", "image_url": { "url": "data:image/png;base64,{{IMAGE_BASE64}}" } }]`. Requires the query parameter `api-version=3` or higher.
-- document internal APIs with TypeSpec/OpenAPI `#505`
+- add vision support `(PR #546)``/.api/completions/stream` now supports vision using the OpenAI-compatible base64 encoding of images. Example `"content": [{"type": "image_url", "image_url": { "url": "data:image/png;base64,{{IMAGE_BASE64}}" } }]`. Requires the query parameter `api-version=3` or higher.
+- document internal APIs with TypeSpec/OpenAPI `(PR #505)`
 
 #### Cody-Gateway
 
-- log requestinteraction in events `#814`
+- log requestinteraction in events `(PR #814)`
 
 #### Database
 
-- bestEffortForce will kill blocking transactions in migrator `#781`
+- bestEffortForce will kill blocking transactions in migrator `(PR #781)`
   - DB Migrator is given the ability to automatically run pg_terminate_backend on transactions blocking a migration. This is done best effort and is opt-in per migration.
 
 #### Dev
 
-- (new web UI) Make it easier to run tests without proxying `#798`
-- add obvious 'target service' notice to `sg msp` commands `#725`
+- (new web UI) Make it easier to run tests without proxying `(PR #798)`
+- add obvious 'target service' notice to `sg msp` commands `(PR #725)`
 
 #### Local
 
-- add cody-gateway version endpoints `#685`
+- add cody-gateway version endpoints `(PR #685)`
   - add cody-gateway environments for subcommand `live`
-- sg - install pgvector `#520`
+- sg - install pgvector `(PR #520)`
   - mac: install pgvector from sourcegraph/pgvector-12
   - ubuntu: install postgresql-12-pgvector
 
 #### Msp
 
-- make databasetest shared `#393`
+- make databasetest shared `(PR #393)`
 
 #### Msp/Databaseutil
 
-- make 'upsert' package shared `#394`
+- make 'upsert' package shared `(PR #394)`
 
 #### Release
 
-- remove test from promotion ci during release pipeline `#495`
+- remove test from promotion ci during release pipeline `(PR #495)`
   - Remove upgradetest from the release promotion ci
-- Stop releases from going out if there's a PR with the release-blocker label `#472`
+- Stop releases from going out if there's a PR with the release-blocker label `(PR #472)`
   - Allow PRs to block a release from going out 😈
-- use releaseregistry for release banner [REL-145] `#429`
+- use releaseregistry for release banner [REL-145] `(PR #429)`
   - implement using the release-registry for the banner
 
 #### Search
 
-- bump Zoekt for ranking and memory improvements `#816`
+- bump Zoekt for ranking and memory improvements `(PR #816)`
   - Reduce peak memory required for Zoekt indexing
   - Improve search ranking by using repo freshness as a scoring signal
-- (new web ui) Add split view support to commit page `#775`
-- enable similarity search by default `#772`
+- (new web ui) Add split view support to commit page `(PR #775)`
+- enable similarity search by default `(PR #772)`
   - With this change we rank repository search results by similarity. Before, repository search results were ordered by star count instead. This affects suggestions and repository search results. To disable this feature and return to the previous behavior, set `{ "experimentalFeatures": { "disableOrderBySimilarity": true}}` in global settings.
-- (new web ui) Add /cody/dashboard page `#764`
-- (new web ui) Add account connection modal `#731`
-- (new web ui) Image previews `#623`
-- respect match order for search.results.repositories resolver `#575`
+- (new web ui) Add /cody/dashboard page `(PR #764)`
+- (new web ui) Add account connection modal `(PR #731)`
+- (new web ui) Image previews `(PR #623)`
+- respect match order for search.results.repositories resolver `(PR #575)`
   - The GraphQL endpoint `search.results.repositories` now returns the list of repositories in the order of the matches we
 found. Before, repositories were sorted by id.
-- remove fzf star tiebreaker for repo suggestions `#541`
-- preserve ranking for repo suggestions `#447`
-- (Svelte) open documentation links in new tabs `#401`
-- Open documentation links in a new tab `#359`
+- remove fzf star tiebreaker for repo suggestions `(PR #541)`
+- preserve ranking for repo suggestions `(PR #447)`
+- (Svelte) open documentation links in new tabs `(PR #401)`
+- Open documentation links in a new tab `(PR #359)`
 
 #### Source
 
-- add ssh auth support for more code hosts `#615`
+- add ssh auth support for more code hosts `(PR #615)`
   - BitBucket Cloud, BitBucket Server,  GitLab, Gerrit, Gitolite, AWS CodeCommit Azure DevOps code host connections now support configuring SSH key authentication from the UI instead of mounting from disk.
-- add support for ssh auth to github `#597`
+- add support for ssh auth to github `(PR #597)`
   - GitHub and generic Git code host connections now support configuring SSH key authentication from the UI instead of mounting from disk.
-- Support Azure Devops Server (onPrem) with NTLM authentication `#217`
+- Support Azure Devops Server (onPrem) with NTLM authentication `(PR #217)`
 
 #### Tenant
 
-- allow configuring host instance id `#826`
-- add initial Workspaces reconciler `#594`
+- allow configuring host instance id `(PR #826)`
+- add initial Workspaces reconciler `(PR #594)`
 
 #### Wolfi
 
-- update server + postgresql-12 images `#519`
+- update server + postgresql-12 images `(PR #519)`
   - add pgvector to server and postgresql-12 images
-- add pgvector-12 package `#513`
+- add pgvector-12 package `(PR #513)`
   - build and add pgvector extension
 
 #### Workspaces
 
-- implement integrations listworkspaces `#794`
-- implement management listworkspaces `#793`
-- delete workspace RPC `#729`
-- add DB list workspaces `#728`
-- add destroy state internally `#644`
-- init database schemas, add Workspaces store handler `#395`
-- add and demo notifications SDK `#356`
+- implement integrations listworkspaces `(PR #794)`
+- implement management listworkspaces `(PR #793)`
+- delete workspace RPC `(PR #729)`
+- add DB list workspaces `(PR #728)`
+- add destroy state internally `(PR #644)`
+- init database schemas, add Workspaces store handler `(PR #395)`
+- add and demo notifications SDK `(PR #356)`
 
 #### Others
 
-- add reranker support to Cody Gateway `#670`
-- Embeddings: v2 `#507`
+- add reranker support to Cody Gateway `(PR #670)`
+- Embeddings: v2 `(PR #507)`
   - Introduce a new experimental embeddings index and context retriever.
-- make scip-syntax process multiple languages in a single invocation `#364`
-- add OpenAI o1 models and early-access models support to Cody Gateway `#323`
+- make scip-syntax process multiple languages in a single invocation `(PR #364)`
+- add OpenAI o1 models and early-access models support to Cody Gateway `(PR #323)`
   - [feat(code gateway): add support for OpenAI o1 models and early-access models handling.](feat: add OpenAI o1 models and early-access models support to Cody Gateway)
-- implements pagination for syntactic usages `#310`
+- implements pagination for syntactic usages `(PR #310)`
 
 ### Fix
 
 #### Batch Changes
 
-- stamp the executor binary with version information `#665`
+- stamp the executor binary with version information `(PR #665)`
   - override `internal/version.version` with `x_defs` at build time in executor
-- disabled "select all" checkbox if all nodes are already disabled `#483`
+- disabled "select all" checkbox if all nodes are already disabled `(PR #483)`
   - fix(batches): disabled "select all" checkbox if all nodes are already disabled
 
 #### Ci
 
-- add runfile initialization to upgradetest file `#890`
-- use generated json in migrations filegroup `#802`
+- add runfile initialization to upgradetest file `(PR #890)`
+- use generated json in migrations filegroup `(PR #802)`
 
 #### Search
 
-- (new web ui) Show correct document highlights when codegraph data is available `#620`
-- 'Save search' action on search results page does not navigate to the saved search creation page `#549`
+- (new web ui) Show correct document highlights when codegraph data is available `(PR #620)`
+- 'Save search' action on search results page does not navigate to the saved search creation page `(PR #549)`
 
 #### Code Intelligence
 
-- Correctly escape special characters in repo names and identifiers `#710`
+- Correctly escape special characters in repo names and identifiers `(PR #710)`
   - The new usagesForSymbol API correctly searches repos whose names contain spaces or other special characters.
-- Use multiple language: filters for search-based usages in case of ambiguity `#708`
-- cleanup button title `#581`
-- Fetch tags for scip-go auto-indexing jobs `#371`
+- Use multiple language: filters for search-based usages in case of ambiguity `(PR #708)`
+- cleanup button title `(PR #581)`
+- Fetch tags for scip-go auto-indexing jobs `(PR #371)`
   - Go cross-repo navigation for tagged versions should work better when using scip-go for auto-indexing. Navigation based on SCIP indexes generated using scip-go in CI or cron jobs should be unaffected.
 
 #### Cody
 
-- return client-side model config via API `#713`
-- Disable ModelAPIEnabled for Dotcom `#678`
+- return client-side model config via API `(PR #713)`
+- Disable ModelAPIEnabled for Dotcom `(PR #678)`
   - `modelsAPIEnabled` is always false for dotcom
-- allow accuracy category in JSON site config `#641`
-- use "balanced" instead of "accuracy" category for SOTA models `#640`
-- allow empty `finish_reason` in `/.api/llm/chat/completions` `#539`
+- allow accuracy category in JSON site config `(PR #641)`
+- use "balanced" instead of "accuracy" category for SOTA models `(PR #640)`
+- allow empty `finish_reason` in `/.api/llm/chat/completions` `(PR #539)`
   - The `/.api/llm/chat/completions` endpoint will now return an empty string `""` for `finish_reason` instead of the string `"unknown_please_report_bug()"`.
 
 #### Database
 
-- use native UUID in telemetry export queue `#669`
+- use native UUID in telemetry export queue `(PR #669)`
 
 #### Database
 
-- correctly find CreateIndexConcurrentlyPhases in migrator `#809`
+- correctly find CreateIndexConcurrentlyPhases in migrator `(PR #809)`
   - INFO logs for migrations that create index concurrently will always correctly report the phase we are in. Previously we sometimes would report a phase of -1.
 
 #### Dev
 
-- use 9002 for pubsubemulator, simplify shutdown `#780`
-- give pubsub pings a more generous timeout locally `#732`
-- use key value for PGDSN in SAMS, EP `#689`
+- use 9002 for pubsubemulator, simplify shutdown `(PR #780)`
+- give pubsub pings a more generous timeout locally `(PR #732)`
+- use key value for PGDSN in SAMS, EP `(PR #689)`
 
 #### Graph
 
-- Prevent duplicate results when performing find references `#497`
+- Prevent duplicate results when performing find references `(PR #497)`
 
 #### Local
 
-- add no-xattrs when running schema descriptions target locally `#905`
-- sg - return the error when checking for remote branch/commits `#485`
+- add no-xattrs when running schema descriptions target locally `(PR #905)`
+- sg - return the error when checking for remote branch/commits `(PR #485)`
   - dump more information out about the branch if it is out of sync
 
 #### Release
 
-- remove embeddings from promotion script (#360) `#361`
+- remove embeddings from promotion script (#360) `(PR #361)`
   - remove embeddings in promotion script
 
 #### Sams-Notifications
 
-- make subscriber tenant-aware `#668`
+- make subscriber tenant-aware `(PR #668)`
 
 #### Search
 
-- (new web UI) Fix cody dashboard background colors in dark mode `#845`
-- (new web ui) Fix list styles in rich text documents `#835`
-- (new web ui) Fix styling of rich text documents `#834`
-- (new web ui) Show added lines content `#832`
-- fix client-side query validation for rev: filters `#810`
+- (new web UI) Fix cody dashboard background colors in dark mode `(PR #845)`
+- (new web ui) Fix list styles in rich text documents `(PR #835)`
+- (new web ui) Fix styling of rich text documents `(PR #834)`
+- (new web ui) Show added lines content `(PR #832)`
+- fix client-side query validation for rev: filters `(PR #810)`
   - We have updated the client-side query validation to allow combining `rev:` filters with query-based search contexts.
-- (new web ui) Clicking 'Code search' in then navbar of the old UI does not redirect to the new UI `#761`
-- (new web ui) Use a Map to group symbol names `#721`
-- VSCode Search extension: Update bug-reporting URL `#693`
-- VSCode Search extension: fix and improve proxy settings `#679`
-- in search jobs, don't time out fetches `#666`
+- (new web ui) Clicking 'Code search' in then navbar of the old UI does not redirect to the new UI `(PR #761)`
+- (new web ui) Use a Map to group symbol names `(PR #721)`
+- VSCode Search extension: Update bug-reporting URL `(PR #693)`
+- VSCode Search extension: fix and improve proxy settings `(PR #679)`
+- in search jobs, don't time out fetches `(PR #666)`
   - For very large repositories, search jobs could time out while fetching the repository. Now, search jobs can fetch and search over repositories, even if they take a long time to fetch.
-- (new web ui) Use CodeGraph data to validate hover occurence `#656`
-- (new web ui) User menu feature parity `#628`
-- add index for search jobs janitor `#624`
+- (new web ui) Use CodeGraph data to validate hover occurence `(PR #656)`
+- (new web ui) User menu feature parity `(PR #628)`
+- add index for search jobs janitor `(PR #624)`
   - We added a new database index to speed up a janitor job which is run as part of Search Jobs. Before, the janitor job might have significantly delayed migrations during an upgrade.
-- (new web ui) Respect 'experimentalFeatures.structuralSearch' setting `#621`
-- VSCode Search extension forgetting endpoint URL and PAT `#560`
-- fix logo links in the VSCode Search extension `#547`
-- Update help router for local development `#271`
+- (new web ui) Respect 'experimentalFeatures.structuralSearch' setting `(PR #621)`
+- VSCode Search extension forgetting endpoint URL and PAT `(PR #560)`
+- fix logo links in the VSCode Search extension `(PR #547)`
+- Update help router for local development `(PR #271)`
 
 #### Sg
 
-- Config.GetEnv uses GetEnv for os.Expand `#380`
+- Config.GetEnv uses GetEnv for os.Expand `(PR #380)`
 
 #### Sg/Msp
 
-- make embed template fmt-compliant, add docstring `#412`
+- make embed template fmt-compliant, add docstring `(PR #412)`
 
 #### Telemetry
 
-- ensure telemetry export only occurs once at a time `#565`
+- ensure telemetry export only occurs once at a time `(PR #565)`
   - Fix an issue where duplicate telemetry can be exported when the `worker` service is scaled horizontally
 
 #### Tenant
 
-- prevent race condition in MockEnforceTenant `#837`
-- stop Iterate if it breaks `#387`
+- prevent race condition in MockEnforceTenant `(PR #837)`
+- stop Iterate if it breaks `(PR #387)`
 
 #### Test
 
-- make workspaces waitforupdate test more reliable `#813`
+- make workspaces waitforupdate test more reliable `(PR #813)`
 
 #### Others
 
-- make rerank metric name distinguishable `#846`
-- Use correct label in splitting metric in embeddings indexing `#771`
-- Add rerank API token variable to sg.config.yaml `#716`
-- adjust formatting when using unix sockets `#653`
+- make rerank metric name distinguishable `(PR #846)`
+- Use correct label in splitting metric in embeddings indexing `(PR #771)`
+- Add rerank API token variable to sg.config.yaml `(PR #716)`
+- adjust formatting when using unix sockets `(PR #653)`
   - fix PGDATASOURCE format when using unix sockets
-- move deletion inside nil check `#556`
-- incrementally updating embeddings index `#555`
-- Decrease parallelism in embeddings indexing `#543`
-- Filter out empty context items in resolver `#537`
-- VIP user access to allowed models in Cody Gateway `#528`
-- properly escape email in URL query `#426`
-- use preferred mermaid APIs `#397`
+- move deletion inside nil check `(PR #556)`
+- incrementally updating embeddings index `(PR #555)`
+- Decrease parallelism in embeddings indexing `(PR #543)`
+- Filter out empty context items in resolver `(PR #537)`
+- VIP user access to allowed models in Cody Gateway `(PR #528)`
+- properly escape email in URL query `(PR #426)`
+- use preferred mermaid APIs `(PR #397)`
   - Fixes a bug that can cause errors when rendering many mermaid diagrams on a page.
 
 ### Chore
 
 #### All
 
-- use constraint names in ON CONFLICT statements `#473`
+- use constraint names in ON CONFLICT statements `(PR #473)`
 
 #### Batch Changes
 
-- add description for env var `#652`
+- add description for env var `(PR #652)`
 
 #### Ci
 
-- Remove stale CODENOTIFY entries `#439`
-- bump Go to 1.23.1 `#391`
-- update gomod lint `#382`
+- Remove stale CODENOTIFY entries `(PR #439)`
+- bump Go to 1.23.1 `(PR #391)`
+- update gomod lint `(PR #382)`
   - remove lint that checks  for promotheus/common 0.32.1 since we are using 0.48
-- upgrade golang.org/x/tools to 0.24 `#373`
+- upgrade golang.org/x/tools to 0.24 `(PR #373)`
   - address printf linter flagged issues
-- add annotation for no merge base `#345`
+- add annotation for no merge base `(PR #345)`
   - post an annotation if there is no merge base
 
 #### Code Intelligence
 
-- Bump autoindexing image SHAs `#831`
+- Bump autoindexing image SHAs `(PR #831)`
   - Upgrades default auto-indexing images to the latest versions (1) scip-go to v0.1.21 (2) scip-typescript to v0.3.14
-- Initialize test to consistent state `#825`
-- Unify GetUsages logic at Service level `#752`
-- Unify local phase usage extraction logic `#748`
-- Document code nav logic & limitations `#742`
-- Factor out & document package mentions code `#740`
-- Bump autoindexing image SHAs `#681`
+- Initialize test to consistent state `(PR #825)`
+- Unify GetUsages logic at Service level `(PR #752)`
+- Unify local phase usage extraction logic `(PR #748)`
+- Document code nav logic & limitations `(PR #742)`
+- Factor out & document package mentions code `(PR #740)`
+- Bump autoindexing image SHAs `(PR #681)`
   - Upgrades the default scip-go auto-indexing image to v0.1.20
-- Log number of paths in auto-inference logic `#635`
-- Add context to timeout error for commit listing `#607`
-- Clarify doc comment for NewCanonicalDocument `#480`
-- Document scip.Document and range canonicalization code `#459`
-- Split inverted ranges extraction code & add comments `#458`
-- Use UploadRelPath instead of string `#438`
-- Bump auto-indexing image SHAs `#403`
+- Log number of paths in auto-inference logic `(PR #635)`
+- Add context to timeout error for commit listing `(PR #607)`
+- Clarify doc comment for NewCanonicalDocument `(PR #480)`
+- Document scip.Document and range canonicalization code `(PR #459)`
+- Split inverted ranges extraction code & add comments `(PR #458)`
+- Use UploadRelPath instead of string `(PR #438)`
+- Bump auto-indexing image SHAs `(PR #403)`
   - Bumps default auto-indexing scip-go image to use Go 1.23.1 and scip-go v0.1.19
 
 #### Cody
 
-- add HTTP record/replay test case for AWS Bedrock backend `#452`
-- add HTTP record/replay test case for Anthropic LLM backend `#448`
-- add HTTP record/replay test case for Azure OpenAI `#446`
-- add HTTP record/replay test case for OpenAI LLM backend `#445`
-- add HTTP record/replay test case for Fireworks LLM backend `#441`
-- add HTTP record/replay test case for Google LLM backend `#410`
+- add HTTP record/replay test case for AWS Bedrock backend `(PR #452)`
+- add HTTP record/replay test case for Anthropic LLM backend `(PR #448)`
+- add HTTP record/replay test case for Azure OpenAI `(PR #446)`
+- add HTTP record/replay test case for OpenAI LLM backend `(PR #445)`
+- add HTTP record/replay test case for Fireworks LLM backend `(PR #441)`
+- add HTTP record/replay test case for Google LLM backend `(PR #410)`
 
 #### Database
 
-- set app.current_tenant outside of multitenant `#502`
+- set app.current_tenant outside of multitenant `(PR #502)`
 
 #### Database
 
-- remove unused redis_key_value table `#688`
-- update oobmigration min version to 4.0 `#540`
-- getRepositoriesForIndexScanQuery uses constraint `#534`
-- handle failed transactions in setTenant `#533`
-- use new constraints for on conflict `#510`
-- constraint for unique indexes used in on conflict `#504`
+- remove unused redis_key_value table `(PR #688)`
+- update oobmigration min version to 4.0 `(PR #540)`
+- getRepositoriesForIndexScanQuery uses constraint `(PR #534)`
+- handle failed transactions in setTenant `(PR #533)`
+- use new constraints for on conflict `(PR #510)`
+- constraint for unique indexes used in on conflict `(PR #504)`
 
 #### Dev
 
-- Bump Go version to 1.23.2 `#830`
+- Bump Go version to 1.23.2 `(PR #830)`
 
 #### Frontend
 
-- sync.Once to sync.OnceValue in service connections `#376`
+- sync.Once to sync.OnceValue in service connections `(PR #376)`
 
 #### Gomod
 
-- update zoekt's dependencies `#462`
+- update zoekt's dependencies `(PR #462)`
 
 #### Local
 
-- Fix ill-formed go.mod file `#434`
-- update sg installation docs `#390`
+- Fix ill-formed go.mod file `(PR #434)`
+- update sg installation docs `(PR #390)`
 
 #### Release
 
-- prepare stitch graph for 5.8 `#852`
+- prepare stitch graph for 5.8 `(PR #852)`
   -  Backport 6b58d4b62bba8f558c097fa97a751e51b178c537 from #850
 
 #### Release
 
-- clarify backport error `#784`
+- clarify backport error `(PR #784)`
 
 #### Reranker
 
-- clean up resolvers, improve perf, add more useful spans `#776`
+- clean up resolvers, improve perf, add more useful spans `(PR #776)`
 
 #### Search
 
-- (new web ui) Add telemetry for opt-out/in `#766`
-- remove codeintel ranking code `#719`
-- remove cursor based repo pagination `#663`
-- VSCode Search extension: remove "SOURCEGRAPH SEARCH" stutter in favor of "Info" `#559`
-- update wording from "Sourcegraph extension" to "Sourcegraph Search extension" `#558`
+- (new web ui) Add telemetry for opt-out/in `(PR #766)`
+- remove codeintel ranking code `(PR #719)`
+- remove cursor based repo pagination `(PR #663)`
+- VSCode Search extension: remove "SOURCEGRAPH SEARCH" stutter in favor of "Info" `(PR #559)`
+- update wording from "Sourcegraph extension" to "Sourcegraph Search extension" `(PR #558)`
 
 #### Semgrep
 
-- add upload artifact step `#616`
+- add upload artifact step `(PR #616)`
 
 #### Sg
 
-- remove enforce-tenant-id --disable `#705`
+- remove enforce-tenant-id --disable `(PR #705)`
 
 #### Tenant
 
-- restructure tenant package into internal subpackages `#587`
+- restructure tenant package into internal subpackages `(PR #587)`
 
 #### Trace
 
-- prevent parallel calls to ConfigureStaticTracerProvider `#467`
+- prevent parallel calls to ConfigureStaticTracerProvider `(PR #467)`
 
 #### Others
 
-- enable reranker by default `#804`
+- enable reranker by default `(PR #804)`
   - Reranker for context retrieval is turned on by default
-- disable IDF jobs `#783`
-- Clean up visible uploads initialization `#739`
-- Rename gatherLocations -> gatherUsages `#737`
-- Cleanup metadata generation code in Gateway `#714`
-- Remove unused endpoints from 969 prototype `#712`
-- trigger changelog audit on label event `#562`
+- disable IDF jobs `(PR #783)`
+- Clean up visible uploads initialization `(PR #739)`
+- Rename gatherLocations -> gatherUsages `(PR #737)`
+- Cleanup metadata generation code in Gateway `(PR #714)`
+- Remove unused endpoints from 969 prototype `(PR #712)`
+- trigger changelog audit on label event `(PR #562)`
 
 ### Refactor
 
 #### Svelte
 
-- Introduce extensible GraphQL store `#309`
+- Introduce extensible GraphQL store `(PR #309)`
 
 #### Others
 
-- move cody context business logic outside of resolvers `#647`
-- remove search mode `#629`
-- rename NonLocal -> Global in scip_strict parser `#366`
+- move cody context business logic outside of resolvers `(PR #647)`
+- remove search mode `(PR #629)`
+- rename NonLocal -> Global in scip_strict parser `(PR #366)`
 
 ### Reverts
 
-- Revert "pgdsn: Allow to fall back to default variables and overwrite … `#369`
+- Revert "pgdsn: Allow to fall back to default variables and overwrite … `(PR #369)`
 
 ### Uncategorized
 
 #### Others
 
-- bug(release): workspace cash time dance (#948) `#949`
-- [Backport 5.8.x] tenant: Improve OOB migration from learnings `#939`
-- [Backport 5.8.x] Revert "migrator: Backfill IDs from overrides into right schema only" `#914`
-- [Backport 5.8.x] migrator: Backfill IDs from overrides into right schema only `#894`
-- [Backport 5.8.x] Revert "fix(migration-graph): add no op migration to backfill overrides" `#888`
-- [Backport 5.8.x] Update lockfiles with newer version of apko `#882`
+- bug(release): workspace cash time dance (#948) `(PR #949)`
+- [Backport 5.8.x] tenant: Improve OOB migration from learnings `(PR #939)`
+- [Backport 5.8.x] Revert "migrator: Backfill IDs from overrides into right schema only" `(PR #914)`
+- [Backport 5.8.x] migrator: Backfill IDs from overrides into right schema only `(PR #894)`
+- [Backport 5.8.x] Revert "fix(migration-graph): add no op migration to backfill overrides" `(PR #888)`
+- [Backport 5.8.x] Update lockfiles with newer version of apko `(PR #882)`
   -  Backport 7f2c3bacf6778fef5f2ef444db2ebd873903c5e6 from #881
-- [Backport 5.8.x] Revert "Update rules_apko and fix issues with `sg wolfi` (#696)" `#880`
-- [Backport 5.8.x] db: Bump date for schema migrations stitch date `#878`
-- tenant: OOB migrator covers more tables `#842`
-- tenant: Default to ID 1 for inserts `#840`
-- migrator: Correctly render indexing progress `#812`
-- adding code qwen 2p5 and deepseek long prompt optimized model `#811`
-  - adding code qwen 2p5 and deepseek long prompt optimized model `#811`
-- security: Update docker dind to latest release `#808`
-- saml: Record requests `#788`
-- saml: Return error instead of appending to it `#787`
-- Add password for sourcegraph-rls `#786`
-- cmd/workspaces: setup routes during ws creation `#782`
-- db: Fix missing globaldbtenant `#779`
-- trace: Fix span pollution in authenticateByCookie `#753`
-- sg: Make sure sourcegraph_rls user also has permissions on future tables `#750`
-- tenant: Fix license check missing tenant `#747`
-- migration: Skip CREATE TABLE if possible `#746`
-- tenant: Fix more tenant-less contexts `#745`
-- tenant: Mark tenants tables as data tables `#738`
-- feat(Cody Reranker): clean up site config and add license-based auth for Cody Gateway `#724`
-- sg: Fix go generate `#722`
-- tenant/db: Safer ordering of migration statements `#718`
-- gitserver: Fix some missing tenant contexts `#717`
-- refactor(cody gateway): update model list for autocompletes `#711`
-- db: Add tenant_id to last remaining columns `#709`
-- db: Add OOB migration to backfill tenant ID `#706`
-- tenant: pass correct context to SetCloneStatus `#701`
-- sg: Reject empty workspace names `#700`
-- sg: Fix enforce-tenant-id after redis_key_value was dropped `#697`
-- Update rules_apko and fix issues with `sg wolfi` `#696`
-- Redis: don't check tenant for system commands `#695`
-- tenant: only skip goroutine recording if tenancy is enabled `#694`
-- Search jobs: set high timeout to protect against stuck jobs `#692`
-- tenant: fix remaining goroutine recorder errors `#691`
-- Reapply "feat(cody): add vision support (#546)" (#686) `#687`
-- Add detailed intent-score pairs to chat intent response `#682`
-- Jsm/disable model api `#680`
-- Site admin: simplify goroutine recording `#677`
-- Update client/vscode/CHANGELOG.md for PR #560 `#676`
-- tenant: Mapper returns more precise error `#675`
-- tenant: add missing IteratorFactory `#674`
-- tenant: Make migrations on startup pass in local dev `#667`
-- msp: report error when PGDSN does not have expected template variable `#664`
-- final ranker config for context v2 `#659`
+- [Backport 5.8.x] Revert "Update rules_apko and fix issues with `sg wolfi` (#696)" `(PR #880)`
+- [Backport 5.8.x] db: Bump date for schema migrations stitch date `(PR #878)`
+- tenant: OOB migrator covers more tables `(PR #842)`
+- tenant: Default to ID 1 for inserts `(PR #840)`
+- migrator: Correctly render indexing progress `(PR #812)`
+- adding code qwen 2p5 and deepseek long prompt optimized model `(PR #811)`
+  - adding code qwen 2p5 and deepseek long prompt optimized model `(PR #811)`
+- security: Update docker dind to latest release `(PR #808)`
+- saml: Record requests `(PR #788)`
+- saml: Return error instead of appending to it `(PR #787)`
+- Add password for sourcegraph-rls `(PR #786)`
+- cmd/workspaces: setup routes during ws creation `(PR #782)`
+- db: Fix missing globaldbtenant `(PR #779)`
+- trace: Fix span pollution in authenticateByCookie `(PR #753)`
+- sg: Make sure sourcegraph_rls user also has permissions on future tables `(PR #750)`
+- tenant: Fix license check missing tenant `(PR #747)`
+- migration: Skip CREATE TABLE if possible `(PR #746)`
+- tenant: Fix more tenant-less contexts `(PR #745)`
+- tenant: Mark tenants tables as data tables `(PR #738)`
+- feat(Cody Reranker): clean up site config and add license-based auth for Cody Gateway `(PR #724)`
+- sg: Fix go generate `(PR #722)`
+- tenant/db: Safer ordering of migration statements `(PR #718)`
+- gitserver: Fix some missing tenant contexts `(PR #717)`
+- refactor(cody gateway): update model list for autocompletes `(PR #711)`
+- db: Add tenant_id to last remaining columns `(PR #709)`
+- db: Add OOB migration to backfill tenant ID `(PR #706)`
+- tenant: pass correct context to SetCloneStatus `(PR #701)`
+- sg: Reject empty workspace names `(PR #700)`
+- sg: Fix enforce-tenant-id after redis_key_value was dropped `(PR #697)`
+- Update rules_apko and fix issues with `sg wolfi` `(PR #696)`
+- Redis: don't check tenant for system commands `(PR #695)`
+- tenant: only skip goroutine recording if tenancy is enabled `(PR #694)`
+- Search jobs: set high timeout to protect against stuck jobs `(PR #692)`
+- tenant: fix remaining goroutine recorder errors `(PR #691)`
+- Reapply "feat(cody): add vision support (#546)" (#686) `(PR #687)`
+- Add detailed intent-score pairs to chat intent response `(PR #682)`
+- Jsm/disable model api `(PR #680)`
+- Site admin: simplify goroutine recording `(PR #677)`
+- Update client/vscode/CHANGELOG.md for PR #560 `(PR #676)`
+- tenant: Mapper returns more precise error `(PR #675)`
+- tenant: add missing IteratorFactory `(PR #674)`
+- tenant: Make migrations on startup pass in local dev `(PR #667)`
+- msp: report error when PGDSN does not have expected template variable `(PR #664)`
+- final ranker config for context v2 `(PR #659)`
   - Changing the ranker configuration -- number of items fetched from zoekt
-- sg: Make enforce-tenant-id idempotent again `#655`
-- refactor(cody gateway): add deprecated models back to dotcom model list `#649`
-- gomod: bump Zoekt for memory debugging `#646`
-- Dev: ensure multi-tenant migration has been run `#645`
-- refactor(cody gateway): update dotcom models list `#643`
+- sg: Make enforce-tenant-id idempotent again `(PR #655)`
+- refactor(cody gateway): add deprecated models back to dotcom model list `(PR #649)`
+- gomod: bump Zoekt for memory debugging `(PR #646)`
+- Dev: ensure multi-tenant migration has been run `(PR #645)`
+- refactor(cody gateway): update dotcom models list `(PR #643)`
   - Cody Gateway: update default model list for dotcom.
-- Bump Cody Web to 0.9.0 version `#642`
-- sg cloud eph deploy:  --wait flag `#637`
-- executors: Check for rows affected instead of running into unique constraint error `#632`
-- Symbols: hide scary error messages from users `#631`
-- Add postgres as datasource for Grafana `#627`
-- add time to first token for upstream as header `#618`
-- workspaces: implement `managementv1.UpdateWorkspaceMembership` RPC `#613`
-- ci: add cloud ephemeral pipeline `#611`
-- add sourcegraph ranker `#610`
-- workspaces: implement GetWorkspaceMembership rpc `#609`
-- workspaces: implement `ReportInstanceState` RPC `#604`
-- workspaces: implement `ListWorkspaceMemberships` RPC `#603`
-- tenant: Add method to create a new tenant in database `#593`
-- workspaces: support []iam.Role in WorkspaceMembership `#590`
-- Cody Web: bump cody web to 0.8.3 `#589`
-- Cody context: fix bug in 'archived' change `#588`
-- workspaces: Add WorkspaceState to GetWorkspace rpc `#585`
-- tenant: Add support for reading tenant by hostname from database instead of hard-coded `#580`
-- workspaces: implement user `CreateWorkspace` API `#574`
-- workspaces: implement GetWorkspace RPC `#573`
-- gomod: bump Zoekt for indexing memory optimization (again) `#572`
-- use direct routing by default if present in the backend `#571`
-- workspaces: database get/upsert instances `#568`
-- workspaces: implement `ReportWorkspaceState` RPC `#564`
-- gomod: bump Zoekt for indexing memory optimization `#557`
-- Bump Cody Web to 0.8.2 version `#545`
-- clean up rerankers for Cody Context `#544`
-- sg(tenant): Add migration for constraints to local dev `#542`
-- rockskip: use full ctx from emitIndexRequest `#532`
-- Add billing metadata for core search, batch, and insights events `#529`
-- Cody context: support archived and forked repos `#527`
-- vsce: patch release v2.2.18 `#526`
-- fix context v2 zoekt subqueries `#523`
-- Repo-updater: continue start-up if hydration fails `#521`
-- Cody Web: bump cody web to 0.8.1 `#518`
-- cody-gateway: do not PING Redis too often `#517`
-- rockskip: Remove another duplicative BTREE index `#516`
-- rockskip: Remove duplicative BTREE index `#515`
-- db(tenant): lock between setTenant and exec to ensure session variable is set atomically `#512`
-- perf: reduce allocations in `evalKeywordExpansions` `#506`
-- local/nix: add pgvector extension `#503`
+- Bump Cody Web to 0.9.0 version `(PR #642)`
+- sg cloud eph deploy:  --wait flag `(PR #637)`
+- executors: Check for rows affected instead of running into unique constraint error `(PR #632)`
+- Symbols: hide scary error messages from users `(PR #631)`
+- Add postgres as datasource for Grafana `(PR #627)`
+- add time to first token for upstream as header `(PR #618)`
+- workspaces: implement `managementv1.UpdateWorkspaceMembership` RPC `(PR #613)`
+- ci: add cloud ephemeral pipeline `(PR #611)`
+- add sourcegraph ranker `(PR #610)`
+- workspaces: implement GetWorkspaceMembership rpc `(PR #609)`
+- workspaces: implement `ReportInstanceState` RPC `(PR #604)`
+- workspaces: implement `ListWorkspaceMemberships` RPC `(PR #603)`
+- tenant: Add method to create a new tenant in database `(PR #593)`
+- workspaces: support []iam.Role in WorkspaceMembership `(PR #590)`
+- Cody Web: bump cody web to 0.8.3 `(PR #589)`
+- Cody context: fix bug in 'archived' change `(PR #588)`
+- workspaces: Add WorkspaceState to GetWorkspace rpc `(PR #585)`
+- tenant: Add support for reading tenant by hostname from database instead of hard-coded `(PR #580)`
+- workspaces: implement user `CreateWorkspace` API `(PR #574)`
+- workspaces: implement GetWorkspace RPC `(PR #573)`
+- gomod: bump Zoekt for indexing memory optimization (again) `(PR #572)`
+- use direct routing by default if present in the backend `(PR #571)`
+- workspaces: database get/upsert instances `(PR #568)`
+- workspaces: implement `ReportWorkspaceState` RPC `(PR #564)`
+- gomod: bump Zoekt for indexing memory optimization `(PR #557)`
+- Bump Cody Web to 0.8.2 version `(PR #545)`
+- clean up rerankers for Cody Context `(PR #544)`
+- sg(tenant): Add migration for constraints to local dev `(PR #542)`
+- rockskip: use full ctx from emitIndexRequest `(PR #532)`
+- Add billing metadata for core search, batch, and insights events `(PR #529)`
+- Cody context: support archived and forked repos `(PR #527)`
+- vsce: patch release v2.2.18 `(PR #526)`
+- fix context v2 zoekt subqueries `(PR #523)`
+- Repo-updater: continue start-up if hydration fails `(PR #521)`
+- Cody Web: bump cody web to 0.8.1 `(PR #518)`
+- cody-gateway: do not PING Redis too often `(PR #517)`
+- rockskip: Remove another duplicative BTREE index `(PR #516)`
+- rockskip: Remove duplicative BTREE index `(PR #515)`
+- db(tenant): lock between setTenant and exec to ensure session variable is set atomically `(PR #512)`
+- perf: reduce allocations in `evalKeywordExpansions` `(PR #506)`
+- local/nix: add pgvector extension `(PR #503)`
   - enable pgvector in nix managed postgres db
-- redispool: allow call sites to custmoize their `TestOnBorrow` and `Dial` `#499`
-- cody-gateway: wait for Redis connection `#498`
-- cody-gateway: set `MaxActive` for Redis `#496`
-- Bump Cody Web to 0.8.0 version `#492`
-- Recorder: remove RegistrationDone method `#489`
-- Repo-updater: add tenancy `#479`
-- tenant: Basic support in worker `#476`
-- Cody context: return matched ranges of chunks `#474`
-- add(cody): `api-version=2` for incremental streaming LLM responses `#470`
+- redispool: allow call sites to custmoize their `TestOnBorrow` and `Dial` `(PR #499)`
+- cody-gateway: wait for Redis connection `(PR #498)`
+- cody-gateway: set `MaxActive` for Redis `(PR #496)`
+- Bump Cody Web to 0.8.0 version `(PR #492)`
+- Recorder: remove RegistrationDone method `(PR #489)`
+- Repo-updater: add tenancy `(PR #479)`
+- tenant: Basic support in worker `(PR #476)`
+- Cody context: return matched ranges of chunks `(PR #474)`
+- add(cody): `api-version=2` for incremental streaming LLM responses `(PR #470)`
   - The `/.api/completions/stream` endpoint now accepts an `api-version=2` query parameter that returns incremental text text responses when using `"stream": true` to improve performance and reduce bandwidth.
-- Remove Neovim from Cody dashboard `#469`
-- Fix flaky test by bringing down memory utilization of POS filter `#468`
-- msp/iam: fixup checks for `ErrNoRows` `#465`
-- gomod: bump Zoekt for zoekt-git-index profiling `#453`
-- worker: Make resetter a periodic goroutine `#450`
-- gomod: bump Zoekt for index optimization `#449`
-- http: Add context to more requests `#437`
-- conf: Remove alias for ExternalURL `#436`
-- frontend: Drop unused orgs_open_beta_stats table `#435`
-- msp/iam: do not close connection pool on startup `#433`
-- Filter out terms based on POS and expand Zoekt queries `#432`
-- authn: Create providers on the fly with current request context `#424`
-- tenant: Use request context when creating OIDC provider `#422`
-- redis: Add optional tenant isolation `#421`
-- tenant: Add context to LogBackendEvent `#420`
-- Remove debug log statement `#418`
-- minor doc change `#413`
-- sg: Use custom site-config for multitenant runset `#405`
-- Retrieve and display change log during upgrades. `#400`
+- Remove Neovim from Cody dashboard `(PR #469)`
+- Fix flaky test by bringing down memory utilization of POS filter `(PR #468)`
+- msp/iam: fixup checks for `ErrNoRows` `(PR #465)`
+- gomod: bump Zoekt for zoekt-git-index profiling `(PR #453)`
+- worker: Make resetter a periodic goroutine `(PR #450)`
+- gomod: bump Zoekt for index optimization `(PR #449)`
+- http: Add context to more requests `(PR #437)`
+- conf: Remove alias for ExternalURL `(PR #436)`
+- frontend: Drop unused orgs_open_beta_stats table `(PR #435)`
+- msp/iam: do not close connection pool on startup `(PR #433)`
+- Filter out terms based on POS and expand Zoekt queries `(PR #432)`
+- authn: Create providers on the fly with current request context `(PR #424)`
+- tenant: Use request context when creating OIDC provider `(PR #422)`
+- redis: Add optional tenant isolation `(PR #421)`
+- tenant: Add context to LogBackendEvent `(PR #420)`
+- Remove debug log statement `(PR #418)`
+- minor doc change `(PR #413)`
+- sg: Use custom site-config for multitenant runset `(PR #405)`
+- Retrieve and display change log during upgrades. `(PR #400)`
   - [Appliance] Retrieve live changelog and display information about the release to be upgraded.
-- Svelte: fix text wrapping for file popover `#399`
+- Svelte: fix text wrapping for file popover `(PR #399)`
   - Fixed a bug in the web app rewrite where long paths would cause file popovers to wrap
-- Svelte: fix loading for ref panel `#398`
+- Svelte: fix loading for ref panel `(PR #398)`
   - Fix loading behavior for the reference panel in the web app rewrite
-- gomod: bump Zoekt for index optimization `#389`
-- Svelte: SymbolTree followups `#388`
-- repo-updater: hack so it uses tenant 1 for now `#386`
-- gitserver: inherit tenant for repoUpdateOrClone `#385`
-- Chore: close rows `#379`
-- database: use keyword value format if connecting via unix socket `#378`
-- frontend: always use DSN from ServiceConnections `#375`
-- Reapply "pgdsn: Allow to fall back to default variables and overwrite..." `#374`
-- postgresdsn: support PGHOST as a filepath `#372`
-- release: specifiy download directory for changelog `#365`
+- gomod: bump Zoekt for index optimization `(PR #389)`
+- Svelte: SymbolTree followups `(PR #388)`
+- repo-updater: hack so it uses tenant 1 for now `(PR #386)`
+- gitserver: inherit tenant for repoUpdateOrClone `(PR #385)`
+- Chore: close rows `(PR #379)`
+- database: use keyword value format if connecting via unix socket `(PR #378)`
+- frontend: always use DSN from ServiceConnections `(PR #375)`
+- Reapply "pgdsn: Allow to fall back to default variables and overwrite..." `(PR #374)`
+- postgresdsn: support PGHOST as a filepath `(PR #372)`
+- release: specifiy download directory for changelog `(PR #365)`
   - specify download directory for changelog
-- frontend: Don't double-close readiness channel during auto upgrades `#358`
-- workspaces: initial IAM schema and implement `iam.Store` `#353`
-- enterprise-portal: implement `iam.Store` and add tests `#351`
-- enterprise-portal: create `internal/iam` package and run schema tests in CI `#350`
-- tenant: Add tenants 1 and 2 in localdev `#340`
-- sg: Introduce first multitenant runset `#335`
-- pgdsn: Allow to fall back to default variables and overwrite frontend `#332`
-- Remove k8s utils dependency `#320`
-- msp/iam: fixup migration PG 12 compatibility and sanity test migrations `#301`
-- Tree-sitter based chunker for embeddings indexing `#298`
-- Context: return multiple chunks per file from Zoekt results `#294`
+- frontend: Don't double-close readiness channel during auto upgrades `(PR #358)`
+- workspaces: initial IAM schema and implement `iam.Store` `(PR #353)`
+- enterprise-portal: implement `iam.Store` and add tests `(PR #351)`
+- enterprise-portal: create `internal/iam` package and run schema tests in CI `(PR #350)`
+- tenant: Add tenants 1 and 2 in localdev `(PR #340)`
+- sg: Introduce first multitenant runset `(PR #335)`
+- pgdsn: Allow to fall back to default variables and overwrite frontend `(PR #332)`
+- Remove k8s utils dependency `(PR #320)`
+- msp/iam: fixup migration PG 12 compatibility and sanity test migrations `(PR #301)`
+- Tree-sitter based chunker for embeddings indexing `(PR #298)`
+- Context: return multiple chunks per file from Zoekt results `(PR #294)`
   - We can improve recall by fetching multiple chunks per file from Zoekt results by turning on the `cody-reranker` feature flag.
-- add(cody): `api-version=2` incremental streaming LLM response `#293`
+- add(cody): `api-version=2` incremental streaming LLM response `(PR #293)`
   - The `/.api/completions/stream` endpoint now accepts an `api-version=2` query parameter that returns incremental text text responses when using `"stream": true` to improve performance and reduce bandwidth.
-- Context: improve ranker integration + loosen the tap `#291`
+- Context: improve ranker integration + loosen the tap `(PR #291)`
   - Ranker for chat context is now available behind `use-reranker` feature flag.
-- Hook Upgrade page to Release Registry API `#276`
-- Move IDF repository stats into Postgres and compute them with the background worker `#270`
-- Svelte: add symbol tree `#209`
+- Hook Upgrade page to Release Registry API `(PR #276)`
+- Move IDF repository stats into Postgres and compute them with the background worker `(PR #270)`
+- Svelte: add symbol tree `(PR #209)`
   - Adds a symbol tree to file page in the experimental webapp
-- Redis: respect context when connecting `#194`
-- Appliance Admin UI `#168`
+- Redis: respect context when connecting `(PR #194)`
+- Appliance Admin UI `(PR #168)`
   - [Appliance]: Adds the upgrade path for the Appliance Admin UX
 
 ### Untracked
 
 The following PRs were merged onto the previous release branch but could not be automatically mapped to a corresponding commit in this release:
 
-- remove the other embedding reference `#362`
+- remove the other embedding reference `(PR #362)`
   - n/a
 
 {/* RSS={"version":"v5.8.0", "releasedAt": "2024-10-08"} */}
@@ -2133,18 +2133,18 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Batch Changes
 
-- workaround for a bug in GitHub `#584`
+- workaround for a bug in GitHub `(PR #584)`
   - fix(batches): workaround for a bug in GitHub
   Backport aad3a04f8c93561a61c404e69132e70a22d0acba from #576
 
 #### Release
 
-- remove the other embedding reference `#362`
+- remove the other embedding reference `(PR #362)`
   - n/a
 
 #### Search
 
-- remove query expansion `#586`
+- remove query expansion `(PR #586)`
   - This fixes a bug where we added &quot;readme&quot; too often to the context.    Backport 28ff196a663f537c6cb6340f976a91431509a90e from #582
 
 ### Reverts
@@ -2155,7 +2155,7 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Others
 
-- [Backport 5.7.x] Search: allow queries with only lang filters `#583`
+- [Backport 5.7.x] Search: allow queries with only lang filters `(PR #583)`
 
 {/* RSS={"version":"v5.7.2474", "releasedAt": "2024-09-18"} */}
 
@@ -2171,433 +2171,433 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Appliance
 
-- enable frontend form and stub out, no backend routes yet `#80`
+- enable frontend form and stub out, no backend routes yet `(PR #80)`
 
 #### Batch Changes
 
-- Add a container registry deny list `#109`
+- Add a container registry deny list `(PR #109)`
   - Add a container registry deny list to complement the allow list.
   - Configure in site config via `"batchChanges.containerRegistryDenylist"`.
   - Mutually exclusive with `"batchChanges.containerRegistryAllowlist"`.
-- add support for registry allowlist `#105`
+- add support for registry allowlist `(PR #105)`
   - Add support to configure container registry allowlist for containers use from batch changes via `batchChanges.containerRegistryAllowlist` in Site Configuration.
 
 #### Cody
 
-- add `/.api/cody/context` API `#66`
+- add `/.api/cody/context` API `(PR #66)`
   - New `POST /.api/cody/context` REST endpoint to retrieve a list of relevant source locations given a natural language query.
 
 #### Dotcom
 
-- add account ID in subscriptions list view `#192`
-- forward license check to Enterprise Portal `#19`
+- add account ID in subscriptions list view `(PR #192)`
+- forward license check to Enterprise Portal `(PR #19)`
 
 #### Enterpriseportal
 
-- use file-based migrations with `goose` `#216`
-- add Salesforce Account ID `#176`
-- internal instances record detected instance `#139`
-- return unknown license as result `#134`
+- use file-based migrations with `goose` `(PR #216)`
+- add Salesforce Account ID `(PR #176)`
+- internal instances record detected instance `(PR #139)`
+- return unknown license as result `(PR #134)`
 
 #### Licensecheck
 
-- check against Enterprise Portal directly `#22`
+- check against Enterprise Portal directly `(PR #22)`
 
 #### Msp/Runtime
 
-- standardised migrations `#242`
-- first-class redis support `#241`
+- standardised migrations `(PR #242)`
+- first-class redis support `(PR #241)`
 
 #### Releases
 
-- scoped releases `#33`
+- scoped releases `(PR #33)`
   - feat(release): scoped releases
 
 #### Sg
 
-- MSP database migrations with `goose` `#215`
+- MSP database migrations with `goose` `(PR #215)`
 
 #### Site Admin
 
-- monitoring/telemetry: add v1 teestore write alerts and v2 export queue write alerts `#321`
+- monitoring/telemetry: add v1 teestore write alerts and v2 export queue write alerts `(PR #321)`
 
 #### Svelte
 
-- Add repository sync status indicator to search results `#260`
-- Sentry: Ignore errors from third party scripts `#171`
-- Add status notifications `#141`
-- Add support for indent-based code folding `#75`
+- Add repository sync status indicator to search results `(PR #260)`
+- Sentry: Ignore errors from third party scripts `(PR #171)`
+- Add status notifications `(PR #141)`
+- Add support for indent-based code folding `(PR #75)`
 
 #### Telemetry/Sensitivemetadataallowlist
 
-- allow string list and nulls `#27`
+- allow string list and nulls `(PR #27)`
 
 #### Others
 
-- Syntactic support for go `#328`
+- Syntactic support for go `(PR #328)`
 
 ### Fix
 
 #### Batch Changes
 
-- omit headRepositoryId if empty `#200`
-- avoid "Name already exists on this account" from creating fork by fetching the repo when the error happens `#159`
+- omit headRepositoryId if empty `(PR #200)`
+- avoid "Name already exists on this account" from creating fork by fetching the repo when the error happens `(PR #159)`
   - fix(batches): avoid "Name already exists on this account" from creating fork by fetching the repo when the error happens
 
 #### Code Intelligence
 
-- ensure syntactic worker marks itself as "ready" on startup `#341`
+- ensure syntactic worker marks itself as "ready" on startup `(PR #341)`
 
 #### Code Nav
 
-- Return ALL references in the same file as the definition `#240`
+- Return ALL references in the same file as the definition `(PR #240)`
 
 #### Cody
 
-- correctly parse queries containing 'or' `#267`
+- correctly parse queries containing 'or' `(PR #267)`
   - Fixes a regression in Cody context where questions containing the word 'or' could return noisy or no results.
-- use reverse proxy for Gemini API `#208`
-- address critical bug from code review `#179`
-- return valid `finish_reason` in `/.api/llm/chat/completions` `#154`
+- use reverse proxy for Gemini API `(PR #208)`
+- address critical bug from code review `(PR #179)`
+- return valid `finish_reason` in `/.api/llm/chat/completions` `(PR #154)`
   - LLM API `/.api/chat/completions` now returns OpenAI-compatible `finish_reason`.
-- fix error handling in LLM API `#153`
+- fix error handling in LLM API `(PR #153)`
   - LLM API endpoints (`/.api/llm`) now return JSON-encoded HTTP bodies for non-200 status codes.
-- use `testdata` instead of `golly-recordings` directory name `#152`
-- give names to LLM API handlers `#151`
-- allow `Bearer TOKEN` header for all LLM APIs `#150`
+- use `testdata` instead of `golly-recordings` directory name `(PR #152)`
+- give names to LLM API handlers `(PR #151)`
+- allow `Bearer TOKEN` header for all LLM APIs `(PR #150)`
   - For compatibility with OpenAI clients, it's possible to use `Bearer TOKEN` header with all API endpoints that start with the prefix `/.api/llm`.
-- deepseek-coder-v2-lite-base model name mapping for dotcom users `#135`
+- deepseek-coder-v2-lite-base model name mapping for dotcom users `(PR #135)`
 
 #### Cody-Gateway
 
-- ignore schema errors on otel init `#237`
+- ignore schema errors on otel init `(PR #237)`
 
 #### Enterpriseportal
 
-- normalize instance domain on create subscription `#163`
-- add subscription ID to trace, other diagnostics improvements `#130`
+- normalize instance domain on create subscription `(PR #163)`
+- add subscription ID to trace, other diagnostics improvements `(PR #130)`
 
 #### Enterpriseportal/E2e
 
-- fix test case for check license `#162`
+- fix test case for check license `(PR #162)`
 
 #### Frontend
 
-- Do not sign-out users when accessing a file path containing /login `#57`
+- Do not sign-out users when accessing a file path containing /login `(PR #57)`
 
 #### Local
 
-- check for rogue files and folders in svelte routes `#337`
+- check for rogue files and folders in svelte routes `(PR #337)`
   - prevent `web-sveltekit` commands from running if there are untracked files under src/routes
-- expand _after_ accumulating the whole env `#257`
+- expand _after_ accumulating the whole env `(PR #257)`
 
 #### Oobmigration
 
-- remove migrations targeting licenses/subscriptions `#263`
+- remove migrations targeting licenses/subscriptions `(PR #263)`
 
 #### Repo-Updater
 
-- add WARN level logs every time we sync a code host `#44`
+- add WARN level logs every time we sync a code host `(PR #44)`
   - repo-updater now emits logs that log the result of every code host sync.
 
 #### Sams-Notifications
 
-- mockrequire.Values incorrectly used `#315`
+- mockrequire.Values incorrectly used `(PR #315)`
 
 #### Search
 
-- skip if git diff not found in hybrid `#333`
+- skip if git diff not found in hybrid `(PR #333)`
   - When searching an unindexed commit we would consult indexed commits for speeding up results. If our index contained a commit that no longer existed in git we would error out due to a regression in v5.4.5099. This is now fixed.
-- add "Create batch change" back to Actions dropdown in search results `#143`
+- add "Create batch change" back to Actions dropdown in search results `(PR #143)`
 
 #### Sg
 
-- make start commands cancel fn be sync.OnceFunc `#319`
+- make start commands cancel fn be sync.OnceFunc `(PR #319)`
   - the cancel funcs used by sg commands are now wrapped in `sync.OnceFunc` to prevent duplicate execution
-- add deprecation notice to sg wolfi update-hashes `#289`
+- add deprecation notice to sg wolfi update-hashes `(PR #289)`
   - sg: fix panic when using `wolfi update-hashes`
   - sg: add deprecation notice for `wolfi update-hashes`
-- check if we are ephemeral before getting lease time `#256`
+- check if we are ephemeral before getting lease time `(PR #256)`
   - sg - fix panic in Cloud Ephemeral listing when listing instances that are not Ephemeral
-- clamp deployment name consistently in cloud ephemeral `#117`
+- clamp deployment name consistently in cloud ephemeral `(PR #117)`
   - ensure deployment / instance names are clamped in all places for cloud ephemeral
-- implement env priority to improve env var ordering `#31`
+- implement env priority to improve env var ordering `(PR #31)`
 
 #### Svelte
 
-- Preserve history panel scroll position after selecting an entry `#251`
-- Update existing query filters when including suggested filters `#115`
-- Remove 'Code Ownership' top navigation `#87`
-- Update main navigation to match React app `#74`
-- Fix regex generation for routes that contain parameters `#73`
-- Fix Bazel production build `#43`
-- Workaround for handling client-side redirections in production `#14`
+- Preserve history panel scroll position after selecting an entry `(PR #251)`
+- Update existing query filters when including suggested filters `(PR #115)`
+- Remove 'Code Ownership' top navigation `(PR #87)`
+- Update main navigation to match React app `(PR #74)`
+- Fix regex generation for routes that contain parameters `(PR #73)`
+- Fix Bazel production build `(PR #43)`
+- Workaround for handling client-side redirections in production `(PR #14)`
 
 #### Others
 
-- Switch to larger runner for scip-go jobs `#221`
-- add deepseek virtual model string `#211`
-- set webRoot to /client/web in launch.json `#83`
-- Speed up auto-index job expiration query `#3`
+- Switch to larger runner for scip-go jobs `(PR #221)`
+- add deepseek virtual model string `(PR #211)`
+- set webRoot to /client/web in launch.json `(PR #83)`
+- Speed up auto-index job expiration query `(PR #3)`
 
 ### Chore
 
 #### Dotcom
 
-- fix typo in subscriptions page `#195`
-- delete subscriptions, licensing, and cody gateway usage `#21`
+- fix typo in subscriptions page `(PR #195)`
+- delete subscriptions, licensing, and cody gateway usage `(PR #21)`
 
 #### Dotcom/Subscriptions
 
-- minor UX tweaks `#175`
+- minor UX tweaks `(PR #175)`
 
 #### Embedding
 
-- delete cmd/embeddings `#181`
+- delete cmd/embeddings `(PR #181)`
 
 #### Enterpriseportal
 
-- declare required scopes in schema and use schema-based enforcement `#305`
-- add Cody Access override case to manual E2E tests `#224`
-- improve formatting of duplicate usage message `#177`
-- remove dotcomdb connection and testing infra `#20`
+- declare required scopes in schema and use schema-based enforcement `(PR #305)`
+- add Cody Access override case to manual E2E tests `(PR #224)`
+- improve formatting of duplicate usage message `(PR #177)`
+- remove dotcomdb connection and testing infra `(PR #20)`
 
 #### Gomod
 
-- update for a bunch of CVEs `#343`
+- update for a bunch of CVEs `(PR #343)`
 
 #### Local
 
-- stop using deprecated `docker-compose` command `#206`
+- stop using deprecated `docker-compose` command `(PR #206)`
 
 #### Pubsub
 
-- upgrade to disable OpenTelemetry tracing `#210`
+- upgrade to disable OpenTelemetry tracing `(PR #210)`
 
 #### Pubsubemulator
 
-- init tool `#272`
+- init tool `(PR #272)`
 
 #### Release
 
-- simplify changelog download in release `#227`
+- simplify changelog download in release `(PR #227)`
   - simplify `changelog` cli download by using `gh` cli
 
 #### Search
 
-- Tell EditorConfig to stop messing with snapshot files `#275`
-- Remove Beta label from code monitors webhooks option. `#274`
+- Tell EditorConfig to stop messing with snapshot files `(PR #275)`
+- Remove Beta label from code monitors webhooks option. `(PR #274)`
 
 #### Search-Jobs
 
-- deprecate experimental site setting `#122`
+- deprecate experimental site setting `(PR #122)`
   - The site setting `experimentalFeatures.searchJobs` is not read anymore. To disable Search Jobs, set `DISABLE_SEARCH_JOBS=true` for the "frontend" and "worker" services.
-- remove EXPERIMENTAL from gql API `#116`
-- remove beta badge `#114`
+- remove EXPERIMENTAL from gql API `(PR #116)`
+- remove beta badge `(PR #114)`
 
 #### Svelte
 
-- Upgrade dependencies and cleanup configs `#279`
-- Fix type import `#277`
-- Reduce build log noise `#252`
-- Ingore 'RepoNotFoundError's in Sentry `#113`
+- Upgrade dependencies and cleanup configs `(PR #279)`
+- Fix type import `(PR #277)`
+- Reduce build log noise `(PR #252)`
+- Ingore 'RepoNotFoundError's in Sentry `(PR #113)`
 
 #### Tenant
 
-- Iterate does not enforce no tenant unlike Inherit `#334`
+- Iterate does not enforce no tenant unlike Inherit `(PR #334)`
 
 #### Tooling
 
-- bump Go to 1.23.0 `#126`
+- bump Go to 1.23.0 `(PR #126)`
 
 #### Wofli
 
-- update images `#290`
+- update images `(PR #290)`
   - update images to use latest p4-fusion binary
 
 #### Workspaces
 
-- define initial Workspaces proto schemas `#262`
-- stub service and directory `#244`
+- define initial Workspaces proto schemas `(PR #262)`
+- stub service and directory `(PR #244)`
 
 #### Others
 
-- fix onUserRolesChanged `has SiteAdmin role` test name `#314`
-- update github.com/openfga/openfga to v1.6.0 `#295`
-- updates Rust toolchain to 1.80.1 `#287`
-- Re-enable SCIP uploads to Demo `#222`
-- create github action for changelog audit `#198`
-- undo unneeded upgrades `#164`
-- upgrade sourcegraph-accounts-sdk-go version `#160`
-- Simplify semaphore-based code using conc.Iterator `#146`
-- Bump autoindexing image SHAs `#131`
-- migrate httpserver to use sg/log `#112`
+- fix onUserRolesChanged `has SiteAdmin role` test name `(PR #314)`
+- update github.com/openfga/openfga to v1.6.0 `(PR #295)`
+- updates Rust toolchain to 1.80.1 `(PR #287)`
+- Re-enable SCIP uploads to Demo `(PR #222)`
+- create github action for changelog audit `(PR #198)`
+- undo unneeded upgrades `(PR #164)`
+- upgrade sourcegraph-accounts-sdk-go version `(PR #160)`
+- Simplify semaphore-based code using conc.Iterator `(PR #146)`
+- Bump autoindexing image SHAs `(PR #131)`
+- migrate httpserver to use sg/log `(PR #112)`
   - update httpserver to use sourcegraph/log instead of log15
-- Updates tree-sitter version `#93`
-- Delete a bunch of unused LSIF-related code `#77`
-- clean up CODENOTIFY for Joe `#28`
+- Updates tree-sitter version `(PR #93)`
+- Delete a bunch of unused LSIF-related code `(PR #77)`
+- clean up CODENOTIFY for Joe `(PR #28)`
 
 ### Refactor
 
 #### Svelte
 
-- Make repo page integration test setups reusable `#249`
-- Refactor temporary settings to remove Apollo dependency `#156`
-- Lazy load mermaid `#16`
+- Make repo page integration test setups reusable `(PR #249)`
+- Refactor temporary settings to remove Apollo dependency `(PR #156)`
+- Lazy load mermaid `(PR #16)`
 
 ### Reverts
 
-- revert reverse proxy usage to access Gemini API `#236`
+- revert reverse proxy usage to access Gemini API `(PR #236)`
 
 ### Uncategorized
 
 #### Others
 
-- Bump Cody Web to 0.7.7 version `#347`
-- bug: fix slice init length `#339`
-- Add migration to create sourcegraph_rls user in local dev `#331`
-- Add tenant1 and tenant2 hostnames to caddy setup `#330`
-- Deglobalize SiteID `#329`
-- gomod: bump zoekt for indexing observability improvements `#327`
-- searcher: check for zoekt empty repo commit in hybrid search `#326`
-- conf: do not log missing tenant `#318`
-- database: introduce globaldbtenant package `#317`
-- database: rm unused Transact, Done, ShareableStore from ConfStore `#316`
-- [perforce] Store label cache file in .p4home `#308`
-- Convert trivial chunk/batching functions to use slices.Chunk `#307`
-- Bump cody web to 0.7.6 `#304`
-- handle error case where anthropic api returns an empty response `#303`
-- msp/iam: use runtime standardized migrations mechanism `#300`
-- frontend: update permissions runs per tenant `#299`
-- tenant: avoid FromContext logging in Inherit `#297`
-- validation: pass in ctx for validateAuthzProviders `#296`
-- siteadmin: Make recoverUsers idempotent `#292`
+- Bump Cody Web to 0.7.7 version `(PR #347)`
+- bug: fix slice init length `(PR #339)`
+- Add migration to create sourcegraph_rls user in local dev `(PR #331)`
+- Add tenant1 and tenant2 hostnames to caddy setup `(PR #330)`
+- Deglobalize SiteID `(PR #329)`
+- gomod: bump zoekt for indexing observability improvements `(PR #327)`
+- searcher: check for zoekt empty repo commit in hybrid search `(PR #326)`
+- conf: do not log missing tenant `(PR #318)`
+- database: introduce globaldbtenant package `(PR #317)`
+- database: rm unused Transact, Done, ShareableStore from ConfStore `(PR #316)`
+- [perforce] Store label cache file in .p4home `(PR #308)`
+- Convert trivial chunk/batching functions to use slices.Chunk `(PR #307)`
+- Bump cody web to 0.7.6 `(PR #304)`
+- handle error case where anthropic api returns an empty response `(PR #303)`
+- msp/iam: use runtime standardized migrations mechanism `(PR #300)`
+- frontend: update permissions runs per tenant `(PR #299)`
+- tenant: avoid FromContext logging in Inherit `(PR #297)`
+- validation: pass in ctx for validateAuthzProviders `(PR #296)`
+- siteadmin: Make recoverUsers idempotent `(PR #292)`
   - The recoverUsers endpoint failed with a spurious error when some of the given users were already active. It is now idempotent.
-- Remove (old friend) storm project `#286`
-- all: skip slow tests when -short `#284`
-- licensing: fix flaky uses of MockGetConfiguredProductLicenseInfo `#283`
-- gitserver: fix RemoveBadRefs on darwin `#280`
-- Cody Web: Remove old cody web logic `#273`
-- Move package `#269`
-- add unit test for idf index `#268`
-- Worker: fix flake in repo syncer test `#266`
-- clean unused flag `#265`
-- Bump own and repos test timeouts to long `#258`
-- Upgrade SCIM package to allow Microsoft Entra string values `#253`
-- add(cody): support for Sonnet 3.5 "fast edit" model `#250`
-- Enable route outside Site Admin into Appliance service. `#247`
-- add common access token for direct routing `#245`
-- Redis: pass context through remaining methods `#239`
-- Bump Cody Web to 0.7.3 for react version `#238`
-- dev: remove compare-hash.sh `#234`
-- doc: update search links for monorepo to be on s2 `#233`
-- change the default model from starcoder to deepseek `#232`
-- database: capture missing tenant for queries `#231`
-- goroutine: support tenants `#229`
-- Rearrange auth provider middlewares `#228`
-- Add option to cache label data with p4-fusion `#225`
+- Remove (old friend) storm project `(PR #286)`
+- all: skip slow tests when -short `(PR #284)`
+- licensing: fix flaky uses of MockGetConfiguredProductLicenseInfo `(PR #283)`
+- gitserver: fix RemoveBadRefs on darwin `(PR #280)`
+- Cody Web: Remove old cody web logic `(PR #273)`
+- Move package `(PR #269)`
+- add unit test for idf index `(PR #268)`
+- Worker: fix flake in repo syncer test `(PR #266)`
+- clean unused flag `(PR #265)`
+- Bump own and repos test timeouts to long `(PR #258)`
+- Upgrade SCIM package to allow Microsoft Entra string values `(PR #253)`
+- add(cody): support for Sonnet 3.5 "fast edit" model `(PR #250)`
+- Enable route outside Site Admin into Appliance service. `(PR #247)`
+- add common access token for direct routing `(PR #245)`
+- Redis: pass context through remaining methods `(PR #239)`
+- Bump Cody Web to 0.7.3 for react version `(PR #238)`
+- dev: remove compare-hash.sh `(PR #234)`
+- doc: update search links for monorepo to be on s2 `(PR #233)`
+- change the default model from starcoder to deepseek `(PR #232)`
+- database: capture missing tenant for queries `(PR #231)`
+- goroutine: support tenants `(PR #229)`
+- Rearrange auth provider middlewares `(PR #228)`
+- Add option to cache label data with p4-fusion `(PR #225)`
   - Perforce connections now support a `cacheLabels` option to cache Perforce label data from the server, speeding up consecutive syncs on systems with a large number of labels.
-- lib/cloudapi: introduce features config `#223`
-- lib/cloudapi: add auth pkg `#214`
-- shortcut noop `#213`
-- dev/msp: expose more runtime values to gotmpl `#212`
-- worker: add OnUserRolesUpdated SAMS notification handler `#204`
-- tenant: use marshal method instead of strconv `#203`
-- [fix] Perforce auth provider panics when only IP is provided `#199`
-- Redis: pass context to hash and ttl methods `#196`
-- Redis: introduce KeyValue.Info() `#193`
-- Respect context in Stop methods `#191`
-- telemetry: wait for v1 writes in tests on teestore `#190`
-- tenant: factor out marshalling `#189`
-- Allow AWS tokens in the repository `#188`
+- lib/cloudapi: introduce features config `(PR #223)`
+- lib/cloudapi: add auth pkg `(PR #214)`
+- shortcut noop `(PR #213)`
+- dev/msp: expose more runtime values to gotmpl `(PR #212)`
+- worker: add OnUserRolesUpdated SAMS notification handler `(PR #204)`
+- tenant: use marshal method instead of strconv `(PR #203)`
+- [fix] Perforce auth provider panics when only IP is provided `(PR #199)`
+- Redis: pass context to hash and ttl methods `(PR #196)`
+- Redis: introduce KeyValue.Info() `(PR #193)`
+- Respect context in Stop methods `(PR #191)`
+- telemetry: wait for v1 writes in tests on teestore `(PR #190)`
+- tenant: factor out marshalling `(PR #189)`
+- Allow AWS tokens in the repository `(PR #188)`
   -
-- tenant: prevent parallel test runs when mocking enforcement `#187`
-- Configure and activate Admin UI `#186`
+- tenant: prevent parallel test runs when mocking enforcement `(PR #187)`
+- Configure and activate Admin UI `(PR #186)`
   - [Appliance] Activate appliance updates on Code Search admin UI
-- sg: skip dev-private check if OFFLINE set `#185`
-- Updating owner tag `#183`
-- security: Ensure sourcegraph will run with uid randomisation `#182`
-- tenant: add context to gitserver's filesystem interface `#178`
-- change re-ranking method from public to private `#173`
-- Web: encode file path for blame `#172`
+- sg: skip dev-private check if OFFLINE set `(PR #185)`
+- Updating owner tag `(PR #183)`
+- security: Ensure sourcegraph will run with uid randomisation `(PR #182)`
+- tenant: add context to gitserver's filesystem interface `(PR #178)`
+- change re-ranking method from public to private `(PR #173)`
+- Web: encode file path for blame `(PR #172)`
   - Fixes an issue that would cause blame view to fail on files that contain some special characters.
-- Fix main lint `#169`
+- Fix main lint `(PR #169)`
   - [Fix] code linting
-- Redis: add context to httpcache and rcache `#167`
-- fixing the limit text for autocompletes `#166`
-- Bug: Fix file/directory popover regression `#165`
+- Redis: add context to httpcache and rcache `(PR #167)`
+- fixing the limit text for autocompletes `(PR #166)`
+- Bug: Fix file/directory popover regression `(PR #165)`
   - Fix File and directory popovers in the file tree when code search is scoped to a perforce depot.
-- ci/srcgql-compat: fix workflow `#161`
-- guardrails: temporary cache for incident `#158`
-- security: Remove root from some containers, and make it clearer which containers run as root `#157`
-- Update site.schema.json `#155`
-- all: update OWNERS and CODENOTIFY to match new team names `#148`
-- migrations: remove read on pg_attribute for tenant_id `#147`
-- Cody Web: Update cody web to 0.7.1 `#144`
-- dev/cloud-relay: add msp delivery target for rollout `#142`
-- Cody Web: fix cody web in svelte safari `#138`
-- Instrument request latency in Cody Gateway `#136`
-- dev/cloud-relay: import repo `#132`
-- all: upgrade staticcheck and unparam `#128`
-- Cody Web: Update cody web to 0.6.1 (svelte and react) `#127`
-- ci/cloud-gql-compat: only report error on remote workflow failure `#125`
-- add perforce support for git references table and labels `#124`
+- ci/srcgql-compat: fix workflow `(PR #161)`
+- guardrails: temporary cache for incident `(PR #158)`
+- security: Remove root from some containers, and make it clearer which containers run as root `(PR #157)`
+- Update site.schema.json `(PR #155)`
+- all: update OWNERS and CODENOTIFY to match new team names `(PR #148)`
+- migrations: remove read on pg_attribute for tenant_id `(PR #147)`
+- Cody Web: Update cody web to 0.7.1 `(PR #144)`
+- dev/cloud-relay: add msp delivery target for rollout `(PR #142)`
+- Cody Web: fix cody web in svelte safari `(PR #138)`
+- Instrument request latency in Cody Gateway `(PR #136)`
+- dev/cloud-relay: import repo `(PR #132)`
+- all: upgrade staticcheck and unparam `(PR #128)`
+- Cody Web: Update cody web to 0.6.1 (svelte and react) `(PR #127)`
+- ci/cloud-gql-compat: only report error on remote workflow failure `(PR #125)`
+- add perforce support for git references table and labels `(PR #124)`
   - Code Search now supports labels for Perforce Depots
-- iterator: add Map function `#123`
-- symbols: skip rockskipintegration on dev if missing binaries `#121`
-- syntactic-indexing: skip tests on dev if scip-syntax is missing `#120`
-- keyring: t.Parallel safe MockDefault `#119`
-- appliance: inject os.Getenv to ensure clean environment `#118`
-- db: add event_logs_export_allowlist and own_signal_configurations to DataTables `#111`
-- expand special case handlers for context endpoint `#110`
-- More context improvements `#104`
-- adding cohere reRanker in the cody context `#102`
-- Don't use markdown header symbols in graphql docs `#99`
-- appliance: check ShouldRunSetupEnvTests in integrationtest `#97`
-- Fix hardcoded version number in security release approval message `#96`
-- blobstore: support tenant isolation `#94`
-- Make syntactic indexing policies non exclusive to precise indexing `#92`
-- Add --build flag to `sg cloud ephemeral upgrade` `#91`
-- Turn off minification for cody web worker `#90`
-- Redis: add context arg for list methods `#89`
-- Basic custom context handler `#86`
-- security: Auto-update package lockfiles for Sourcegraph base images `#85`
-- React: Bump Cody Web to 0.5.1 `#79`
-- lib/cloudapi: restructure pkg to reduce nesting `#68`
-- nix flake update to go 1.23 `#62`
-- nix: local is a string for GOTOOLCHAIN `#61`
-- sg CLI: Use correct pipeline when retrieving annotations `#60`
-- security: Auto-update package lockfiles for Sourcegraph base images `#56`
-- nix: set GOTOOLCHAIN=local `#55`
-- Search: improve indexing delay dashboards `#54`
-- telemetry: always best-effort write to v1 store `#53`
-- database: limit concurrent event log inserts `#52`
-- Only commits in policy commitmap `#49`
-- lib/cloudapi: import cloud-api proto def `#40`
-- ctags/6.1.0 package update `#38`
-- redis_exporter/1.62.0 package update `#37`
-- docker-client/27.1.2 package update `#36`
-- p4-fusion/1.13 package update `#35`
-- jaeger/1.60.0 package update `#34`
-- [Stream API]: Add external_service_type field to the SearchedRepo type `#32`
+- iterator: add Map function `(PR #123)`
+- symbols: skip rockskipintegration on dev if missing binaries `(PR #121)`
+- syntactic-indexing: skip tests on dev if scip-syntax is missing `(PR #120)`
+- keyring: t.Parallel safe MockDefault `(PR #119)`
+- appliance: inject os.Getenv to ensure clean environment `(PR #118)`
+- db: add event_logs_export_allowlist and own_signal_configurations to DataTables `(PR #111)`
+- expand special case handlers for context endpoint `(PR #110)`
+- More context improvements `(PR #104)`
+- adding cohere reRanker in the cody context `(PR #102)`
+- Don't use markdown header symbols in graphql docs `(PR #99)`
+- appliance: check ShouldRunSetupEnvTests in integrationtest `(PR #97)`
+- Fix hardcoded version number in security release approval message `(PR #96)`
+- blobstore: support tenant isolation `(PR #94)`
+- Make syntactic indexing policies non exclusive to precise indexing `(PR #92)`
+- Add --build flag to `sg cloud ephemeral upgrade` `(PR #91)`
+- Turn off minification for cody web worker `(PR #90)`
+- Redis: add context arg for list methods `(PR #89)`
+- Basic custom context handler `(PR #86)`
+- security: Auto-update package lockfiles for Sourcegraph base images `(PR #85)`
+- React: Bump Cody Web to 0.5.1 `(PR #79)`
+- lib/cloudapi: restructure pkg to reduce nesting `(PR #68)`
+- nix flake update to go 1.23 `(PR #62)`
+- nix: local is a string for GOTOOLCHAIN `(PR #61)`
+- sg CLI: Use correct pipeline when retrieving annotations `(PR #60)`
+- security: Auto-update package lockfiles for Sourcegraph base images `(PR #56)`
+- nix: set GOTOOLCHAIN=local `(PR #55)`
+- Search: improve indexing delay dashboards `(PR #54)`
+- telemetry: always best-effort write to v1 store `(PR #53)`
+- database: limit concurrent event log inserts `(PR #52)`
+- Only commits in policy commitmap `(PR #49)`
+- lib/cloudapi: import cloud-api proto def `(PR #40)`
+- ctags/6.1.0 package update `(PR #38)`
+- redis_exporter/1.62.0 package update `(PR #37)`
+- docker-client/27.1.2 package update `(PR #36)`
+- p4-fusion/1.13 package update `(PR #35)`
+- jaeger/1.60.0 package update `(PR #34)`
+- [Stream API]: Add external_service_type field to the SearchedRepo type `(PR #32)`
   - Searched repo, commit, path, symbol and file match responses will now include external service type.
--  Directory mentions: extract and test buildKeywordQuery `#30`
-- lib/background: fix flaky test of monitor routines with context cancel `#29`
-- direct route for fireworks models `#26`
-- repos: use passed in ctx for SystemsInfo `#18`
-- Removing featureflag for expanded audit logs `#15`
+-  Directory mentions: extract and test buildKeywordQuery `(PR #30)`
+- lib/background: fix flaky test of monitor routines with context cancel `(PR #29)`
+- direct route for fireworks models `(PR #26)`
+- repos: use passed in ctx for SystemsInfo `(PR #18)`
+- Removing featureflag for expanded audit logs `(PR #15)`
   - More auditlogs for sensitive admin actions will be automatically logged.
-- Perforce UI Elements: Add perforce UI elements to history panel `#12`
-- Add typescript parser for SCIP symbols `#10`
-- migrations: run squash targetting v5.3.0 `#9`
+- Perforce UI Elements: Add perforce UI elements to history panel `(PR #12)`
+- Add typescript parser for SCIP symbols `(PR #10)`
+- migrations: run squash targetting v5.3.0 `(PR #9)`
 
 ### Untracked
 
 The following PRs were merged onto the previous release branch but could not be automatically mapped to a corresponding commit in this release:
 
-- Support SAST Scanning with both GHAS and Custom post processing scrip… `#67`
+- Support SAST Scanning with both GHAS and Custom post processing scrip… `(PR #67)`
   - sast scans are reported without any issues
-- added better GHAS check (#64537) `#65`
+- added better GHAS check (#64537) `(PR #65)`
   - chore(security): Fix GHAS check as non-zero exit code
 
 {/* RSS={"version":"v5.7.0", "releasedAt": "2024-09-04"} */}
@@ -2617,21 +2617,21 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Security
 
-- security: added better GHAS check (#64537) `#65`
+- security: added better GHAS check (#64537) `(PR #65)`
   - chore(security): Fix GHAS check as non-zero exit code
 
 ### Uncategorized
 
-- Support SAST Scanning with both GHAS and Custom post processing scrip… `#67`
+- Support SAST Scanning with both GHAS and Custom post processing scrip… `(PR #67)`
   - sast scans are reported without any issues
-- [Backport 5.6.x] fix(search): fix query parsing bug around quoted phrases #59 `#70`
-- [Backport 5.6.x] fix(batches): fix broken forking workflow `#81`fix(batches): fix broken forking workflow
+- [Backport 5.6.x] fix(search): fix query parsing bug around quoted phrases #59 `(PR #70)`
+- [Backport 5.6.x] fix(batches): fix broken forking workflow `(PR #81)`fix(batches): fix broken forking workflow
   Backport f833c4a3bf2210c127ffbf1146be69e1f461a449 from #48
-- [Backport 5.6.x] svelte: add slash to path scope `#98`
+- [Backport 5.6.x] svelte: add slash to path scope `(PR #98)`
   - Fixes a bug in the new web app that causes incorrect links to be generated for collapsed file names
  Backport 23dad06bb2af1e7eb6a2f3847ad7f2c76c2a89a5 from #95
-- [Backport 5.6.x] feat(cody): add deepseek-coder-v2-lite-base support `#103` Backport f71fe081aa43ca40fef66c067c8eaf49d62d491e from #4
-- backporting #106 `#107`
+- [Backport 5.6.x] feat(cody): add deepseek-coder-v2-lite-base support `(PR #103)` Backport f71fe081aa43ca40fef66c067c8eaf49d62d491e from #4
+- backporting #106 `(PR #107)`
 
 # 5.6 Patch 1
 
@@ -3072,7 +3072,7 @@ convention.
 
 ### Reverts
 
-- Revert "Cody: add support for neovim, cody-cli, eclipse, and visualstudio clients [#0](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/63854)
+- Revert "Cody: add support for neovim, cody-cli, eclipse, and visualstudio clients [#63854](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/63854)
 - Revert "chore(ci): post instructions for PR sections in a comment" [#64176](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/64187)
 
 ### Uncategorized
@@ -4239,7 +4239,7 @@ feature.feat(appliance): deploy codeinsights-dbReady for review, but draft until
 
 ### Reverts
 
-- [0](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/62684) Revert "Svelte [RepoPopover]: Instantiate the RepoPopover result across the web-app
+- [#62684](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/62684) Revert "Svelte [RepoPopover]: Instantiate the RepoPopover result across the web-app
 
 ### Uncategorized
 

--- a/docs/technical-changelog.mdx
+++ b/docs/technical-changelog.mdx
@@ -26,12 +26,12 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 
 #### Database
 
-- remove 5.10 deprecation dates on out of band migrations [#1996](https://github.com/sourcegraph/sourcegraph/pull/1996)
+- remove 5.10 deprecation dates on out of band migrations `#1996`
   - We are removing the deprecation dates on out of band migrations which deprecated in 5.10. This is to unblock MVU and autoupgrades which are encountering a bug with deprecated out of band migrations.  Backport f654dcc9200e2dda2deddc8f98bcd972e6a873fd from #1995
 
 #### Search
 
-- disable zoekt go-git optimization by default [#2051](https://github.com/sourcegraph/sourcegraph/pull/2051)
+- disable zoekt go-git optimization by default `#2051`
   - Disabled an indexed search optimization which would skip files accidentally (`ZOEKT_DISABLE_GOGIT_OPTIMIZATION=true`).  Backport 34ada948bdcee3d75499c98f4db5c32986943e88 from #2050
 
 ### Reverts
@@ -42,7 +42,7 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 
 #### Others
 
-- [Backport 5.10.x] oob: Actually run for all tenants [#1994](https://github.com/sourcegraph/sourcegraph/pull/1994)
+- [Backport 5.10.x] oob: Actually run for all tenants `#1994`
 
 {/* RSS={"version":"v5.10.1164", "releasedAt": "2024-12-03"} */}
 
@@ -71,632 +71,632 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 
 #### Autoedit
 
-- add autoedit model to use chat completions end point [#1809](https://github.com/sourcegraph/sourcegraph/pull/1809)
+- add autoedit model to use chat completions end point `#1809`
 
 #### Ci
 
-- move rules_pkg to MODULE.bazel [#1660](https://github.com/sourcegraph/sourcegraph/pull/1660)
+- move rules_pkg to MODULE.bazel `#1660`
 
 #### Cody
 
-- fix ootb prompt details page [#1902](https://github.com/sourcegraph/sourcegraph/pull/1902)
-- update cody web to 0.14.0 version [#1895](https://github.com/sourcegraph/sourcegraph/pull/1895)
-- add support for out-of-the-box prompts [#1726](https://github.com/sourcegraph/sourcegraph/pull/1726)
-- support openai predicted outputs [#1625](https://github.com/sourcegraph/sourcegraph/pull/1625)
+- fix ootb prompt details page `#1902`
+- update cody web to 0.14.0 version `#1895`
+- add support for out-of-the-box prompts `#1726`
+- support openai predicted outputs `#1625`
   - Cody Gateway: add support for OpeanAI predicted outputs
-- added `systemPreInstruction` (CODY-4032) [#1402](https://github.com/sourcegraph/sourcegraph/pull/1402)
+- added `systemPreInstruction` (CODY-4032) `#1402`
   - adds `systemPreInstruction` to the `modelConfiguration` key in site admin config that allows injecting a prelude prompt into every chat request for an enterprise
 
 #### Cody-Gateway
 
-- add gpt-4o-mini model [#1591](https://github.com/sourcegraph/sourcegraph/pull/1591)
+- add gpt-4o-mini model `#1591`
   - Cody Gateway: add `gpt-4o-mini` to Cody Gateway allow list
   - Cody Gateway: add `gpt-4o-mini` to DotCom models list
 
 #### Conf/Deploy
 
-- add 'workspace' deploy type [#1710](https://github.com/sourcegraph/sourcegraph/pull/1710)
+- add 'workspace' deploy type `#1710`
 
 #### Dev
 
-- use svelte-dev for multi-tenant [#1843](https://github.com/sourcegraph/sourcegraph/pull/1843)
-- add alias 'sg bz cf' for 'sg bz configure' [#1827](https://github.com/sourcegraph/sourcegraph/pull/1827)
-- add '-open=false' option for 'sg sams login' [#1498](https://github.com/sourcegraph/sourcegraph/pull/1498)
-- Adding sg command to request Entitle bundles [#1370](https://github.com/sourcegraph/sourcegraph/pull/1370)
+- use svelte-dev for multi-tenant `#1843`
+- add alias 'sg bz cf' for 'sg bz configure' `#1827`
+- add '-open=false' option for 'sg sams login' `#1498`
+- Adding sg command to request Entitle bundles `#1370`
 
 #### Gateway
 
-- Add `/models.json` endpoint (PRIME-601) [#1728](https://github.com/sourcegraph/sourcegraph/pull/1728)
-- Disable flagged model blocking for enterprise (PRIME-602, PRIME-605) [#1659](https://github.com/sourcegraph/sourcegraph/pull/1659)
+- Add `/models.json` endpoint (PRIME-601) `#1728`
+- Disable flagged model blocking for enterprise (PRIME-602, PRIME-605) `#1659`
 
 #### Github
 
-- add client ID support for GitHub App authentication [#1622](https://github.com/sourcegraph/sourcegraph/pull/1622)
+- add client ID support for GitHub App authentication `#1622`
   - The GitHub app authentication package now supports authenticating a GitHub app via the OAuth client ID following the announcement of [https://github.blog/changelog/2024-05-01-github-apps-can-now-use-the-client-id-to-fetch-installation-tokens/](https://github.blog/changelog/2024-05-01-github-apps-can-now-use-the-client-id-to-fetch-installation-tokens/)
 
 #### Graphql
 
-- add support for reading GitHub App Installation repos from GitHub REST API [#1711](https://github.com/sourcegraph/sourcegraph/pull/1711)
+- add support for reading GitHub App Installation repos from GitHub REST API `#1711`
   - A new GraphQL query, `GithubAppRepositoriesForInstallation`, has been added that provides a paginated list of all the GitHub repositories that are accessible to the GitHub app with the provided installation id.
-- add endpoint for getting github app installations scoped by user [#1606](https://github.com/sourcegraph/sourcegraph/pull/1606)
+- add endpoint for getting github app installations scoped by user `#1606`
   - A new graphql endpoint has been added, GithubAppInstallationsForUser, that returns installation information for the global GitHub multi tenant app when running in multitenant mode.
 
 #### Internal/Github
 
-- add pagination support and test for GetUserInstallations [#1572](https://github.com/sourcegraph/sourcegraph/pull/1572)
+- add pagination support and test for GetUserInstallations `#1572`
   - The Github API client's [GetUserInstallations](https://docs.github.com/en/rest/reference/apps#list-app-installations-accessible-to-the-user-access-token) route, which lists of GitHub App installations the user has access to, now has pagination support.
 
 #### Lib/Cloudapi
 
-- add support for workload identity to auth roundtripper [#1623](https://github.com/sourcegraph/sourcegraph/pull/1623)
+- add support for workload identity to auth roundtripper `#1623`
 
 #### Local
 
-- add bazel mod tidy to `sg bazel configure` step [#1656](https://github.com/sourcegraph/sourcegraph/pull/1656)
+- add bazel mod tidy to `sg bazel configure` step `#1656`
 
 #### Msp
 
-- apply default max DB conns of 8*CPU [#1394](https://github.com/sourcegraph/sourcegraph/pull/1394)
+- apply default max DB conns of 8*CPU `#1394`
 
 #### Msp/Cloudsql
 
-- annotate cloudsql trace spans with target database [#1398](https://github.com/sourcegraph/sourcegraph/pull/1398)
+- annotate cloudsql trace spans with target database `#1398`
 
 #### Mt-Router
 
-- add support for SOAP redirect [#1510](https://github.com/sourcegraph/sourcegraph/pull/1510)
+- add support for SOAP redirect `#1510`
 
 #### Multi-Tenant
 
-- redirect to workspaces/join on user-not-found [#1604](https://github.com/sourcegraph/sourcegraph/pull/1604)
+- redirect to workspaces/join on user-not-found `#1604`
 
 #### Multitenant
 
-- Rework GraphQL resolvers and add back App installation link [#1819](https://github.com/sourcegraph/sourcegraph/pull/1819)
-- Add temporary UI for workspace repository management [#1791](https://github.com/sourcegraph/sourcegraph/pull/1791)
-- add helper routine for instantiating github app from multitenant credentials [#1758](https://github.com/sourcegraph/sourcegraph/pull/1758)
+- Rework GraphQL resolvers and add back App installation link `#1819`
+- Add temporary UI for workspace repository management `#1791`
+- add helper routine for instantiating github app from multitenant credentials `#1758`
   - A simple helper routine to the multitenantenv package that automatically populates a github app struct with the provided validated credentials.
-- use default cookie for github app oauth login [#1571](https://github.com/sourcegraph/sourcegraph/pull/1571)
+- use default cookie for github app oauth login `#1571`
   - The routing logic for multitenant mode now has a new route that uses the "last seen tenant" cookie to route github app login authorization callbacks to the appropriate tenant.
 
 #### Release
 
-- add pg16 and pg16 codeinsights to published images [#1731](https://github.com/sourcegraph/sourcegraph/pull/1731)
+- add pg16 and pg16 codeinsights to published images `#1731`
   - feat(rel): Add Postgresql 16 and Postgresql 16 codeinsights images to published image list.
-- add pg 16 codeinsights entrypoint and tests [#1730](https://github.com/sourcegraph/sourcegraph/pull/1730)
+- add pg 16 codeinsights entrypoint and tests `#1730`
   - feat(rel): Add self updating to Postgres 16 codeinsights db image.
-- add pg 16 entrypoint and tests [#1718](https://github.com/sourcegraph/sourcegraph/pull/1718)
+- add pg 16 entrypoint and tests `#1718`
   - feat(rel): Add self updating to Postgres 16 container image.
-- Add wolfi postgres 16 codeinsights-db base image [#1619](https://github.com/sourcegraph/sourcegraph/pull/1619)
+- Add wolfi postgres 16 codeinsights-db base image `#1619`
   - feat(rel): Add Postgres 16 CodeInsights Wolfi image
-- Add wolfi postgres 16 base image [#1617](https://github.com/sourcegraph/sourcegraph/pull/1617)
+- Add wolfi postgres 16 base image `#1617`
   - feat(rel): Add Postgres 16 Wolfi image
 
 #### Release
 
-- Handle postgres version upgrades in upgrade test [#1918](https://github.com/sourcegraph/sourcegraph/pull/1918)
+- Handle postgres version upgrades in upgrade test `#1918`
   - refactor upgradetest
   - introduce proper handling of the postgres version upgrade
  Backport 9ccdf4200e3e08cea56bffe5779ca8a6cda2909c from #1894
 
 #### Search
 
-- include file paths in reranker items [#1866](https://github.com/sourcegraph/sourcegraph/pull/1866)
+- include file paths in reranker items `#1866`
   - Cody context now incorporates filename information in reranking, improving context quality when the reranker is enabled.
-- (new web ui) Add 'open in code host' button to repo root and folder pages [#1776](https://github.com/sourcegraph/sourcegraph/pull/1776)
-- (new web ui) Copy URL to clipboard when clicking 'Permalink' [#1774](https://github.com/sourcegraph/sourcegraph/pull/1774)
-- (new web ui) Show file/folder name in title instead of full path [#1735](https://github.com/sourcegraph/sourcegraph/pull/1735)
-- (new web ui) Add survey toast [#1453](https://github.com/sourcegraph/sourcegraph/pull/1453)
-- (new web ui) Show loading indicator when navigating up the file tree [#1465](https://github.com/sourcegraph/sourcegraph/pull/1465)
+- (new web ui) Add 'open in code host' button to repo root and folder pages `#1776`
+- (new web ui) Copy URL to clipboard when clicking 'Permalink' `#1774`
+- (new web ui) Show file/folder name in title instead of full path `#1735`
+- (new web ui) Add survey toast `#1453`
+- (new web ui) Show loading indicator when navigating up the file tree `#1465`
 
 #### Sg
 
-- add workspaces common operations [#1845](https://github.com/sourcegraph/sourcegraph/pull/1845)
+- add workspaces common operations `#1845`
   - support `get`, `list`, and `delete` workspaces to `sg`
 
 #### Source
 
-- Allow GitHub code host connections to specify an external account as the authenticator [#1842](https://github.com/sourcegraph/sourcegraph/pull/1842)
-- multitenant: add worker job for inserting github multitenant app credentials [#1668](https://github.com/sourcegraph/sourcegraph/pull/1668)
+- Allow GitHub code host connections to specify an external account as the authenticator `#1842`
+- multitenant: add worker job for inserting github multitenant app credentials `#1668`
   - A new worker job has been added that updates the database with the credentials for the global github app when running in multitenant mode.
 
 #### Telemetry
 
-- Add request client name and version to telemetry gateway payload [#1607](https://github.com/sourcegraph/sourcegraph/pull/1607)
+- Add request client name and version to telemetry gateway payload `#1607`
 
 #### Tenant/Reconciler
 
-- report backpressure when tenants > 0.85*targetMaxTenants [#1719](https://github.com/sourcegraph/sourcegraph/pull/1719)
-- exclude DESTROY_SUCCESS from global reconcile [#1534](https://github.com/sourcegraph/sourcegraph/pull/1534)
+- report backpressure when tenants > 0.85*targetMaxTenants `#1719`
+- exclude DESTROY_SUCCESS from global reconcile `#1534`
 
 #### Workspaces
 
-- check basic email validity to create invite [#1849](https://github.com/sourcegraph/sourcegraph/pull/1849)
-- always set displayName=name if displayName is not set [#1838](https://github.com/sourcegraph/sourcegraph/pull/1838)
-- email all workspace admins when a user joins a workspace [#1824](https://github.com/sourcegraph/sourcegraph/pull/1824)
-- add CheckWorkspaceName RPC [#1822](https://github.com/sourcegraph/sourcegraph/pull/1822)
-- Initial iteration of new creation flow [#1806](https://github.com/sourcegraph/sourcegraph/pull/1806)
-- check billing seats when joining and inviting [#1770](https://github.com/sourcegraph/sourcegraph/pull/1770)
-- always apply DEFAULT_WORKSPACE_INSTANCE_CLASS on workspace create [#1763](https://github.com/sourcegraph/sourcegraph/pull/1763)
-- accept instance class [#1752](https://github.com/sourcegraph/sourcegraph/pull/1752)
-- list eligible-to-join workspaces in UI [#1672](https://github.com/sourcegraph/sourcegraph/pull/1672)
-- explicit invites POC [#1624](https://github.com/sourcegraph/sourcegraph/pull/1624)
-- error-log illegal state transitions for Sentry [#1616](https://github.com/sourcegraph/sourcegraph/pull/1616)
-- list includes workpsaces a user can join via open invite [#1586](https://github.com/sourcegraph/sourcegraph/pull/1586)
-- make membership limits configurable [#1584](https://github.com/sourcegraph/sourcegraph/pull/1584)
-- name, display name, and open invite email domain blocklists [#1539](https://github.com/sourcegraph/sourcegraph/pull/1539)
-- free up assigned workspace slot when workspace is DESTROY_SUCCESS [#1535](https://github.com/sourcegraph/sourcegraph/pull/1535)
-- prevent management API from reading workspaces in deletion state [#1508](https://github.com/sourcegraph/sourcegraph/pull/1508)
-- prune iam store on deletion [#1504](https://github.com/sourcegraph/sourcegraph/pull/1504)
-- implement router pruning, add 'pruned_router_at', 'pruned_iam_at' [#1480](https://github.com/sourcegraph/sourcegraph/pull/1480)
-- delete and reconcile routes [#1440](https://github.com/sourcegraph/sourcegraph/pull/1440)
+- check basic email validity to create invite `#1849`
+- always set displayName=name if displayName is not set `#1838`
+- email all workspace admins when a user joins a workspace `#1824`
+- add CheckWorkspaceName RPC `#1822`
+- Initial iteration of new creation flow `#1806`
+- check billing seats when joining and inviting `#1770`
+- always apply DEFAULT_WORKSPACE_INSTANCE_CLASS on workspace create `#1763`
+- accept instance class `#1752`
+- list eligible-to-join workspaces in UI `#1672`
+- explicit invites POC `#1624`
+- error-log illegal state transitions for Sentry `#1616`
+- list includes workpsaces a user can join via open invite `#1586`
+- make membership limits configurable `#1584`
+- name, display name, and open invite email domain blocklists `#1539`
+- free up assigned workspace slot when workspace is DESTROY_SUCCESS `#1535`
+- prevent management API from reading workspaces in deletion state `#1508`
+- prune iam store on deletion `#1504`
+- implement router pruning, add 'pruned_router_at', 'pruned_iam_at' `#1480`
+- delete and reconcile routes `#1440`
 
 #### Workspaces/Blocklists
 
-- improve heuristics and errors [#1801](https://github.com/sourcegraph/sourcegraph/pull/1801)
+- improve heuristics and errors `#1801`
 
 #### Workspaces/Instances
 
-- add UNAVAILABLE, CAPACITY_PRESSURE states [#1712](https://github.com/sourcegraph/sourcegraph/pull/1712)
+- add UNAVAILABLE, CAPACITY_PRESSURE states `#1712`
 
 #### Workspaces/Integrations
 
-- provide workspace uri [#1477](https://github.com/sourcegraph/sourcegraph/pull/1477)
+- provide workspace uri `#1477`
 
 #### Workspaces/Web
 
-- as-you-type name validation POC [#1858](https://github.com/sourcegraph/sourcegraph/pull/1858)
+- as-you-type name validation POC `#1858`
 
 #### Others
 
-- switch to buildkite for nightly release pipeline [#1690](https://github.com/sourcegraph/sourcegraph/pull/1690)
+- switch to buildkite for nightly release pipeline `#1690`
   - N/A
-- add new telemetry v2 events for server side batch changes [#1666](https://github.com/sourcegraph/sourcegraph/pull/1666)
-- add events for interactions with search input toggle buttons [#1469](https://github.com/sourcegraph/sourcegraph/pull/1469)
-- add events for codenav actions [#1441](https://github.com/sourcegraph/sourcegraph/pull/1441)
-- make filters sidebar collapsible [#1437](https://github.com/sourcegraph/sourcegraph/pull/1437)
+- add new telemetry v2 events for server side batch changes `#1666`
+- add events for interactions with search input toggle buttons `#1469`
+- add events for codenav actions `#1441`
+- make filters sidebar collapsible `#1437`
   - Search filters sidebar is now collapsible
-- add dynamic filters and aggregation for repo metadata and topics [#1420](https://github.com/sourcegraph/sourcegraph/pull/1420)
+- add dynamic filters and aggregation for repo metadata and topics `#1420`
   - Added dynamic filters and the ability to aggregate by repo metadata and repo topic
-- render mdx as markdown [#1392](https://github.com/sourcegraph/sourcegraph/pull/1392)
+- render mdx as markdown `#1392`
   - Render .mdx files as markdown
 
 ### Fix
 
 #### Batch Changes
 
-- titles now break over multiple lines if they are too long [#1582](https://github.com/sourcegraph/sourcegraph/pull/1582)
+- titles now break over multiple lines if they are too long `#1582`
   - fix(batches): titles now break over multiple lines if they are too long
-- do not ignore bool env var parsing error [#1537](https://github.com/sourcegraph/sourcegraph/pull/1537)
+- do not ignore bool env var parsing error `#1537`
 
 #### Client
 
-- address pnpm lint:js:web issues and add job in CI [#1520](https://github.com/sourcegraph/sourcegraph/pull/1520)
+- address pnpm lint:js:web issues and add job in CI `#1520`
 
 #### Code Intelligence
 
-- Align repo batch settings between syntactic and precise indexing [#1663](https://github.com/sourcegraph/sourcegraph/pull/1663)
-- Fix wrong offset in policy iteration [#1546](https://github.com/sourcegraph/sourcegraph/pull/1546)
+- Align repo batch settings between syntactic and precise indexing `#1663`
+- Fix wrong offset in policy iteration `#1546`
 
 #### Cody
 
-- use models from model config for PLG chat [#1870](https://github.com/sourcegraph/sourcegraph/pull/1870)
-- sync allowed models in dotcom user rate limits with models.json [#1864](https://github.com/sourcegraph/sourcegraph/pull/1864)
+- use models from model config for PLG chat `#1870`
+- sync allowed models in dotcom user rate limits with models.json `#1864`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
-- filter allowed models based on subscription tier [#1636](https://github.com/sourcegraph/sourcegraph/pull/1636)
+- filter allowed models based on subscription tier `#1636`
 
 #### Database
 
-- drop unique slug contraint from github app table [#1689](https://github.com/sourcegraph/sourcegraph/pull/1689)
+- drop unique slug contraint from github app table `#1689`
   - The github_apps table has removed an erroneous unique constraint that accidentally incorporated an app's slug (which is mutable) as part of the unique identifier for an app.
 
 #### Database
 
-- update generated squash and schemas [#1917](https://github.com/sourcegraph/sourcegraph/pull/1917)
+- update generated squash and schemas `#1917`
 
 #### Dev
 
-- fix kill pubsubemulator [#1850](https://github.com/sourcegraph/sourcegraph/pull/1850)
-- correctly pick up error message from 'sg sams login' [#1482](https://github.com/sourcegraph/sourcegraph/pull/1482)
+- fix kill pubsubemulator `#1850`
+- correctly pick up error message from 'sg sams login' `#1482`
 
 #### Enterpriseportal
 
-- allow list to accept display name query of 2 characters [#1603](https://github.com/sourcegraph/sourcegraph/pull/1603)
+- allow list to accept display name query of 2 characters `#1603`
 
 #### Gateway
 
-- add blocked phrase if request was blocked due to flagged models list (PRIME-603) [#1670](https://github.com/sourcegraph/sourcegraph/pull/1670)
-- Make model cost a pointer (CODY-4007) [#1427](https://github.com/sourcegraph/sourcegraph/pull/1427)
+- add blocked phrase if request was blocked due to flagged models list (PRIME-603) `#1670`
+- Make model cost a pointer (CODY-4007) `#1427`
 
 #### Graphql
 
-- refactor getGithubAppFromEnvvar to use multitenantEnv.Config.AsGithubApp [#1767](https://github.com/sourcegraph/sourcegraph/pull/1767)
+- refactor getGithubAppFromEnvvar to use multitenantEnv.Config.AsGithubApp `#1767`
   - The logic in the new multitenant GraphQL resolvers has been reworked to use the new helper methods introduced in the Multitenant GitHub app configuration logic introduced in [https://app.graphite.dev/github/pr/sourcegraph/sourcegraph/1758/](https://app.graphite.dev/github/pr/sourcegraph/sourcegraph/1758/).
 
 #### Insights
 
-- Fix incorrect line counts in non-default config [#1517](https://github.com/sourcegraph/sourcegraph/pull/1517)
+- Fix incorrect line counts in non-default config `#1517`
   - Code insights should show correct line counts when enhanced language detection is turned off (note: this setting is on by default).
 
 #### Local
 
-- display external env overrides when displaying environment variables [#1595](https://github.com/sourcegraph/sourcegraph/pull/1595)
-- sg - fix images query to point to correct rule [#1430](https://github.com/sourcegraph/sourcegraph/pull/1430)
+- display external env overrides when displaying environment variables `#1595`
+- sg - fix images query to point to correct rule `#1430`
 
 #### Release
 
-- fix oob migrations hanging [#1959](https://github.com/sourcegraph/sourcegraph/pull/1959)
+- fix oob migrations hanging `#1959`
   - NA
   Backport a943412a99852332f921b52a0ee3179dc3331d20 from #1958
-- add vacuum after reindex in Postgres upgrade script [#1779](https://github.com/sourcegraph/sourcegraph/pull/1779)
+- add vacuum after reindex in Postgres upgrade script `#1779`
   - fix(rel): Add vacuum to Postgres upgrade process
-- install `sg` in the nightly pipeline GHA [#1675](https://github.com/sourcegraph/sourcegraph/pull/1675)
+- install `sg` in the nightly pipeline GHA `#1675`
   - N/A
 
 #### Release
 
-- correct views drift in postgres 16 [#1878](https://github.com/sourcegraph/sourcegraph/pull/1878)
+- correct views drift in postgres 16 `#1878`
   - add migrations to handle database drift caused during postgres 12 to postgres 16 upgrade
-- fix drift check in local upgradetest [#1832](https://github.com/sourcegraph/sourcegraph/pull/1832)
+- fix drift check in local upgradetest `#1832`
   - Fix bug in local upgrade test preventing final stage drift check via private monorepo
 
 #### Search
 
-- consistently marshal SearchTypeRegex as regexp [#1919](https://github.com/sourcegraph/sourcegraph/pull/1919)
+- consistently marshal SearchTypeRegex as regexp `#1919`
   - We sometimes would emit `patternType:regex` instead of `patternType:regexp`. We now always do regexp as well as treating regex as an alias for regexp.
   Backport a095b39ac39cfcbe3526ecf85ed6d50cb5fa3d9d from #1808
-- Executors on Kubernetes: propagate user and group from Executor env vars to batch change job pod [#1863](https://github.com/sourcegraph/sourcegraph/pull/1863)
+- Executors on Kubernetes: propagate user and group from Executor env vars to batch change job pod `#1863`
   - The environment variables `KUBERNETES_RUN_AS_USER` and `KUBERNETES_RUN_AS_GROUP` contribute to the Job `PodSpec`'s `SecurityContext`.
   - The default value for those variables is `-1`, which could cause errors with some Kubernetes clusters.
-- (new web app) Only update user activity data once on load [#1797](https://github.com/sourcegraph/sourcegraph/pull/1797)
-- (new web ui) Respect 'window.context.disableFeedbackSurvey' flag [#1778](https://github.com/sourcegraph/sourcegraph/pull/1778)
-- (search input) Treat not, and, or as keywords regardless of case [#1733](https://github.com/sourcegraph/sourcegraph/pull/1733)
-- (new web ui) Fix dimensions of line selection marker [#1417](https://github.com/sourcegraph/sourcegraph/pull/1417)
-- (new web ui) Add rollover effect to RadioButtonGroup [#1416](https://github.com/sourcegraph/sourcegraph/pull/1416)
-- (new web ui) Fix duplicate lint suggestion insertion [#1413](https://github.com/sourcegraph/sourcegraph/pull/1413)
-- (new web ui) Remove unintentional vertical scrollbars [#1411](https://github.com/sourcegraph/sourcegraph/pull/1411)
-- (new web ui) Only show specific repo menu items when features are enabled [#1401](https://github.com/sourcegraph/sourcegraph/pull/1401)
+- (new web app) Only update user activity data once on load `#1797`
+- (new web ui) Respect 'window.context.disableFeedbackSurvey' flag `#1778`
+- (search input) Treat not, and, or as keywords regardless of case `#1733`
+- (new web ui) Fix dimensions of line selection marker `#1417`
+- (new web ui) Add rollover effect to RadioButtonGroup `#1416`
+- (new web ui) Fix duplicate lint suggestion insertion `#1413`
+- (new web ui) Remove unintentional vertical scrollbars `#1411`
+- (new web ui) Only show specific repo menu items when features are enabled `#1401`
 
 #### Security
 
-- Do not expand env vars in executor logs [#1811](https://github.com/sourcegraph/sourcegraph/pull/1811)
+- Do not expand env vars in executor logs `#1811`
   - This change reduces the risk of secrets being emitted in executor logs even if there are bugs in the secret redaction logic.
 
 #### Sg
 
-- remove noop -d declaration for psql [#1455](https://github.com/sourcegraph/sourcegraph/pull/1455)
-- specify postgres database for psql commands [#1450](https://github.com/sourcegraph/sourcegraph/pull/1450)
+- remove noop -d declaration for psql `#1455`
+- specify postgres database for psql commands `#1450`
 
 #### Source
 
-- p4-fusion now decodes encode file paths from Perforce [#1347](https://github.com/sourcegraph/sourcegraph/pull/1347)
+- p4-fusion now decodes encode file paths from Perforce `#1347`
   - When cloning Perforce depots, Sourcegraph will now decode encoded paths correctly (paths that include characters like `@` and `#`)
 
 #### Tenant/Reconciler
 
-- do not check dormancy if still in PROVISION states, only check if needed [#1605](https://github.com/sourcegraph/sourcegraph/pull/1605)
-- on getTenantErr, report destroy state if in destroy state [#1563](https://github.com/sourcegraph/sourcegraph/pull/1563)
+- do not check dormancy if still in PROVISION states, only check if needed `#1605`
+- on getTenantErr, report destroy state if in destroy state `#1563`
 
 #### Workspaces
 
-- properly represent workspace state to management API [#1816](https://github.com/sourcegraph/sourcegraph/pull/1816)
-- fix DESTROY_PENDING proto adapter, improve handling of unknown states [#1814](https://github.com/sourcegraph/sourcegraph/pull/1814)
-- improve CreateWorkspace resilience [#1773](https://github.com/sourcegraph/sourcegraph/pull/1773)
-- remove broken down-migration statements [#1754](https://github.com/sourcegraph/sourcegraph/pull/1754)
-- support creating workspaces over API [#1714](https://github.com/sourcegraph/sourcegraph/pull/1714)
-- do not list all workspaces if user has no memberships [#1671](https://github.com/sourcegraph/sourcegraph/pull/1671)
-- tidy up email-disabled error log [#1667](https://github.com/sourcegraph/sourcegraph/pull/1667)
+- properly represent workspace state to management API `#1816`
+- fix DESTROY_PENDING proto adapter, improve handling of unknown states `#1814`
+- improve CreateWorkspace resilience `#1773`
+- remove broken down-migration statements `#1754`
+- support creating workspaces over API `#1714`
+- do not list all workspaces if user has no memberships `#1671`
+- tidy up email-disabled error log `#1667`
 
 #### Workspacesreconciler
 
-- fix double-counting of checked workspaces [#1753](https://github.com/sourcegraph/sourcegraph/pull/1753)
+- fix double-counting of checked workspaces `#1753`
 
 #### Others
 
-- Prompt page tweaks [#1899](https://github.com/sourcegraph/sourcegraph/pull/1899)
-- revision picker growth [#1875](https://github.com/sourcegraph/sourcegraph/pull/1875)
-- more contrast updates [#1871](https://github.com/sourcegraph/sourcegraph/pull/1871)
-- Reranker: recreate from config on every call [#1865](https://github.com/sourcegraph/sourcegraph/pull/1865)
-- prompt library visual updates [#1852](https://github.com/sourcegraph/sourcegraph/pull/1852)
-- Use standard protojson library for reducing memory [#1846](https://github.com/sourcegraph/sourcegraph/pull/1846)
-- Increase contrast everywhere [#1840](https://github.com/sourcegraph/sourcegraph/pull/1840)
-- make owner nullable in prompts [#1746](https://github.com/sourcegraph/sourcegraph/pull/1746)
-- only retry queries [#1706](https://github.com/sourcegraph/sourcegraph/pull/1706)
-- Reranker: listen to config changes, do not mutate config [#1705](https://github.com/sourcegraph/sourcegraph/pull/1705)
-- retry graphql on 502 errors [#1683](https://github.com/sourcegraph/sourcegraph/pull/1683)
+- Prompt page tweaks `#1899`
+- revision picker growth `#1875`
+- more contrast updates `#1871`
+- Reranker: recreate from config on every call `#1865`
+- prompt library visual updates `#1852`
+- Use standard protojson library for reducing memory `#1846`
+- Increase contrast everywhere `#1840`
+- make owner nullable in prompts `#1746`
+- only retry queries `#1706`
+- Reranker: listen to config changes, do not mutate config `#1705`
+- retry graphql on 502 errors `#1683`
   - fix(web): retry graphql requests on network errors
-- styling changes to explore panel and badges [#1528](https://github.com/sourcegraph/sourcegraph/pull/1528)
-- increase contrast of highlighted code background and line numbers in selected area [#508](https://github.com/sourcegraph/sourcegraph/pull/508)
+- styling changes to explore panel and badges `#1528`
+- increase contrast of highlighted code background and line numbers in selected area `#508`
 
 ### Chore
 
 #### Ci
 
-- container structure test bzlmod migration [#1818](https://github.com/sourcegraph/sourcegraph/pull/1818)
-- migrate protobuf and rules_proto rules to bzlmod [#1749](https://github.com/sourcegraph/sourcegraph/pull/1749)
-- move buildifier prebuilt to bzlmod [#1709](https://github.com/sourcegraph/sourcegraph/pull/1709)
-- increase buildifier timeout to 6m [#1658](https://github.com/sourcegraph/sourcegraph/pull/1658)
-- move bazel_skylib to bzlmod [#1654](https://github.com/sourcegraph/sourcegraph/pull/1654)
-- bazel - remove build_tests_only flag for db tests [#1610](https://github.com/sourcegraph/sourcegraph/pull/1610)
-- bazel - add config settings to switch between pg-12 and pg-16 binaries [#1601](https://github.com/sourcegraph/sourcegraph/pull/1601)
-- refactor bazel migrations [#1583](https://github.com/sourcegraph/sourcegraph/pull/1583)
-- update github workflow for pg-12 and pg-16 package variants [#1580](https://github.com/sourcegraph/sourcegraph/pull/1580)
-- upgrade aspect bazel lib [#1425](https://github.com/sourcegraph/sourcegraph/pull/1425)
-- Upgrade to latest rules proto grpc [#1424](https://github.com/sourcegraph/sourcegraph/pull/1424)
-- enable db tests task to run on ci agents with postgres 16 [#1293](https://github.com/sourcegraph/sourcegraph/pull/1293)
-- upgrade rules_pkg [#976](https://github.com/sourcegraph/sourcegraph/pull/976)
-- upgrade aspect cli [#975](https://github.com/sourcegraph/sourcegraph/pull/975)
+- container structure test bzlmod migration `#1818`
+- migrate protobuf and rules_proto rules to bzlmod `#1749`
+- move buildifier prebuilt to bzlmod `#1709`
+- increase buildifier timeout to 6m `#1658`
+- move bazel_skylib to bzlmod `#1654`
+- bazel - remove build_tests_only flag for db tests `#1610`
+- bazel - add config settings to switch between pg-12 and pg-16 binaries `#1601`
+- refactor bazel migrations `#1583`
+- update github workflow for pg-12 and pg-16 package variants `#1580`
+- upgrade aspect bazel lib `#1425`
+- Upgrade to latest rules proto grpc `#1424`
+- enable db tests task to run on ci agents with postgres 16 `#1293`
+- upgrade rules_pkg `#976`
+- upgrade aspect cli `#975`
 
 #### Code Intelligence
 
-- Remove unused return value & pass TraceLogger [#1551](https://github.com/sourcegraph/sourcegraph/pull/1551)
-- Enable exhaustruct for more subfolders (part 2) [#1547](https://github.com/sourcegraph/sourcegraph/pull/1547)
-- Document why RepositoryID field is nil [#1545](https://github.com/sourcegraph/sourcegraph/pull/1545)
-- Add helper types for relationships [#1542](https://github.com/sourcegraph/sourcegraph/pull/1542)
+- Remove unused return value & pass TraceLogger `#1551`
+- Enable exhaustruct for more subfolders (part 2) `#1547`
+- Document why RepositoryID field is nil `#1545`
+- Add helper types for relationships `#1542`
 
 #### Dev
 
-- Delete tracking-issue package [#1556](https://github.com/sourcegraph/sourcegraph/pull/1556)
-- Add iterator helper for pagination [#1555](https://github.com/sourcegraph/sourcegraph/pull/1555)
-- Fix links to sg monorepo in Markdown [#1554](https://github.com/sourcegraph/sourcegraph/pull/1554)
-- Add more helper functions to iterext [#1549](https://github.com/sourcegraph/sourcegraph/pull/1549)
-- Enable exhaustruct for more subfolders [#1544](https://github.com/sourcegraph/sourcegraph/pull/1544)
-- Add helper package for property-based testing [#1540](https://github.com/sourcegraph/sourcegraph/pull/1540)
-- Introduce helper package for iter.Seq [#1522](https://github.com/sourcegraph/sourcegraph/pull/1522)
-- Fix links to sg monorepo [#1519](https://github.com/sourcegraph/sourcegraph/pull/1519)
-- Simplify language detection code in inventory [#1518](https://github.com/sourcegraph/sourcegraph/pull/1518)
-- Flip polarity of boolean for language detection [#1516](https://github.com/sourcegraph/sourcegraph/pull/1516)
-- Use a lazyFile type to consolidate lazy file content fetching [#1515](https://github.com/sourcegraph/sourcegraph/pull/1515)
-- Rename functions for clarity [#1514](https://github.com/sourcegraph/sourcegraph/pull/1514)
-- Remove direct usages of enry.IsVendor [#1513](https://github.com/sourcegraph/sourcegraph/pull/1513)
-- Simplify sorting logic [#1512](https://github.com/sourcegraph/sourcegraph/pull/1512)
-- Rename type Lang -> LanguageStats [#1511](https://github.com/sourcegraph/sourcegraph/pull/1511)
-- Migrate from sync.WaitGroup to conc APIs [#1495](https://github.com/sourcegraph/sourcegraph/pull/1495)
-- Fix warning about missing integrity field [#1494](https://github.com/sourcegraph/sourcegraph/pull/1494)
-- Update for loops for newer syntax [#1488](https://github.com/sourcegraph/sourcegraph/pull/1488)
-- Factor out offset & limit logic [#1486](https://github.com/sourcegraph/sourcegraph/pull/1486)
-- Switch to alternate orderedmap library [#1414](https://github.com/sourcegraph/sourcegraph/pull/1414)
-- Clarify docs & naming in debugserver code [#1384](https://github.com/sourcegraph/sourcegraph/pull/1384)
+- Delete tracking-issue package `#1556`
+- Add iterator helper for pagination `#1555`
+- Fix links to sg monorepo in Markdown `#1554`
+- Add more helper functions to iterext `#1549`
+- Enable exhaustruct for more subfolders `#1544`
+- Add helper package for property-based testing `#1540`
+- Introduce helper package for iter.Seq `#1522`
+- Fix links to sg monorepo `#1519`
+- Simplify language detection code in inventory `#1518`
+- Flip polarity of boolean for language detection `#1516`
+- Use a lazyFile type to consolidate lazy file content fetching `#1515`
+- Rename functions for clarity `#1514`
+- Remove direct usages of enry.IsVendor `#1513`
+- Simplify sorting logic `#1512`
+- Rename type Lang -> LanguageStats `#1511`
+- Migrate from sync.WaitGroup to conc APIs `#1495`
+- Fix warning about missing integrity field `#1494`
+- Update for loops for newer syntax `#1488`
+- Factor out offset & limit logic `#1486`
+- Switch to alternate orderedmap library `#1414`
+- Clarify docs & naming in debugserver code `#1384`
 
 #### Dev/Mt-Router
 
-- silence cache miss on default [#1565](https://github.com/sourcegraph/sourcegraph/pull/1565)
+- silence cache miss on default `#1565`
 
 #### Dotcom
 
-- rename 'cody services' to just 'cody gateway' [#1466](https://github.com/sourcegraph/sourcegraph/pull/1466)
+- rename 'cody services' to just 'cody gateway' `#1466`
 
 #### Frontend
 
-- Store model config in global var [#1805](https://github.com/sourcegraph/sourcegraph/pull/1805)
+- Store model config in global var `#1805`
 
 #### Gateway
 
-- A few small docs fixes [#1751](https://github.com/sourcegraph/sourcegraph/pull/1751)
-- Make provider type more specific [#1750](https://github.com/sourcegraph/sourcegraph/pull/1750)
+- A few small docs fixes `#1751`
+- Make provider type more specific `#1750`
 
 #### Local
 
-- small improvements to sg entitle [#1794](https://github.com/sourcegraph/sourcegraph/pull/1794)
+- small improvements to sg entitle `#1794`
 
 #### Msp/Iam
 
-- suggest standard IAM_MAX_DB_CONNS as env var [#1499](https://github.com/sourcegraph/sourcegraph/pull/1499)
+- suggest standard IAM_MAX_DB_CONNS as env var `#1499`
 
 #### Release
 
-- remove postgres-12 wolfi from published images [#1737](https://github.com/sourcegraph/sourcegraph/pull/1737)
+- remove postgres-12 wolfi from published images `#1737`
   - chore(rel): remove unused Postgres 12 images
-- remove appliance from published images and codebase [#1732](https://github.com/sourcegraph/sourcegraph/pull/1732)
+- remove appliance from published images and codebase `#1732`
   - chore(rel): remove appliance from published images
 
 #### Release
 
-- remove check against latest full version in `--post-release-version` code path [#1585](https://github.com/sourcegraph/sourcegraph/pull/1585)
+- remove check against latest full version in `--post-release-version` code path `#1585`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 
 #### Search
 
-- (new web ui) Improve search home page SG logo rendering [#1813](https://github.com/sourcegraph/sourcegraph/pull/1813)
-- add NodeJS 20 to the Bundled Executor image [#1569](https://github.com/sourcegraph/sourcegraph/pull/1569)
-- Update search web app title and description for SEO on dotcom [#1509](https://github.com/sourcegraph/sourcegraph/pull/1509)
-- Add JDK 17 and 21 to the Bundled Executor image [#1502](https://github.com/sourcegraph/sourcegraph/pull/1502)
-- (new web ui) Remove beta badge from search progress popover [#1418](https://github.com/sourcegraph/sourcegraph/pull/1418)
-- update CPU and MEM panels for zoekt [#1368](https://github.com/sourcegraph/sourcegraph/pull/1368)
+- (new web ui) Improve search home page SG logo rendering `#1813`
+- add NodeJS 20 to the Bundled Executor image `#1569`
+- Update search web app title and description for SEO on dotcom `#1509`
+- Add JDK 17 and 21 to the Bundled Executor image `#1502`
+- (new web ui) Remove beta badge from search progress popover `#1418`
+- update CPU and MEM panels for zoekt `#1368`
   - We have updated the CPU and MEM monitoring panels for Zoekt on Grafana. The new panels reduce redundancy and provide more insight into MEM distribution.
 
 #### Source
 
-- simplify oauth middleware [#1876](https://github.com/sourcegraph/sourcegraph/pull/1876)
-- Update the gitserver image lockfile to contain the latest p4-fusion [#1410](https://github.com/sourcegraph/sourcegraph/pull/1410)
-- Default perforce changelist mapping to enabled [#1376](https://github.com/sourcegraph/sourcegraph/pull/1376)
+- simplify oauth middleware `#1876`
+- Update the gitserver image lockfile to contain the latest p4-fusion `#1410`
+- Default perforce changelist mapping to enabled `#1376`
 
 #### Telemetry
 
-- align billing metadata values with 'sourcegraph/cody' [#1396](https://github.com/sourcegraph/sourcegraph/pull/1396)
+- align billing metadata values with 'sourcegraph/cody' `#1396`
 
 #### Telemetry/Geolocation
 
-- update DB-IP Lite database [#1468](https://github.com/sourcegraph/sourcegraph/pull/1468)
+- update DB-IP Lite database `#1468`
   - The local geolocation inference database used in telemetry and audit logs has been updated.
 
 #### Telemetrygateway
 
-- bump slow-request threshold [#1647](https://github.com/sourcegraph/sourcegraph/pull/1647)
+- bump slow-request threshold `#1647`
 
 #### Tenant/Reconciler
 
-- add some additional diagnostics [#1795](https://github.com/sourcegraph/sourcegraph/pull/1795)
+- add some additional diagnostics `#1795`
 
 #### Workspaces
 
-- include longer s&p500 names for fuzzy matching [#1844](https://github.com/sourcegraph/sourcegraph/pull/1844)
-- make unexpected errors more friendly [#1821](https://github.com/sourcegraph/sourcegraph/pull/1821)
-- add spans on write interactions [#1807](https://github.com/sourcegraph/sourcegraph/pull/1807)
-- instantiate large blocklists once in store [#1562](https://github.com/sourcegraph/sourcegraph/pull/1562)
+- include longer s&p500 names for fuzzy matching `#1844`
+- make unexpected errors more friendly `#1821`
+- add spans on write interactions `#1807`
+- instantiate large blocklists once in store `#1562`
 
 #### Workspaces/Web
 
-- use unified client constructor [#1828](https://github.com/sourcegraph/sourcegraph/pull/1828)
+- use unified client constructor `#1828`
 
 #### Others
 
-- Rename method to indicate lack of redaction clearly [#1790](https://github.com/sourcegraph/sourcegraph/pull/1790)
-- Reorder fields in executor Config [#1785](https://github.com/sourcegraph/sourcegraph/pull/1785)
-- Remove custom Set type [#1742](https://github.com/sourcegraph/sourcegraph/pull/1742)
-- Rename Set.Values() -> ValuesNonDet() for clarity [#1741](https://github.com/sourcegraph/sourcegraph/pull/1741)
-- Avoid materializing Set Values() just for length [#1739](https://github.com/sourcegraph/sourcegraph/pull/1739)
-- Add env var to disable precise & syntactic [#1707](https://github.com/sourcegraph/sourcegraph/pull/1707)
-- Bump autoindexing image SHAs [#1703](https://github.com/sourcegraph/sourcegraph/pull/1703)
-- Move CodyGatewayRateLimit calculation to where it's used [#1693](https://github.com/sourcegraph/sourcegraph/pull/1693)
-- remove env lock mechanism [#1593](https://github.com/sourcegraph/sourcegraph/pull/1593)
+- Rename method to indicate lack of redaction clearly `#1790`
+- Reorder fields in executor Config `#1785`
+- Remove custom Set type `#1742`
+- Rename Set.Values() -> ValuesNonDet() for clarity `#1741`
+- Avoid materializing Set Values() just for length `#1739`
+- Add env var to disable precise & syntactic `#1707`
+- Bump autoindexing image SHAs `#1703`
+- Move CodyGatewayRateLimit calculation to where it's used `#1693`
+- remove env lock mechanism `#1593`
   - fix(dev): remove env.Get lock that could cause a runtime panic
-- update event names [#1500](https://github.com/sourcegraph/sourcegraph/pull/1500)
-- remove robert from many CODENOTIFYs [#1421](https://github.com/sourcegraph/sourcegraph/pull/1421)
-- update new search events to make them easier to use [#1395](https://github.com/sourcegraph/sourcegraph/pull/1395)
+- update event names `#1500`
+- remove robert from many CODENOTIFYs `#1421`
+- update new search events to make them easier to use `#1395`
 
 ### Refactor
 
 #### Local
 
-- move reset-pg to internal/db [#1573](https://github.com/sourcegraph/sourcegraph/pull/1573)
+- move reset-pg to internal/db `#1573`
 
 ### Reverts
 
-- Revert "chore/dev: upgrade aspect_bazel_lib to 2.9.4 (#1713)" [#1713](https://github.com/sourcegraph/sourcegraph/pull/1724)
+- Revert "chore/dev: upgrade aspect_bazel_lib to 2.9.4 (#1713)" `#1713`
 
 ### Uncategorized
 
 #### Others
 
-- [Backport 5.10.x] Revert "chore(source): simplify oauth middleware" [#1928](https://github.com/sourcegraph/sourcegraph/pull/1928)
-- githubapp: Expose monolith GitHub app ClientID [#1904](https://github.com/sourcegraph/sourcegraph/pull/1904)
-- pnpm: Remove leftover appliance links in workspace [#1900](https://github.com/sourcegraph/sourcegraph/pull/1900)
-- core: Fixup pnpm lockfile [#1886](https://github.com/sourcegraph/sourcegraph/pull/1886)
-- tenant: Hide unlink button for SAMS external accounts [#1885](https://github.com/sourcegraph/sourcegraph/pull/1885)
-- auth: Hide unlink button for external accounts that cannot be unlinked [#1884](https://github.com/sourcegraph/sourcegraph/pull/1884)
-- svelte: Correctly hide navbar entries [#1883](https://github.com/sourcegraph/sourcegraph/pull/1883)
-- svelte: Add back settings link [#1882](https://github.com/sourcegraph/sourcegraph/pull/1882)
-- workspaces/billing: attach metadata and context without cancel whenever possible [#1881](https://github.com/sourcegraph/sourcegraph/pull/1881)
-- web: respect `expanded` in the search results URL [#1880](https://github.com/sourcegraph/sourcegraph/pull/1880)
+- [Backport 5.10.x] Revert "chore(source): simplify oauth middleware" `#1928`
+- githubapp: Expose monolith GitHub app ClientID `#1904`
+- pnpm: Remove leftover appliance links in workspace `#1900`
+- core: Fixup pnpm lockfile `#1886`
+- tenant: Hide unlink button for SAMS external accounts `#1885`
+- auth: Hide unlink button for external accounts that cannot be unlinked `#1884`
+- svelte: Correctly hide navbar entries `#1883`
+- svelte: Add back settings link `#1882`
+- workspaces/billing: attach metadata and context without cancel whenever possible `#1881`
+- web: respect `expanded` in the search results URL `#1880`
   - Fixed an issue where searches from saved URLs may now show aggregations by default
-- add timeout to gateway calls [#1879](https://github.com/sourcegraph/sourcegraph/pull/1879)
-- workspaces: Align styling for join page [#1860](https://github.com/sourcegraph/sourcegraph/pull/1860)
-- workspaces: Add tables for listing workspaces [#1857](https://github.com/sourcegraph/sourcegraph/pull/1857)
+- add timeout to gateway calls `#1879`
+- workspaces: Align styling for join page `#1860`
+- workspaces: Add tables for listing workspaces `#1857`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
-- workspaces: Slightly tweak style [#1851](https://github.com/sourcegraph/sourcegraph/pull/1851)
-- workspaces: Directly link to installation target [#1848](https://github.com/sourcegraph/sourcegraph/pull/1848)
-- tenant: Suppress some irrelevant missing_context pprof traces [#1847](https://github.com/sourcegraph/sourcegraph/pull/1847)
-- Workspaces: Fix workspace picker rendering in React [#1841](https://github.com/sourcegraph/sourcegraph/pull/1841)
+- workspaces: Slightly tweak style `#1851`
+- workspaces: Directly link to installation target `#1848`
+- tenant: Suppress some irrelevant missing_context pprof traces `#1847`
+- Workspaces: Fix workspace picker rendering in React `#1841`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
-- fix permissions connection resolver ordering [#1839](https://github.com/sourcegraph/sourcegraph/pull/1839)
-- workspaces: Add seat selector on plan page [#1835](https://github.com/sourcegraph/sourcegraph/pull/1835)
-- workspaces/billing: create RPC for purchasing seats [#1831](https://github.com/sourcegraph/sourcegraph/pull/1831)
-- workspaces/billing: extract subscription attribute computation into a `Plan` helper [#1830](https://github.com/sourcegraph/sourcegraph/pull/1830)
-- workspaces: Add updated workspace pickers for tenant [#1829](https://github.com/sourcegraph/sourcegraph/pull/1829)
+- fix permissions connection resolver ordering `#1839`
+- workspaces: Add seat selector on plan page `#1835`
+- workspaces/billing: create RPC for purchasing seats `#1831`
+- workspaces/billing: extract subscription attribute computation into a `Plan` helper `#1830`
+- workspaces: Add updated workspace pickers for tenant `#1829`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
-- workspaces: Add field to pre-purchase extra seats [#1826](https://github.com/sourcegraph/sourcegraph/pull/1826)
-- workspaces/billing: implement periodic workers for subscription renewal [#1823](https://github.com/sourcegraph/sourcegraph/pull/1823)
-- auth: Fix background contexts in validate authz provider [#1802](https://github.com/sourcegraph/sourcegraph/pull/1802)
-- redispool: support more configuration options [#1799](https://github.com/sourcegraph/sourcegraph/pull/1799)
-- workspaces/billing: add tests to `cmd/workspaces/internal/billing` [#1786](https://github.com/sourcegraph/sourcegraph/pull/1786)
-- workspaces/billing: update test for `ManagementService.CreateWorkspace` [#1784](https://github.com/sourcegraph/sourcegraph/pull/1784)
-- workspaces/billing: add database tests for customers [#1783](https://github.com/sourcegraph/sourcegraph/pull/1783)
-- workspaces/billing: add database tests for transactions [#1782](https://github.com/sourcegraph/sourcegraph/pull/1782)
-- Require `X-Requested-With` for Cody API (CODY-4209) [#1781](https://github.com/sourcegraph/sourcegraph/pull/1781)
+- workspaces: Add field to pre-purchase extra seats `#1826`
+- workspaces/billing: implement periodic workers for subscription renewal `#1823`
+- auth: Fix background contexts in validate authz provider `#1802`
+- redispool: support more configuration options `#1799`
+- workspaces/billing: add tests to `cmd/workspaces/internal/billing` `#1786`
+- workspaces/billing: update test for `ManagementService.CreateWorkspace` `#1784`
+- workspaces/billing: add database tests for customers `#1783`
+- workspaces/billing: add database tests for transactions `#1782`
+- Require `X-Requested-With` for Cody API (CODY-4209) `#1781`
   - `X-Requested-With` is now a required HTTP header for Cody API calls
-- Context: narrow down stopwords list [#1780](https://github.com/sourcegraph/sourcegraph/pull/1780)
-- workspaces/billing: ignore invoices that are not for the current instance [#1777](https://github.com/sourcegraph/sourcegraph/pull/1777)
-- workspaces/billing: support soft-deleting subscriptions [#1772](https://github.com/sourcegraph/sourcegraph/pull/1772)
-- feature/internal: upsert github credentials on tenant creation [#1769](https://github.com/sourcegraph/sourcegraph/pull/1769)
+- Context: narrow down stopwords list `#1780`
+- workspaces/billing: ignore invoices that are not for the current instance `#1777`
+- workspaces/billing: support soft-deleting subscriptions `#1772`
+- feature/internal: upsert github credentials on tenant creation `#1769`
   - The multitenant reconciler now proactively inserts the credentials for the shared multitenant GitHub app whenever a new tenant is created.
-- lib/cloudapi: add mt instance type [#1766](https://github.com/sourcegraph/sourcegraph/pull/1766)
-- tenant: Add configuration for MT GitHub App to localdev [#1756](https://github.com/sourcegraph/sourcegraph/pull/1756)
-- Seed builtin prompts [#1755](https://github.com/sourcegraph/sourcegraph/pull/1755)
+- lib/cloudapi: add mt instance type `#1766`
+- tenant: Add configuration for MT GitHub App to localdev `#1756`
+- Seed builtin prompts `#1755`
   - Prompts including "Document Code", "Explain Code", "Generate Unit Tests", "Find Code Smells"
-- tenant: Enable onebox on tenant creation [#1748](https://github.com/sourcegraph/sourcegraph/pull/1748)
-- Onebox: introduce 'nls' patterntype [#1744](https://github.com/sourcegraph/sourcegraph/pull/1744)
-- workspaces/billing: implement Stripe webhook handler [#1740](https://github.com/sourcegraph/sourcegraph/pull/1740)
-- cody-gateway: update deployment id for model [#1729](https://github.com/sourcegraph/sourcegraph/pull/1729)
-- workspaces/billing: implement seat purchase and consumption [#1723](https://github.com/sourcegraph/sourcegraph/pull/1723)
-- localdev: Disable precise, syntactic codeintel in multitenant mode [#1720](https://github.com/sourcegraph/sourcegraph/pull/1720)
-- workspaces/billing: use the "correct" way to list customer payment methods [#1717](https://github.com/sourcegraph/sourcegraph/pull/1717)
-- `sg start sveltekit-minimal` for quickly running the new UI [#1702](https://github.com/sourcegraph/sourcegraph/pull/1702)
-- conf: Move more types to conftypes [#1692](https://github.com/sourcegraph/sourcegraph/pull/1692)
-- Remove experimental admin onboarding v2 [#1691](https://github.com/sourcegraph/sourcegraph/pull/1691)
-- telemetry: Implement telemetry exports for workspaces [#1677](https://github.com/sourcegraph/sourcegraph/pull/1677)
-- autoedit: add speculative decoding [#1673](https://github.com/sourcegraph/sourcegraph/pull/1673)
+- tenant: Enable onebox on tenant creation `#1748`
+- Onebox: introduce 'nls' patterntype `#1744`
+- workspaces/billing: implement Stripe webhook handler `#1740`
+- cody-gateway: update deployment id for model `#1729`
+- workspaces/billing: implement seat purchase and consumption `#1723`
+- localdev: Disable precise, syntactic codeintel in multitenant mode `#1720`
+- workspaces/billing: use the "correct" way to list customer payment methods `#1717`
+- `sg start sveltekit-minimal` for quickly running the new UI `#1702`
+- conf: Move more types to conftypes `#1692`
+- Remove experimental admin onboarding v2 `#1691`
+- telemetry: Implement telemetry exports for workspaces `#1677`
+- autoedit: add speculative decoding `#1673`
   - autoedit: Add speculative decoding support from fireworks
-- fix `marketingTracking` sending null [#1669](https://github.com/sourcegraph/sourcegraph/pull/1669)
+- fix `marketingTracking` sending null `#1669`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
-- Prompts: fix prompt name validation and prompts migration  [#1664](https://github.com/sourcegraph/sourcegraph/pull/1664)
-- Add GraphQL resolvers to read and set a list of repositories for a GH App installation ID [#1657](https://github.com/sourcegraph/sourcegraph/pull/1657)
-- fixup: remove Git conflict marks in `sg.config.yaml` [#1649](https://github.com/sourcegraph/sourcegraph/pull/1649)
-- Require prompt field before successful submission [#1639](https://github.com/sourcegraph/sourcegraph/pull/1639)
-- Add builtin prompts field to prompts [#1633](https://github.com/sourcegraph/sourcegraph/pull/1633)
+- Prompts: fix prompt name validation and prompts migration  `#1664`
+- Add GraphQL resolvers to read and set a list of repositories for a GH App installation ID `#1657`
+- fixup: remove Git conflict marks in `sg.config.yaml` `#1649`
+- Require prompt field before successful submission `#1639`
+- Add builtin prompts field to prompts `#1633`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
-- Zoekt: refactor memory dashboards [#1618](https://github.com/sourcegraph/sourcegraph/pull/1618)
-- workspaces: add billing prototype for subscription creation [#1611](https://github.com/sourcegraph/sourcegraph/pull/1611)
-- admin: Update report an issue link [#1608](https://github.com/sourcegraph/sourcegraph/pull/1608)
-- change default autoedit model [#1589](https://github.com/sourcegraph/sourcegraph/pull/1589)
-- feat(cloud) sg cloud eph deploy: support ms env [#1581](https://github.com/sourcegraph/sourcegraph/pull/1581)
-- add Cody.promptLibrary telemetry [#1568](https://github.com/sourcegraph/sourcegraph/pull/1568)
+- Zoekt: refactor memory dashboards `#1618`
+- workspaces: add billing prototype for subscription creation `#1611`
+- admin: Update report an issue link `#1608`
+- change default autoedit model `#1589`
+- feat(cloud) sg cloud eph deploy: support ms env `#1581`
+- add Cody.promptLibrary telemetry `#1568`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
-- worker: Group tasks by purpose [#1566](https://github.com/sourcegraph/sourcegraph/pull/1566)
-- Improve policy iterator tests to not rely on SQL for insertion [#1560](https://github.com/sourcegraph/sourcegraph/pull/1560)
-- repoupdater: Fix slow scheduling of cloned->uncloned repos [#1552](https://github.com/sourcegraph/sourcegraph/pull/1552)
-- repoupdater: Fix reporting of background routines [#1550](https://github.com/sourcegraph/sourcegraph/pull/1550)
-- Update Prompts Library UI (list page) [#1548](https://github.com/sourcegraph/sourcegraph/pull/1548)
-- Update prompt detail header UI [#1538](https://github.com/sourcegraph/sourcegraph/pull/1538)
-- Context: remove experimental intent routing [#1536](https://github.com/sourcegraph/sourcegraph/pull/1536)
-- Add 'recommended' checkbox to new creation UI. [#1531](https://github.com/sourcegraph/sourcegraph/pull/1531)
-- dormancy: Also fall asleep tenants that never see traffic [#1530](https://github.com/sourcegraph/sourcegraph/pull/1530)
-- Fix reranker not being applied [#1529](https://github.com/sourcegraph/sourcegraph/pull/1529)
-- sg: Fix local dev pguser setup [#1506](https://github.com/sourcegraph/sourcegraph/pull/1506)
-- Context: ensure we propagate timeouts and missing repos [#1505](https://github.com/sourcegraph/sourcegraph/pull/1505)
-- Make Visual Studio Experimental [#1503](https://github.com/sourcegraph/sourcegraph/pull/1503)
+- worker: Group tasks by purpose `#1566`
+- Improve policy iterator tests to not rely on SQL for insertion `#1560`
+- repoupdater: Fix slow scheduling of cloned->uncloned repos `#1552`
+- repoupdater: Fix reporting of background routines `#1550`
+- Update Prompts Library UI (list page) `#1548`
+- Update prompt detail header UI `#1538`
+- Context: remove experimental intent routing `#1536`
+- Add 'recommended' checkbox to new creation UI. `#1531`
+- dormancy: Also fall asleep tenants that never see traffic `#1530`
+- Fix reranker not being applied `#1529`
+- sg: Fix local dev pguser setup `#1506`
+- Context: ensure we propagate timeouts and missing repos `#1505`
+- Make Visual Studio Experimental `#1503`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
-- Context: always use more items for reranker [#1476](https://github.com/sourcegraph/sourcegraph/pull/1476)
-- Remove insert prompt mode [#1475](https://github.com/sourcegraph/sourcegraph/pull/1475)
-- Add missing Cody Web Alert CSS variable override [#1474](https://github.com/sourcegraph/sourcegraph/pull/1474)
-- repoupdater: Fix no rows returned error [#1472](https://github.com/sourcegraph/sourcegraph/pull/1472)
-- add autoedits to cody gateway [#1459](https://github.com/sourcegraph/sourcegraph/pull/1459)
-- ci: bump go-mod-tidy step timeout [#1452](https://github.com/sourcegraph/sourcegraph/pull/1452)
-- Add commands to prompts migration [#1449](https://github.com/sourcegraph/sourcegraph/pull/1449)
-- repoupdater: Speed up repo_update_job dequeues [#1448](https://github.com/sourcegraph/sourcegraph/pull/1448)
-- repoupdater: Clean up metrics [#1447](https://github.com/sourcegraph/sourcegraph/pull/1447)
-- repoupdater: Speed up and simplify not fetched metric [#1446](https://github.com/sourcegraph/sourcegraph/pull/1446)
-- migration: Checkpoint new repo_update_jobs migration [#1445](https://github.com/sourcegraph/sourcegraph/pull/1445)
-- gomod: bump Zoekt for query perf fix [#1438](https://github.com/sourcegraph/sourcegraph/pull/1438)
-- Implement prompt detail page re-design [#1423](https://github.com/sourcegraph/sourcegraph/pull/1423)
+- Context: always use more items for reranker `#1476`
+- Remove insert prompt mode `#1475`
+- Add missing Cody Web Alert CSS variable override `#1474`
+- repoupdater: Fix no rows returned error `#1472`
+- add autoedits to cody gateway `#1459`
+- ci: bump go-mod-tidy step timeout `#1452`
+- Add commands to prompts migration `#1449`
+- repoupdater: Speed up repo_update_job dequeues `#1448`
+- repoupdater: Clean up metrics `#1447`
+- repoupdater: Speed up and simplify not fetched metric `#1446`
+- migration: Checkpoint new repo_update_jobs migration `#1445`
+- gomod: bump Zoekt for query perf fix `#1438`
+- Implement prompt detail page re-design `#1423`
   - Re-designed prompt detail page.
-- Add page faults to Zoekt memory metrics [#1422](https://github.com/sourcegraph/sourcegraph/pull/1422)
-- chore/source Update src-cli version to 5.8.2 [#1415](https://github.com/sourcegraph/sourcegraph/pull/1415)
+- Add page faults to Zoekt memory metrics `#1422`
+- chore/source Update src-cli version to 5.8.2 `#1415`
   - chore/source Update src-cli version to 5.8.2
-- siteadmin: Reset pagination cursors after filter change [#1404](https://github.com/sourcegraph/sourcegraph/pull/1404)
-- bugfix: fix settings link [#1393](https://github.com/sourcegraph/sourcegraph/pull/1393)
-- gomod: bump Zoekt for go-git optimization [#1391](https://github.com/sourcegraph/sourcegraph/pull/1391)
-- Update Marketing URLs in the site footer links [#1390](https://github.com/sourcegraph/sourcegraph/pull/1390)
-- Soft delete prompts [#1386](https://github.com/sourcegraph/sourcegraph/pull/1386)
-- Widen blocked phrases, but only confine blocked phrases to expensive (aka flagged) models [#1344](https://github.com/sourcegraph/sourcegraph/pull/1344)
+- siteadmin: Reset pagination cursors after filter change `#1404`
+- bugfix: fix settings link `#1393`
+- gomod: bump Zoekt for go-git optimization `#1391`
+- Update Marketing URLs in the site footer links `#1390`
+- Soft delete prompts `#1386`
+- Widen blocked phrases, but only confine blocked phrases to expensive (aka flagged) models `#1344`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
-- repoupdater: Drop support for gitUpdateInterval [#1339](https://github.com/sourcegraph/sourcegraph/pull/1339)
+- repoupdater: Drop support for gitUpdateInterval `#1339`
   - The site config setting `gitUpdateInterval` has been deprecated and removed. We are removing it in favor of smarter heuristics like webhooks, user traffic, and repo staleness.
-- repoupdater: Remove total from schedule and update queue state [#1338](https://github.com/sourcegraph/sourcegraph/pull/1338)
-- Add system workspace admin role [#1327](https://github.com/sourcegraph/sourcegraph/pull/1327)
-- Add syntactic worker to images so it gets updated in helm charts [#1323](https://github.com/sourcegraph/sourcegraph/pull/1323)
-- feature/source: adjust exclude definition in github schema to disallow using name, id with other filter conditions [#1250](https://github.com/sourcegraph/sourcegraph/pull/1250)
+- repoupdater: Remove total from schedule and update queue state `#1338`
+- Add system workspace admin role `#1327`
+- Add syntactic worker to images so it gets updated in helm charts `#1323`
+- feature/source: adjust exclude definition in github schema to disallow using name, id with other filter conditions `#1250`
   - The github code host connection schema for `exclude` has been updated to enforce that the name and id fields can't be combined with any other fields.
-- Add gitSSHCipher for git code hosts [#1175](https://github.com/sourcegraph/sourcegraph/pull/1175)
-- RFC: Dormancy and tenant states [#756](https://github.com/sourcegraph/sourcegraph/pull/756)
-- web telemetry: update `marketingTracking` to retrieve latest cookies set on web [#460](https://github.com/sourcegraph/sourcegraph/pull/460)
+- Add gitSSHCipher for git code hosts `#1175`
+- RFC: Dormancy and tenant states `#756`
+- web telemetry: update `marketingTracking` to retrieve latest cookies set on web `#460`
 
 ### Untracked
 
 The following PRs were merged onto the previous release branch but could not be automatically mapped to a corresponding commit in this release:
 
-- Fix wrong offset in policy iteration [#1559](https://github.com/sourcegraph/sourcegraph/pull/1559)
-- Release: Prep stitched migration graph for release (#1388) [#1389](https://github.com/sourcegraph/sourcegraph/pull/1389)
+- Fix wrong offset in policy iteration `#1559`
+- Release: Prep stitched migration graph for release (#1388) `#1389`
   - n/a
 
 {/* RSS={"version":"v5.10.0", "releasedAt": "2024-11-27"} */}
@@ -718,23 +718,23 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Code Intelligence
 
-- Fix wrong offset in policy iteration [#1559](https://github.com/sourcegraph/sourcegraph/pull/1559)
+- Fix wrong offset in policy iteration `#1559`
 
 #### Cody
 
-- fix broken homepage redirect for cody only plans [#1626](https://github.com/sourcegraph/sourcegraph/pull/1626)
+- fix broken homepage redirect for cody only plans `#1626`
   - When using an instance with a Cody-only license, accessing the home page now correctly redirects you to /cody/dashboard, instead of a non-existent /cody page.
   Backport a4cb5a0723bad18e1c215d81231db457d1abfbdb from #1621
 
 #### Search
 
-- (new web ui) Disable persistence for history/explore panel [#1614](https://github.com/sourcegraph/sourcegraph/pull/1614)
+- (new web ui) Disable persistence for history/explore panel `#1614`
 
 ### Chore
 
 #### Release
 
-- remove extra v identifier for version in artifact exporter [#1594](https://github.com/sourcegraph/sourcegraph/pull/1594)
+- remove extra v identifier for version in artifact exporter `#1594`
   - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
   Backport c4b838103ce2f71e7591ade720e8bdf17f9a5b39 from #1490
 
@@ -746,7 +746,7 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Others
 
-- [Backport 5.9.x] azure: Add support for repositoryPathPattern [#1629](https://github.com/sourcegraph/sourcegraph/pull/1629)
+- [Backport 5.9.x] azure: Add support for repositoryPathPattern `#1629`
   - Added support for the `repositoryPathPattern` property to Azure DevOps code host connections.
   - Fixed an issue where Azure DevOps repo names included a port number - aligning with other code host connection implementations  Backport 762bd89a12825ff05de98d9c2d8adfcf1ef5bf4a from #1543
 
@@ -769,7 +769,7 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Dev
 
-- hoist env vars init to avoid repo-updater panic [#1527](https://github.com/sourcegraph/sourcegraph/pull/1527)
+- hoist env vars init to avoid repo-updater panic `#1527`
 
 ### Reverts
 
@@ -798,7 +798,7 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Others
 
-- "Add syntactic worker to images so it gets updated in helm charts"" [#1483](https://github.com/sourcegraph/sourcegraph/pull/1483)
+- "Add syntactic worker to images so it gets updated in helm charts"" `#1483`
 
 {/* RSS={"version":"v5.9.45", "releasedAt": "2024-11-05"} */}
 
@@ -819,68 +819,68 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Api
 
-- Added a better error message for 429 errors for `/.api/cody/completions` (CODY-4097) [#1380](https://github.com/sourcegraph/sourcegraph/pull/1380)
+- Added a better error message for 429 errors for `/.api/cody/completions` (CODY-4097) `#1380`
 
 #### Audit
 
-- add tenant to audit logs, fix log stack [#960](https://github.com/sourcegraph/sourcegraph/pull/960)
+- add tenant to audit logs, fix log stack `#960`
 
 #### Batch Changes
 
-- show name of additional fields that cause errors [#799](https://github.com/sourcegraph/sourcegraph/pull/799)
+- show name of additional fields that cause errors `#799`
   - feat(batches): show name of additional fields that cause errors
 
 #### Ci
 
-- generate frozen files as part of stich_migration_graph generation [#957](https://github.com/sourcegraph/sourcegraph/pull/957)
-- record Test infrastructure failures [#884](https://github.com/sourcegraph/sourcegraph/pull/884)
+- generate frozen files as part of stich_migration_graph generation `#957`
+- record Test infrastructure failures `#884`
   - add library that writes to TEST_INFRASTRUCTURE_FAILURE_FILE if it is defined for test failures
 
 #### Cloud
 
-- allow monolithsams instances to have no conf auth providers [#1247](https://github.com/sourcegraph/sourcegraph/pull/1247)
-- add support to override target managed service endpoints [#1238](https://github.com/sourcegraph/sourcegraph/pull/1238)
-- add support to override license generation public key from cloud site config [#1193](https://github.com/sourcegraph/sourcegraph/pull/1193)
+- allow monolithsams instances to have no conf auth providers `#1247`
+- add support to override target managed service endpoints `#1238`
+- add support to override license generation public key from cloud site config `#1193`
 
 #### Code Intelligence
 
-- Syntactic indexing grafana monitoring dashboard [#1263](https://github.com/sourcegraph/sourcegraph/pull/1263)
+- Syntactic indexing grafana monitoring dashboard `#1263`
 
 #### Cody
 
-- add more API docs content [#1378](https://github.com/sourcegraph/sourcegraph/pull/1378)
-- add CLI tool to compute PCW [#1349](https://github.com/sourcegraph/sourcegraph/pull/1349)
-- Add Claude 3.5 Sonnet (Latest) & Claude 3 Opus (Latest) [#1244](https://github.com/sourcegraph/sourcegraph/pull/1244)
-- add Cody Audit Log [#1232](https://github.com/sourcegraph/sourcegraph/pull/1232)
-- add cody audit log table and store [#1182](https://github.com/sourcegraph/sourcegraph/pull/1182)
-- Expose token usage in the LLM API [#1070](https://github.com/sourcegraph/sourcegraph/pull/1070)
+- add more API docs content `#1378`
+- add CLI tool to compute PCW `#1349`
+- Add Claude 3.5 Sonnet (Latest) & Claude 3 Opus (Latest) `#1244`
+- add Cody Audit Log `#1232`
+- add cody audit log table and store `#1182`
+- Expose token usage in the LLM API `#1070`
   - The `/.api/completions/stream` API now includes used input/output tokens and the upstream model name in the response body when using the query parameter `api-version=5` or higher. Does not apply to: Vertex Anthropic, Azure OpenAI (mo model name, and no token usage in streaming response), Gemini (no model name in streaming response)
   - LLM chat completions now support `stream: false` when using Azure OpenAI and OpenAI-compatible providers.
-- update telemetry feature prefix for Cody API [#1023](https://github.com/sourcegraph/sourcegraph/pull/1023)
-- add embedded API docs via OpenAPI/Redocly [#1014](https://github.com/sourcegraph/sourcegraph/pull/1014)
+- update telemetry feature prefix for Cody API `#1023`
+- add embedded API docs via OpenAPI/Redocly `#1014`
   - New OpenAPI API docs within the instance at the URL `$SRC_ENDPOINT/api/openapi/public`. Alternatively, reach the page at "User > Settings > OpenAPI Reference".
-- add basic telemetry recording for Cody API [#943](https://github.com/sourcegraph/sourcegraph/pull/943)
-- add support to format raw API responses for Cody [#877](https://github.com/sourcegraph/sourcegraph/pull/877)
+- add basic telemetry recording for Cody API `#943`
+- add support to format raw API responses for Cody `#877`
   - The raw HTTP API now accepts the query paramter `format=cody` or header `Accept: application/cody` to render files and directories as context items for Cody. Example request path: `/github.com/sourcegraph/cody/-/raw/agent/src/index.ts?format=cody`.
 
 #### Cody-Gateway
 
-- add new claude-3-5-haiku-latest model [#1471](https://github.com/sourcegraph/sourcegraph/pull/1471)
+- add new claude-3-5-haiku-latest model `#1471`
 Cody Gateway: add new claude-3-5-haiku-latest dotcom models list  Backport 11e7481ba3c810ae5b47d32b8cf32066e2f0b2bb from #1470
-- deprecate old claude 3.5 sonnet [#1248](https://github.com/sourcegraph/sourcegraph/pull/1248)
+- deprecate old claude 3.5 sonnet `#1248`
 
 #### Dev
 
-- add externalSecret support for commandsets [#1027](https://github.com/sourcegraph/sourcegraph/pull/1027)
-- sg sams login and cookie-less workspace creation [#913](https://github.com/sourcegraph/sourcegraph/pull/913)
+- add externalSecret support for commandsets `#1027`
+- sg sams login and cookie-less workspace creation `#913`
 
 #### Graphql
 
-- upload graphql schemas to GCS bucket [#1245](https://github.com/sourcegraph/sourcegraph/pull/1245)
+- upload graphql schemas to GCS bucket `#1245`
 
 #### Internal/Requestclient
 
-- have HTTP middleware populate all response headers with observed X-Forwarded-For and calculated IP for debugging purposes [#524](https://github.com/sourcegraph/sourcegraph/pull/524)
+- have HTTP middleware populate all response headers with observed X-Forwarded-For and calculated IP for debugging purposes `#524`
   - All of Sourcegraph's HTTP responses now contain two new headers for easier debugging purposes.
 - `Observed-X-Forwarded-For`: echos the `X-Forwarded-For` header
 that we observed on the user's incoming request
@@ -888,560 +888,560 @@ that we observed on the user's incoming request
 
 #### Local
 
-- use pending spinner for build waiting in cloud ephemeral [#1039](https://github.com/sourcegraph/sourcegraph/pull/1039)
-- add format for displaying env [#918](https://github.com/sourcegraph/sourcegraph/pull/918)
+- use pending spinner for build waiting in cloud ephemeral `#1039`
+- add format for displaying env `#918`
 
 #### Monitoring
 
-- set decimals to 1 for standard heatmap [#1361](https://github.com/sourcegraph/sourcegraph/pull/1361)
+- set decimals to 1 for standard heatmap `#1361`
 
 #### Monolithsams
 
-- load SAMS provider and creds from env [#1024](https://github.com/sourcegraph/sourcegraph/pull/1024)
+- load SAMS provider and creds from env `#1024`
 
 #### Msp
 
-- package 'auditlog' [#1223](https://github.com/sourcegraph/sourcegraph/pull/1223)
+- package 'auditlog' `#1223`
 
 #### Msp/Pg
 
-- updated o11y for pool acquire, add overrides for pgxpool.Config [#1375](https://github.com/sourcegraph/sourcegraph/pull/1375)
+- updated o11y for pool acquire, add overrides for pgxpool.Config `#1375`
 
 #### Search
 
-- (new web ui) Show loading feedback for hovercards [#1239](https://github.com/sourcegraph/sourcegraph/pull/1239)
-- (new web ui) Add ability so switch search scope in fuzzy finder [#1201](https://github.com/sourcegraph/sourcegraph/pull/1201)
-- (new web ui) Make view modes available when opening a file at a commit [#1090](https://github.com/sourcegraph/sourcegraph/pull/1090)
-- (new web ui) Render relative images in rich text documents [#841](https://github.com/sourcegraph/sourcegraph/pull/841)
+- (new web ui) Show loading feedback for hovercards `#1239`
+- (new web ui) Add ability so switch search scope in fuzzy finder `#1201`
+- (new web ui) Make view modes available when opening a file at a commit `#1090`
+- (new web ui) Render relative images in rich text documents `#841`
 
 #### Sg
 
-- make workspaces endpoint configurable [#998](https://github.com/sourcegraph/sourcegraph/pull/998)
-- implement show-env flag [#883](https://github.com/sourcegraph/sourcegraph/pull/883)
+- make workspaces endpoint configurable `#998`
+- implement show-env flag `#883`
 
 #### Site Admin
 
-- site config 'telemetry: \{ disableLocalEventLogs \}' to disable event_logs [#1275](https://github.com/sourcegraph/sourcegraph/pull/1275)
+- site config 'telemetry: \{ disableLocalEventLogs \}' to disable event_logs `#1275`
   - Long-term local retention of user telemetry as 'event logs' can now be disabled entirely via the `telemetry: { disableLocalEventLogs }` site configuration.
 
 #### Sub_repo_perms
 
-- add conditional logging for seeing if sub_repo_permisisons are working [#673](https://github.com/sourcegraph/sourcegraph/pull/673)
+- add conditional logging for seeing if sub_repo_permisisons are working `#673`
   - The sub repository permissions implementation now emits logs that describe the rules that were evaluated for a given request whenever tracing is enabled. (We limit these logs for only when tracing is enabled since they can be quite verbose).
 
 #### Telemetry
 
-- Log estimated LLM cost telemetry (CODY-4007) [#1312](https://github.com/sourcegraph/sourcegraph/pull/1312)
+- Log estimated LLM cost telemetry (CODY-4007) `#1312`
   - Adds cost estimates to the ModelConfiguration returned by `.api/llm/supported-models.json`
   - Adds `llmTokenUsageCostEstimate` telemetry value with estimates of each requests LLM cost in pennies
-- Add check for PGDATASOURCE [#1281](https://github.com/sourcegraph/sourcegraph/pull/1281)
-- Add source.server.server_client.user_agent to telemetry payload [#1120](https://github.com/sourcegraph/sourcegraph/pull/1120)
+- Add check for PGDATASOURCE `#1281`
+- Add source.server.server_client.user_agent to telemetry payload `#1120`
   - Add the sourcegraph API client user-agent to telemetry payload types under `source.server.server_client.user_agent`.
-- check for external dbs [#1083](https://github.com/sourcegraph/sourcegraph/pull/1083)
-- propagate new x-sourcegraph-api-client-* headers to request clients [#1025](https://github.com/sourcegraph/sourcegraph/pull/1025)
+- check for external dbs `#1083`
+- propagate new x-sourcegraph-api-client-* headers to request clients `#1025`
   - Propagates new X-Sourcegraph-API-Client-Name and X-Sourcegraph-API-Client-Version headers to request clients
 
 #### Telemetry-Gateway
 
-- improve logging on processing done [#1252](https://github.com/sourcegraph/sourcegraph/pull/1252)
+- improve logging on processing done `#1252`
 
 #### Telemetrygateway
 
-- implement publishusermetadata RPC [#1095](https://github.com/sourcegraph/sourcegraph/pull/1095)
-- spec PublishInstanceUserMetadata and pubsub format [#1053](https://github.com/sourcegraph/sourcegraph/pull/1053)
+- implement publishusermetadata RPC `#1095`
+- spec PublishInstanceUserMetadata and pubsub format `#1053`
 
 #### Telemetrygatewayexporter
 
-- log export duration, use better duration buckets [#1305](https://github.com/sourcegraph/sourcegraph/pull/1305)
+- log export duration, use better duration buckets `#1305`
 
 #### Tenant/Reconciler
 
-- full membership reconcile [#953](https://github.com/sourcegraph/sourcegraph/pull/953)
-- handle tenant-exists, new-tenant, and error combination paths [#895](https://github.com/sourcegraph/sourcegraph/pull/895)
+- full membership reconcile `#953`
+- handle tenant-exists, new-tenant, and error combination paths `#895`
 
 #### Worker
 
-- delete legacy event_logs exporter [#859](https://github.com/sourcegraph/sourcegraph/pull/859)
+- delete legacy event_logs exporter `#859`
 
 #### Worker/Telemetrygatewayexporter
 
-- opt-in user metadata exporter [#1096](https://github.com/sourcegraph/sourcegraph/pull/1096)
+- opt-in user metadata exporter `#1096`
 
 #### Workspaces
 
-- notify user state updates [#1316](https://github.com/sourcegraph/sourcegraph/pull/1316)
-- allow join-by-email to be provided on creation [#1280](https://github.com/sourcegraph/sourcegraph/pull/1280)
-- add management GetWorkspace that allows view-by-email-domain [#1277](https://github.com/sourcegraph/sourcegraph/pull/1277)
-- guard against excessive join-workspaces [#1251](https://github.com/sourcegraph/sourcegraph/pull/1251)
-- restrict memberships/admins before allowing workspace creation [#1212](https://github.com/sourcegraph/sourcegraph/pull/1212)
-- join by email domain POC [#1162](https://github.com/sourcegraph/sourcegraph/pull/1162)
-- configure join by email domains [#1158](https://github.com/sourcegraph/sourcegraph/pull/1158)
-- only recently seen instances are candidates for hosting workspace [#1031](https://github.com/sourcegraph/sourcegraph/pull/1031)
-- ban 'default' as a workspace name [#992](https://github.com/sourcegraph/sourcegraph/pull/992)
-- forbid 'src-'-prefix workspace names [#920](https://github.com/sourcegraph/sourcegraph/pull/920)
-- refactor workspace states with reconcile and dormancy [#819](https://github.com/sourcegraph/sourcegraph/pull/819)
+- notify user state updates `#1316`
+- allow join-by-email to be provided on creation `#1280`
+- add management GetWorkspace that allows view-by-email-domain `#1277`
+- guard against excessive join-workspaces `#1251`
+- restrict memberships/admins before allowing workspace creation `#1212`
+- join by email domain POC `#1162`
+- configure join by email domains `#1158`
+- only recently seen instances are candidates for hosting workspace `#1031`
+- ban 'default' as a workspace name `#992`
+- forbid 'src-'-prefix workspace names `#920`
+- refactor workspace states with reconcile and dormancy `#819`
 
 #### Workspaces/Management
 
-- always return roles [#1358](https://github.com/sourcegraph/sourcegraph/pull/1358)
-- provide workspace URI [#1055](https://github.com/sourcegraph/sourcegraph/pull/1055)
+- always return roles `#1358`
+- provide workspace URI `#1055`
 
 #### Workspacesreconciler
 
-- add WORKSPACESRECONCILER_INSTANCE_STATE_OVERRIDE and 'AT_CAPACITY' state [#1297](https://github.com/sourcegraph/sourcegraph/pull/1297)
-- global periodic reconciler [#997](https://github.com/sourcegraph/sourcegraph/pull/997)
+- add WORKSPACESRECONCILER_INSTANCE_STATE_OVERRIDE and 'AT_CAPACITY' state `#1297`
+- global periodic reconciler `#997`
 
 #### Others
 
-- surface result precision in the explore panel [#1359](https://github.com/sourcegraph/sourcegraph/pull/1359)
-- more complete search backend events [#1257](https://github.com/sourcegraph/sourcegraph/pull/1257)
-- add embedded file snippet page [#1196](https://github.com/sourcegraph/sourcegraph/pull/1196)
+- surface result precision in the explore panel `#1359`
+- more complete search backend events `#1257`
+- add embedded file snippet page `#1196`
   - Added embeddable page for file snippets
-- add embedded file snippet component [#1122](https://github.com/sourcegraph/sourcegraph/pull/1122)
-- add search aggregations to svelte webapp [#1093](https://github.com/sourcegraph/sourcegraph/pull/1093)
+- add embedded file snippet component `#1122`
+- add search aggregations to svelte webapp `#1093`
 
 ### Fix
 
 #### Api-Docs
 
-- Added OpenAPI Urls to static page info [#1379](https://github.com/sourcegraph/sourcegraph/pull/1379)
+- Added OpenAPI Urls to static page info `#1379`
 
 #### Batch Changes
 
-- enable request splitting by default [#1229](https://github.com/sourcegraph/sourcegraph/pull/1229)
+- enable request splitting by default `#1229`
   - fix(batches): enable request splitting by default
-- handle spec being nil for suffix salt [#1228](https://github.com/sourcegraph/sourcegraph/pull/1228)
+- handle spec being nil for suffix salt `#1228`
   - fix(batches): handle spec being nil for suffix salt
-- enable GQL request splitting via BATCH_CHANGES_REQUEST_SPLITTING [#1150](https://github.com/sourcegraph/sourcegraph/pull/1150)
+- enable GQL request splitting via BATCH_CHANGES_REQUEST_SPLITTING `#1150`
   - fix(batches): enable GQL request splitting via BATCH_CHANGES_REQUEST_SPLITTING
-- display "Deleted Namespace" instead of throwing an error [#778](https://github.com/sourcegraph/sourcegraph/pull/778)
+- display "Deleted Namespace" instead of throwing an error `#778`
   - fix(batches): display "Deleted Namespace" instead of throwing an error
 
 #### Ci
 
-- remove dependsOn key for PG16 step [#1295](https://github.com/sourcegraph/sourcegraph/pull/1295)
-- disable db test task temporarily [#1292](https://github.com/sourcegraph/sourcegraph/pull/1292)
-- generate coreos iptable BUILD.bazel file [#1230](https://github.com/sourcegraph/sourcegraph/pull/1230)
-- cap branch names in image tags [#1103](https://github.com/sourcegraph/sourcegraph/pull/1103)
+- remove dependsOn key for PG16 step `#1295`
+- disable db test task temporarily `#1292`
+- generate coreos iptable BUILD.bazel file `#1230`
+- cap branch names in image tags `#1103`
 
 #### Code Monitor
 
-- fail monitors with missing/unverified primary email address [#938](https://github.com/sourcegraph/sourcegraph/pull/938)
+- fail monitors with missing/unverified primary email address `#938`
   - fix(code-monitor): fail monitors with missing/unverified primary email address
 
 #### Code Intelligence
 
-- Add more limits in auto-indexing inference code [#1170](https://github.com/sourcegraph/sourcegraph/pull/1170)
+- Add more limits in auto-indexing inference code `#1170`
   - Introduces new limits for auto-indexing inference to reduce the risk of continuously growing auto-indexing queues.
   - The number of jobs spawned per round of auto-indexing inference per repo is capped (default: 100) to reduce risk of clogging of auto-indexing queues. Excess jobs will be discarded.
   - The number of paths inspected for a single round of auto-indexing inference per repo is capped (default: 500) to reduce risk of timeouts. Excess paths will be discarded.
-- Handle annotated tag hashes passed as 'commit' for uploads [#1135](https://github.com/sourcegraph/sourcegraph/pull/1135)
+- Handle annotated tag hashes passed as 'commit' for uploads `#1135`
   - Fixes handling of SCIP uploads when the hash passed to the `-commit` flag of `src-cli` corresponds to the hash of an annotated tag instead of the hash of a commit. Previously, these uploads were not accessible for code navigation.
-- Propagate error collector to fix retention tab GraphQL API call [#847](https://github.com/sourcegraph/sourcegraph/pull/847)
+- Propagate error collector to fix retention tab GraphQL API call `#847`
   - Fixes a bug where the retention tab for precise indexes would show
 a nil pointer exception instead of retention information.
 
 #### Code Nav
 
-- Trigger hovers for all programming languages [#1076](https://github.com/sourcegraph/sourcegraph/pull/1076)
+- Trigger hovers for all programming languages `#1076`
   - Fixes a bug where hovers were not triggered for less mainstream languages like F#,
 Standard ML, Visual Basic, Pkl, Hack, MATLAB etc.
 
 #### Cody
 
-- convert nil message content parts for OpenAI compatability [#1467](https://github.com/sourcegraph/sourcegraph/pull/1467)
-- guard against completion usage missing (CODY-4135) [#1218](https://github.com/sourcegraph/sourcegraph/pull/1218)
-- API telemetry [#1026](https://github.com/sourcegraph/sourcegraph/pull/1026)
-- reset usage when rate limit value or interval decreased [#1015](https://github.com/sourcegraph/sourcegraph/pull/1015)
-- fix CodyLLMConfiguration resolver [#839](https://github.com/sourcegraph/sourcegraph/pull/839)
+- convert nil message content parts for OpenAI compatability `#1467`
+- guard against completion usage missing (CODY-4135) `#1218`
+- API telemetry `#1026`
+- reset usage when rate limit value or interval decreased `#1015`
+- fix CodyLLMConfiguration resolver `#839`
 
 #### Codyapi
 
-- Restrict audit log retrieval to site admins only [#1285](https://github.com/sourcegraph/sourcegraph/pull/1285)
-- Add usage to completions/chat (CODY-3498) [#1131](https://github.com/sourcegraph/sourcegraph/pull/1131)
+- Restrict audit log retrieval to site admins only `#1285`
+- Add usage to completions/chat (CODY-3498) `#1131`
   - Added token usage information to `.api/llm/chat/completions`
 
 #### Completions
 
-- clear out usage information on the completions API when version < 5 (CODY-4114) [#1153](https://github.com/sourcegraph/sourcegraph/pull/1153)
+- clear out usage information on the completions API when version < 5 (CODY-4114) `#1153`
 
 #### Dev
 
-- Correctly propagate error key-value pairs [#1258](https://github.com/sourcegraph/sourcegraph/pull/1258)
+- Correctly propagate error key-value pairs `#1258`
   - Fixes a bug where logs and traces were sometimes missing key-value pairs recorded alongside errors.
-- fix sg db reset-pg PGUSER overwrite [#1220](https://github.com/sourcegraph/sourcegraph/pull/1220)
-- fix secrets deadlock [#1032](https://github.com/sourcegraph/sourcegraph/pull/1032)
-- fix workspaces client in local dev [#1028](https://github.com/sourcegraph/sourcegraph/pull/1028)
-- (new web ui) Properly initialize local dev defaults [#961](https://github.com/sourcegraph/sourcegraph/pull/961)
-- remove removed table from MT migration [#910](https://github.com/sourcegraph/sourcegraph/pull/910)
-- report warning if workspace creation failed [#909](https://github.com/sourcegraph/sourcegraph/pull/909)
-- fix workspaces flakey test [#862](https://github.com/sourcegraph/sourcegraph/pull/862)
+- fix sg db reset-pg PGUSER overwrite `#1220`
+- fix secrets deadlock `#1032`
+- fix workspaces client in local dev `#1028`
+- (new web ui) Properly initialize local dev defaults `#961`
+- remove removed table from MT migration `#910`
+- report warning if workspace creation failed `#909`
+- fix workspaces flakey test `#862`
 
 #### Frontend
 
-- place requestclient as one of the first middleware [#1215](https://github.com/sourcegraph/sourcegraph/pull/1215)
+- place requestclient as one of the first middleware `#1215`
 
 #### Local
 
-- move env into correct grouping [#1332](https://github.com/sourcegraph/sourcegraph/pull/1332)
-- specify default database when checking psql version in `sg setup` [#924](https://github.com/sourcegraph/sourcegraph/pull/924)
-- fix issue with sg start monitoring ignoring dockerCommands [#848](https://github.com/sourcegraph/sourcegraph/pull/848)
+- move env into correct grouping `#1332`
+- specify default database when checking psql version in `sg setup` `#924`
+- fix issue with sg start monitoring ignoring dockerCommands `#848`
 
 #### Mt-Router
 
-- prevent infinite oauth redirect [#1118](https://github.com/sourcegraph/sourcegraph/pull/1118)
+- prevent infinite oauth redirect `#1118`
 
 #### Release
 
-- rename generated changelog file [#1136](https://github.com/sourcegraph/sourcegraph/pull/1136)
-- Add stitched migration graph override (#935) [#941](https://github.com/sourcegraph/sourcegraph/pull/941)
+- rename generated changelog file `#1136`
+- Add stitched migration graph override (#935) `#941`
   - NA
 
 #### Search
 
-- disable hybrid search with index:no [#1462](https://github.com/sourcegraph/sourcegraph/pull/1462)
-  - `index:no` will now avoid the index completely. Previously it would still consult the index via a process called hybrid search. Search jobs always uses `index:no`, so if you notice a performance problem please reach out to Sourcegraph support. Setting `SRC_DISABLE_RESPECT_INDEX_FIELD` environment variable on the frontend and worker pods will disable this new behaviour in 5.9.x only.Stacked on [https://github.com/sourcegraph/sourcegraph/pull/1456](https://github.com/sourcegraph/sourcegraph/pull/1456)Closes [https://linear.app/sourcegraph/issue/SPLF-663/disable-hybrid-search-for-search-jobs](https://linear.app/sourcegraph/issue/SPLF-663/disable-hybrid-search-for-search-jobs)  Backport 7aced46a7bc3526695a77e492ee69ad2cfa7bb17 from #1460
-- (new web ui) Render submodules differently in file trees [#1377](https://github.com/sourcegraph/sourcegraph/pull/1377)
-- Fix document highlights in certain situations [#1343](https://github.com/sourcegraph/sourcegraph/pull/1343)
-- (new web ui) Fix relative links to folders [#1331](https://github.com/sourcegraph/sourcegraph/pull/1331)
-- (new web ui) Fix file tree sidebar not staying at top level directory [#1328](https://github.com/sourcegraph/sourcegraph/pull/1328)
-- (new web ui) Show informative message when repo has no README or description [#1240](https://github.com/sourcegraph/sourcegraph/pull/1240)
-- (new web ui) Fix linkifying files [#1236](https://github.com/sourcegraph/sourcegraph/pull/1236)
-- (new web ui) Make blob view readonly [#1234](https://github.com/sourcegraph/sourcegraph/pull/1234)
+- disable hybrid search with index:no `#1462`
+  - `index:no` will now avoid the index completely. Previously it would still consult the index via a process called hybrid search. Search jobs always uses `index:no`, so if you notice a performance problem please reach out to Sourcegraph support. Setting `SRC_DISABLE_RESPECT_INDEX_FIELD` environment variable on the frontend and worker pods will disable this new behaviour in 5.9.x only.Stacked on `#1456`Closes [https://linear.app/sourcegraph/issue/SPLF-663/disable-hybrid-search-for-search-jobs](https://linear.app/sourcegraph/issue/SPLF-663/disable-hybrid-search-for-search-jobs)  Backport 7aced46a7bc3526695a77e492ee69ad2cfa7bb17 from #1460
+- (new web ui) Render submodules differently in file trees `#1377`
+- Fix document highlights in certain situations `#1343`
+- (new web ui) Fix relative links to folders `#1331`
+- (new web ui) Fix file tree sidebar not staying at top level directory `#1328`
+- (new web ui) Show informative message when repo has no README or description `#1240`
+- (new web ui) Fix linkifying files `#1236`
+- (new web ui) Make blob view readonly `#1234`
   - Prevents default browser shortcuts from modifying the file content locally.
-- (new web ui) Prevent uncaught error when navigating back to file page [#1199](https://github.com/sourcegraph/sourcegraph/pull/1199)
-- (new web ui) Show helpful message for root commit/change list page [#1138](https://github.com/sourcegraph/sourcegraph/pull/1138)
-- (new web ui) Do not show loading spinner for empty commit ranges on compare page [#1126](https://github.com/sourcegraph/sourcegraph/pull/1126)
-- (new web ui) Fix search aggregation styles [#1125](https://github.com/sourcegraph/sourcegraph/pull/1125)
-- exclude content filters from phrase boosting [#1038](https://github.com/sourcegraph/sourcegraph/pull/1038)
+- (new web ui) Prevent uncaught error when navigating back to file page `#1199`
+- (new web ui) Show helpful message for root commit/change list page `#1138`
+- (new web ui) Do not show loading spinner for empty commit ranges on compare page `#1126`
+- (new web ui) Fix search aggregation styles `#1125`
+- exclude content filters from phrase boosting `#1038`
   - This fixes a bug where we would apply a phrase boost if a `content:` filter was specified with keyword search enabled. This led to inconsistent behavior (regexp vs keyword search) and it also rendered the `content:` filter ineffective, because we ran a general text search instead of a just a content search.
-- (new web ui) 'File not found' when quickly navigating between files [#959](https://github.com/sourcegraph/sourcegraph/pull/959)
-- (new web ui) Blame view not visible for files that use `\r` as line separators [#929](https://github.com/sourcegraph/sourcegraph/pull/929)
-- (new web ui) Show settings link to site admins when repo error occurs [#817](https://github.com/sourcegraph/sourcegraph/pull/817)
+- (new web ui) 'File not found' when quickly navigating between files `#959`
+- (new web ui) Blame view not visible for files that use `\r` as line separators `#929`
+- (new web ui) Show settings link to site admins when repo error occurs `#817`
 
 #### Sg
 
-- workaround dangling dev resources [#1048](https://github.com/sourcegraph/sourcegraph/pull/1048)
+- workaround dangling dev resources `#1048`
 
 #### Source
 
-- correct Name() documentation for gitserver's ReadDirIterator [#1278](https://github.com/sourcegraph/sourcegraph/pull/1278)
+- correct Name() documentation for gitserver's ReadDirIterator `#1278`
   - The documentation for gitserver's ReadDir method has been clarified to reflect that the return iterator's Name() method returns the full path of the file, as opposed to just the basename.
-- multiple GitHub external accounts to the same URL now refresh correctly [#1260](https://github.com/sourcegraph/sourcegraph/pull/1260)
+- multiple GitHub external accounts to the same URL now refresh correctly `#1260`
   - When there are multiple auth providers configured that point to the same GitHub URL, as can be the case when using private GitHub Apps, user external account tokens will now refresh correctly.
-- clarify exclude docs in github connection schema to say that individual expressions within block are `and`-ed together [#1249](https://github.com/sourcegraph/sourcegraph/pull/1249)
+- clarify exclude docs in github connection schema to say that individual expressions within block are `and`-ed together `#1249`
   - The documentation for the "exclude" section in the github code host connection schema has been clarified to explain that each block is OR'd together, and the expressions within each block are AND'd together.
-- Fix Azure Devops OnPrem connection editing and repo name [#1184](https://github.com/sourcegraph/sourcegraph/pull/1184)
-- The sync of a GitHub repositoryQuery failing will no longer cause repos to be deleted [#1177](https://github.com/sourcegraph/sourcegraph/pull/1177)
+- Fix Azure Devops OnPrem connection editing and repo name `#1184`
+- The sync of a GitHub repositoryQuery failing will no longer cause repos to be deleted `#1177`
   - GitHub code host connections using `repositoryQuery` will no longer delete repositories if the sync fails for reasons like a GitHub outage or a token expiring.
 
 #### Sourcegraphaccounts
 
-- use native openidconnect provider [#1030](https://github.com/sourcegraph/sourcegraph/pull/1030)
+- use native openidconnect provider `#1030`
 
 #### Telemetry
 
-- only log Cody API events to a remote data store, do n… [#1304](https://github.com/sourcegraph/sourcegraph/pull/1304)
+- only log Cody API events to a remote data store, do n… `#1304`
 
 #### Telemetry-Gateway
 
-- fix configuration [#1129](https://github.com/sourcegraph/sourcegraph/pull/1129)
+- fix configuration `#1129`
 
 #### Tenant/Reconciler
 
-- avoid illegal state transitions [#1133](https://github.com/sourcegraph/sourcegraph/pull/1133)
-- double-check assigned instance ID [#1092](https://github.com/sourcegraph/sourcegraph/pull/1092)
-- try to audit log after tenant context creation [#1051](https://github.com/sourcegraph/sourcegraph/pull/1051)
+- avoid illegal state transitions `#1133`
+- double-check assigned instance ID `#1092`
+- try to audit log after tenant context creation `#1051`
 
 #### Workspaces
 
-- build full redirect_to URL [#1315](https://github.com/sourcegraph/sourcegraph/pull/1315)
-- apply 'secure headers' to SPA [#1313](https://github.com/sourcegraph/sourcegraph/pull/1313)
+- build full redirect_to URL `#1315`
+- apply 'secure headers' to SPA `#1313`
 
 #### Others
 
-- copy changes to prompt settings [#1286](https://github.com/sourcegraph/sourcegraph/pull/1286)
-- remove call to possibly nil error [#973](https://github.com/sourcegraph/sourcegraph/pull/973)
+- copy changes to prompt settings `#1286`
+- remove call to possibly nil error `#973`
 
 ### Chore
 
 #### Ci
 
-- add TAG_DB_TEST to all go_tests that depends on dbtest [#1288](https://github.com/sourcegraph/sourcegraph/pull/1288)
-- add test task in workflows for dbtest to run on postgres 16 agents [#1287](https://github.com/sourcegraph/sourcegraph/pull/1287)
-- use bazel 7.4.0 [#1284](https://github.com/sourcegraph/sourcegraph/pull/1284)
-- nix - update pg-utils for patch renames [#1172](https://github.com/sourcegraph/sourcegraph/pull/1172)
-- Move //client/svelte:e2e_test to Integration/E2E_test step [#1148](https://github.com/sourcegraph/sourcegraph/pull/1148)
-- upgrade platform rules [#1020](https://github.com/sourcegraph/sourcegraph/pull/1020)
-- move rustfmt flags to ci bazelrc [#1017](https://github.com/sourcegraph/sourcegraph/pull/1017)
-- upgrade rules_ts and rules_js [#1006](https://github.com/sourcegraph/sourcegraph/pull/1006)
-- upgrade aspect rules swc [#988](https://github.com/sourcegraph/sourcegraph/pull/988)
-- update rules rust v0.52.2 [#985](https://github.com/sourcegraph/sourcegraph/pull/985)
-- set test label prefix for backcompat tests [#984](https://github.com/sourcegraph/sourcegraph/pull/984)
-- upgrade rules_buf [#974](https://github.com/sourcegraph/sourcegraph/pull/974)
-- skip check if author is sg teammate [#969](https://github.com/sourcegraph/sourcegraph/pull/969)
-- bazel skylib 1.7.1 [#936](https://github.com/sourcegraph/sourcegraph/pull/936)
-- Upgrade rules_go, gazelle, buildifier_prebuilt & rules_proto [#791](https://github.com/sourcegraph/sourcegraph/pull/791)
+- add TAG_DB_TEST to all go_tests that depends on dbtest `#1288`
+- add test task in workflows for dbtest to run on postgres 16 agents `#1287`
+- use bazel 7.4.0 `#1284`
+- nix - update pg-utils for patch renames `#1172`
+- Move //client/svelte:e2e_test to Integration/E2E_test step `#1148`
+- upgrade platform rules `#1020`
+- move rustfmt flags to ci bazelrc `#1017`
+- upgrade rules_ts and rules_js `#1006`
+- upgrade aspect rules swc `#988`
+- update rules rust v0.52.2 `#985`
+- set test label prefix for backcompat tests `#984`
+- upgrade rules_buf `#974`
+- skip check if author is sg teammate `#969`
+- bazel skylib 1.7.1 `#936`
+- Upgrade rules_go, gazelle, buildifier_prebuilt & rules_proto `#791`
 
 #### Code Intelligence
 
-- Remove unused parameter [#1204](https://github.com/sourcegraph/sourcegraph/pull/1204)
-- Rename flag -update -> -update-jobs-snapshots [#1203](https://github.com/sourcegraph/sourcegraph/pull/1203)
-- Use HTTPError type in uploadhandler code paths [#1174](https://github.com/sourcegraph/sourcegraph/pull/1174)
-- Remove unused parameters [#1166](https://github.com/sourcegraph/sourcegraph/pull/1166)
-- Introduce new FileContentsMap type for clarity [#828](https://github.com/sourcegraph/sourcegraph/pull/828)
-- Use consistent casing for op strings [#789](https://github.com/sourcegraph/sourcegraph/pull/789)
-- Clarify state transitions in GetUsages [#755](https://github.com/sourcegraph/sourcegraph/pull/755)
+- Remove unused parameter `#1204`
+- Rename flag -update -> -update-jobs-snapshots `#1203`
+- Use HTTPError type in uploadhandler code paths `#1174`
+- Remove unused parameters `#1166`
+- Introduce new FileContentsMap type for clarity `#828`
+- Use consistent casing for op strings `#789`
+- Clarify state transitions in GetUsages `#755`
 
 #### Database
 
-- remove residual event_logs export stuff [#864](https://github.com/sourcegraph/sourcegraph/pull/864)
-- drop product_licenses and product_subscriptions [#264](https://github.com/sourcegraph/sourcegraph/pull/264)
+- remove residual event_logs export stuff `#864`
+- drop product_licenses and product_subscriptions `#264`
 
 #### Database
 
-- OOB migration for setting non-null columns via page [#885](https://github.com/sourcegraph/sourcegraph/pull/885)
+- OOB migration for setting non-null columns via page `#885`
   - An out of band migration is introduced to set slowly set the value of a new column on all tables. If you have a large postgres database for Sourcegraph (1tb+) please ensure you deploy 5.9 instead of doing a multi-version upgrade past it.
 
 #### Dev
 
-- Use clearer names in health server initialization [#1383](https://github.com/sourcegraph/sourcegraph/pull/1383)
-- Make syntactic-code-intel-worker config uniform [#1382](https://github.com/sourcegraph/sourcegraph/pull/1382)
-- Enable metrics for precise-code-intel-worker in dev [#1365](https://github.com/sourcegraph/sourcegraph/pull/1365)
-- Merge fileutil package into fsext [#1351](https://github.com/sourcegraph/sourcegraph/pull/1351)
-- Migrate gitserver APIs from fs.FileInfo to fsext.FileInfo [#1318](https://github.com/sourcegraph/sourcegraph/pull/1318)
-- Introduce new package with FileInfo type [#1317](https://github.com/sourcegraph/sourcegraph/pull/1317)
-- Document footguns around escaping trace data writers [#1291](https://github.com/sourcegraph/sourcegraph/pull/1291)
-- Rename errors.ErrCollector -> errors.Collector [#1265](https://github.com/sourcegraph/sourcegraph/pull/1265)
-- Introduce new o11y-friendly RichError interface [#1264](https://github.com/sourcegraph/sourcegraph/pull/1264)
-- Replace WithErrors -> With for simplicity [#1261](https://github.com/sourcegraph/sourcegraph/pull/1261)
-- Generalize 'observation.With' for custom errors [#1233](https://github.com/sourcegraph/sourcegraph/pull/1233)
+- Use clearer names in health server initialization `#1383`
+- Make syntactic-code-intel-worker config uniform `#1382`
+- Enable metrics for precise-code-intel-worker in dev `#1365`
+- Merge fileutil package into fsext `#1351`
+- Migrate gitserver APIs from fs.FileInfo to fsext.FileInfo `#1318`
+- Introduce new package with FileInfo type `#1317`
+- Document footguns around escaping trace data writers `#1291`
+- Rename errors.ErrCollector -> errors.Collector `#1265`
+- Introduce new o11y-friendly RichError interface `#1264`
+- Replace WithErrors -> With for simplicity `#1261`
+- Generalize 'observation.With' for custom errors `#1233`
 
 #### Gitserver
 
-- Inline one-liner for error checking [#1108](https://github.com/sourcegraph/sourcegraph/pull/1108)
+- Inline one-liner for error checking `#1108`
 
 #### Msp
 
-- upgrade openfga dependency [#1357](https://github.com/sourcegraph/sourcegraph/pull/1357)
+- upgrade openfga dependency `#1357`
 
 #### Mt-Router
 
-- disable proxy for s2 [#1186](https://github.com/sourcegraph/sourcegraph/pull/1186)
-- use bazel to run generator [#1065](https://github.com/sourcegraph/sourcegraph/pull/1065)
-- setup sentry for stage environment [#1064](https://github.com/sourcegraph/sourcegraph/pull/1064)
-- add scripts to interact with local kv [#1056](https://github.com/sourcegraph/sourcegraph/pull/1056)
+- disable proxy for s2 `#1186`
+- use bazel to run generator `#1065`
+- setup sentry for stage environment `#1064`
+- add scripts to interact with local kv `#1056`
 
 #### Search
 
-- (new web ui) Enable new web UI by default [#1373](https://github.com/sourcegraph/sourcegraph/pull/1373)
-- fix description for KUBERNETES_JOB_STEP_IMAGE [#1360](https://github.com/sourcegraph/sourcegraph/pull/1360)
-- Remove all non-single job pod code from Executors on Kubernetes. [#1163](https://github.com/sourcegraph/sourcegraph/pull/1163)
+- (new web ui) Enable new web UI by default `#1373`
+- fix description for KUBERNETES_JOB_STEP_IMAGE `#1360`
+- Remove all non-single job pod code from Executors on Kubernetes. `#1163`
   - The environment variable `KUBERNETES_SINGLE_JOB_STEP_IMAGE` is now `KUBERNETES_JOB_STEP_IMAGE`.
   - Both environment variables are read, with preference given to `KUBERNETES_JOB_STEP_IMAGE`, to preserve backward compatibility, but reading of `KUBERNETES_SINGLE_JOB_STEP_IMAGE` may be removed in a future version.
-- (new web ui) Improve search input CSS [#962](https://github.com/sourcegraph/sourcegraph/pull/962)
+- (new web ui) Improve search input CSS `#962`
 
 #### Security
 
-- Update rules_apko and fix issues with sg wolfi v2 [#901](https://github.com/sourcegraph/sourcegraph/pull/901)
+- Update rules_apko and fix issues with sg wolfi v2 `#901`
   - Build containers using latest version of apko and rules_apko
 
 #### Telemetry
 
-- report token usage per request to telemetry [#1165](https://github.com/sourcegraph/sourcegraph/pull/1165)
+- report token usage per request to telemetry `#1165`
   - Added LLM token usage telemetry
 
 #### Telemetrygatewayexporter
 
-- bump default TELEMETRY_GATEWAY_EXPORTER_EXPORT_INTERVAL [#1303](https://github.com/sourcegraph/sourcegraph/pull/1303)
+- bump default TELEMETRY_GATEWAY_EXPORTER_EXPORT_INTERVAL `#1303`
 
 #### Telemetrytest
 
-- add working example [#1274](https://github.com/sourcegraph/sourcegraph/pull/1274)
+- add working example `#1274`
 
 #### Others
 
-- fix storybook [#1335](https://github.com/sourcegraph/sourcegraph/pull/1335)
-- add searchSource to new search events [#1306](https://github.com/sourcegraph/sourcegraph/pull/1306)
-- make core-services internal/telemetry codeowners [#1272](https://github.com/sourcegraph/sourcegraph/pull/1272)
-- upgrade Mocha from 8.3.4 to ^10 [#1246](https://github.com/sourcegraph/sourcegraph/pull/1246)
-- move web app into child layout group to make room for embedded pages [#1128](https://github.com/sourcegraph/sourcegraph/pull/1128)
-- run prettier [#906](https://github.com/sourcegraph/sourcegraph/pull/906)
-- Upgrade hermetic cc toolchain [#844](https://github.com/sourcegraph/sourcegraph/pull/844)
-- upgrade rules_oci [#818](https://github.com/sourcegraph/sourcegraph/pull/818)
+- fix storybook `#1335`
+- add searchSource to new search events `#1306`
+- make core-services internal/telemetry codeowners `#1272`
+- upgrade Mocha from 8.3.4 to ^10 `#1246`
+- move web app into child layout group to make room for embedded pages `#1128`
+- run prettier `#906`
+- Upgrade hermetic cc toolchain `#844`
+- upgrade rules_oci `#818`
 
 ### Test
 
 #### Others
 
-- implement structure for e2e tests [#108](https://github.com/sourcegraph/sourcegraph/pull/108)
+- implement structure for e2e tests `#108`
 
 ### Refactor
 
 #### Cody-Gateway
 
-- support max_completion_tokens for o1 models [#947](https://github.com/sourcegraph/sourcegraph/pull/947)
+- support max_completion_tokens for o1 models `#947`
   - refactor(cody-gateway): support max_completion_tokens for o1 models
 
 #### Search
 
-- (new web ui) Update folder page table styling [#1221](https://github.com/sourcegraph/sourcegraph/pull/1221)
+- (new web ui) Update folder page table styling `#1221`
 
 #### Others
 
-- move all business logic out of context resolvers [#821](https://github.com/sourcegraph/sourcegraph/pull/821)
+- move all business logic out of context resolvers `#821`
 
 ### Reverts
 
-- revert filtering out deprecated models on server [#-1](https://github.com/sourcegraph/sourcegraph/pull/1267)
+- revert filtering out deprecated models on server `#1267`
 
 ### Uncategorized
 
 #### Others
 
-- [Backport 5.9.x] oob: Run without tenant iterator for older versions [#1429](https://github.com/sourcegraph/sourcegraph/pull/1429)
-- Release: Prep stitched migration graph for release (#1388) [#1389](https://github.com/sourcegraph/sourcegraph/pull/1389)
+- [Backport 5.9.x] oob: Run without tenant iterator for older versions `#1429`
+- Release: Prep stitched migration graph for release (#1388) `#1389`
   - n/a
-- Move cody.serverSideContext out of experimentalFeatures in site config [#1385](https://github.com/sourcegraph/sourcegraph/pull/1385)
-- bugfix: add key to search result file header [#1374](https://github.com/sourcegraph/sourcegraph/pull/1374)
-- gitserver: Parse LastChanged, LastFetched as nulltime [#1372](https://github.com/sourcegraph/sourcegraph/pull/1372)
-- add code llama 7B model for ab test [#1371](https://github.com/sourcegraph/sourcegraph/pull/1371)
+- Move cody.serverSideContext out of experimentalFeatures in site config `#1385`
+- bugfix: add key to search result file header `#1374`
+- gitserver: Parse LastChanged, LastFetched as nulltime `#1372`
+- add code llama 7B model for ab test `#1371`
   - adding code llama 7B for completions
-- Hide auto submit checkbox and add promoted badge [#1367](https://github.com/sourcegraph/sourcegraph/pull/1367)
-- Enable reranker by default if Gateway is enabled [#1366](https://github.com/sourcegraph/sourcegraph/pull/1366)
+- Hide auto submit checkbox and add promoted badge `#1367`
+- Enable reranker by default if Gateway is enabled `#1366`
   - Cody Chat: the context engine now uses the reranker by default everywhere where Cody Gateway is enabled.
-- db: Set default permissions to RLS user as well [#1362](https://github.com/sourcegraph/sourcegraph/pull/1362)
-- Remove promote-to-public dependency on bazel-push-images step [#1356](https://github.com/sourcegraph/sourcegraph/pull/1356)
-- release: Only fail SBOM step if all uploads fail [#1355](https://github.com/sourcegraph/sourcegraph/pull/1355)
-- source: Fix code host connection editor validation [#1354](https://github.com/sourcegraph/sourcegraph/pull/1354)
-- bugfix: fix symbol tree hover selector [#1353](https://github.com/sourcegraph/sourcegraph/pull/1353)
-- dev: Exclude generated code from prettier [#1341](https://github.com/sourcegraph/sourcegraph/pull/1341)
-- Prompt library: fix input description for prompt name [#1337](https://github.com/sourcegraph/sourcegraph/pull/1337)
-- workspaces: Various mini fixes and a landing page [#1336](https://github.com/sourcegraph/sourcegraph/pull/1336)
-- tenant: Fix gRPC in local dev [#1334](https://github.com/sourcegraph/sourcegraph/pull/1334)
-- Reapply "worker: Fix configuration error reporting" [#1311](https://github.com/sourcegraph/sourcegraph/pull/1311)
-- Search: document choice for ZoektScoreBoost [#1310](https://github.com/sourcegraph/sourcegraph/pull/1310)
-- bugfix: escape file paths [#1308](https://github.com/sourcegraph/sourcegraph/pull/1308)
-- Change clickable elements to buttons [#1298](https://github.com/sourcegraph/sourcegraph/pull/1298)
-- Allow users to insert chips according to cursor position [#1296](https://github.com/sourcegraph/sourcegraph/pull/1296)
-- Change prompt creation flow feature flag name [#1294](https://github.com/sourcegraph/sourcegraph/pull/1294)
-- Pass Context to scip-syntax invocation to propagate cancellation [#1290](https://github.com/sourcegraph/sourcegraph/pull/1290)
-- gomod: bump Zoekt for metrics improvement [#1276](https://github.com/sourcegraph/sourcegraph/pull/1276)
-- Redis: rename RedisWrapper [#1273](https://github.com/sourcegraph/sourcegraph/pull/1273)
-- connectutil: UnexpectedError handler [#1271](https://github.com/sourcegraph/sourcegraph/pull/1271)
-- Add recommended flag to Prompt Templates [#1268](https://github.com/sourcegraph/sourcegraph/pull/1268)
+- db: Set default permissions to RLS user as well `#1362`
+- Remove promote-to-public dependency on bazel-push-images step `#1356`
+- release: Only fail SBOM step if all uploads fail `#1355`
+- source: Fix code host connection editor validation `#1354`
+- bugfix: fix symbol tree hover selector `#1353`
+- dev: Exclude generated code from prettier `#1341`
+- Prompt library: fix input description for prompt name `#1337`
+- workspaces: Various mini fixes and a landing page `#1336`
+- tenant: Fix gRPC in local dev `#1334`
+- Reapply "worker: Fix configuration error reporting" `#1311`
+- Search: document choice for ZoektScoreBoost `#1310`
+- bugfix: escape file paths `#1308`
+- Change clickable elements to buttons `#1298`
+- Allow users to insert chips according to cursor position `#1296`
+- Change prompt creation flow feature flag name `#1294`
+- Pass Context to scip-syntax invocation to propagate cancellation `#1290`
+- gomod: bump Zoekt for metrics improvement `#1276`
+- Redis: rename RedisWrapper `#1273`
+- connectutil: UnexpectedError handler `#1271`
+- Add recommended flag to Prompt Templates `#1268`
   - Adds ability to mark prompts as recommended and then sort the recommended prompts at the top.
-- bugfix: remove possibility of infinite recursion from the symbol tree [#1256](https://github.com/sourcegraph/sourcegraph/pull/1256)
-- Update cody web to 0.10.0 [#1254](https://github.com/sourcegraph/sourcegraph/pull/1254)
-- bugfix: use short OID for file popover [#1242](https://github.com/sourcegraph/sourcegraph/pull/1242)
-- Remove outdated install instructions for sg [#1227](https://github.com/sourcegraph/sourcegraph/pull/1227)
-- site: Fix missing unredaction in site config [#1226](https://github.com/sourcegraph/sourcegraph/pull/1226)
-- Update the sg docs link [#1225](https://github.com/sourcegraph/sourcegraph/pull/1225)
-- multi-tenant: support synchronized user sign-out [#1222](https://github.com/sourcegraph/sourcegraph/pull/1222)
-- sg: Fix db reset with default local settings [#1217](https://github.com/sourcegraph/sourcegraph/pull/1217)
-- db: Improve error message for failed version update [#1216](https://github.com/sourcegraph/sourcegraph/pull/1216)
-- Only push final images on specific default runtypes [#1211](https://github.com/sourcegraph/sourcegraph/pull/1211)
-- OpenaI completions response type fixing for gpt-3.5-turbo-instruct and gpt-4o-mini [#1207](https://github.com/sourcegraph/sourcegraph/pull/1207)
-- sg: Always run with lower privileges in dev [#1197](https://github.com/sourcegraph/sourcegraph/pull/1197)
-- tenant: Deactivate OOB migrations [#1192](https://github.com/sourcegraph/sourcegraph/pull/1192)
-- Update Enterprise footer link on dotcom [#1191](https://github.com/sourcegraph/sourcegraph/pull/1191)
-- bugfix: escape spaces in repo filter names [#1187](https://github.com/sourcegraph/sourcegraph/pull/1187)
+- bugfix: remove possibility of infinite recursion from the symbol tree `#1256`
+- Update cody web to 0.10.0 `#1254`
+- bugfix: use short OID for file popover `#1242`
+- Remove outdated install instructions for sg `#1227`
+- site: Fix missing unredaction in site config `#1226`
+- Update the sg docs link `#1225`
+- multi-tenant: support synchronized user sign-out `#1222`
+- sg: Fix db reset with default local settings `#1217`
+- db: Improve error message for failed version update `#1216`
+- Only push final images on specific default runtypes `#1211`
+- OpenaI completions response type fixing for gpt-3.5-turbo-instruct and gpt-4o-mini `#1207`
+- sg: Always run with lower privileges in dev `#1197`
+- tenant: Deactivate OOB migrations `#1192`
+- Update Enterprise footer link on dotcom `#1191`
+- bugfix: escape spaces in repo filter names `#1187`
   - Fixed a bug that would cause filters added from the search sidebar to not be correctly escaped
-- Attempt to fix flaky database test [#1181](https://github.com/sourcegraph/sourcegraph/pull/1181)
-- chore/search - Remove runner.Spec.Image and use command.Spec.Image instead [#1161](https://github.com/sourcegraph/sourcegraph/pull/1161)
-- dev: Disable otel in MT dev [#1157](https://github.com/sourcegraph/sourcegraph/pull/1157)
-- bug(release): remove semver check for release branch in `sg backport`  [#1156](https://github.com/sourcegraph/sourcegraph/pull/1156)
-- Make GetCodyContextAlternatives usable for evals [#1152](https://github.com/sourcegraph/sourcegraph/pull/1152)
-- multi-tenant: list workspaces for the authenticated user [#1146](https://github.com/sourcegraph/sourcegraph/pull/1146)
-- saml: Prevent logspam from context cancel [#1143](https://github.com/sourcegraph/sourcegraph/pull/1143)
-- sg: Update localdev migration [#1132](https://github.com/sourcegraph/sourcegraph/pull/1132)
-- tenant: Exclude product subscription tables from OOB migrator [#1124](https://github.com/sourcegraph/sourcegraph/pull/1124)
-- Add prompt mode [#1123](https://github.com/sourcegraph/sourcegraph/pull/1123)
+- Attempt to fix flaky database test `#1181`
+- chore/search - Remove runner.Spec.Image and use command.Spec.Image instead `#1161`
+- dev: Disable otel in MT dev `#1157`
+- bug(release): remove semver check for release branch in `sg backport`  `#1156`
+- Make GetCodyContextAlternatives usable for evals `#1152`
+- multi-tenant: list workspaces for the authenticated user `#1146`
+- saml: Prevent logspam from context cancel `#1143`
+- sg: Update localdev migration `#1132`
+- tenant: Exclude product subscription tables from OOB migrator `#1124`
+- Add prompt mode `#1123`
   - Adds mode (CHAT, EDIT, INSERT) to prompt.
-- gitserver: Clarify annotated tags behavior in ResolveRevision [#1107](https://github.com/sourcegraph/sourcegraph/pull/1107)
-- Rate limit: rename GlobalLimiter to DistributedLimiter [#1100](https://github.com/sourcegraph/sourcegraph/pull/1100)
-- Rate limit: make GlobalLimiter tenant-aware [#1099](https://github.com/sourcegraph/sourcegraph/pull/1099)
-- saml: Fix nil panic [#1098](https://github.com/sourcegraph/sourcegraph/pull/1098)
-- tenant: Disable migrator for ranking tables [#1097](https://github.com/sourcegraph/sourcegraph/pull/1097)
-- Rate limit: avoid using KeyValue within GlobalLimiter [#1082](https://github.com/sourcegraph/sourcegraph/pull/1082)
-- Rate limit: simplify inMemoryLimiter [#1081](https://github.com/sourcegraph/sourcegraph/pull/1081)
-- tenant: Use frozen schema for OOB migration [#1077](https://github.com/sourcegraph/sourcegraph/pull/1077)
-- Make user emails soft-deletable [#1071](https://github.com/sourcegraph/sourcegraph/pull/1071)
-- Fix prompt duplication name [#1067](https://github.com/sourcegraph/sourcegraph/pull/1067)
-- sg: Add no-open flag to workspaces create [#1057](https://github.com/sourcegraph/sourcegraph/pull/1057)
-- Creating/Editing Prompts Re-design [#1054](https://github.com/sourcegraph/sourcegraph/pull/1054)
+- gitserver: Clarify annotated tags behavior in ResolveRevision `#1107`
+- Rate limit: rename GlobalLimiter to DistributedLimiter `#1100`
+- Rate limit: make GlobalLimiter tenant-aware `#1099`
+- saml: Fix nil panic `#1098`
+- tenant: Disable migrator for ranking tables `#1097`
+- Rate limit: avoid using KeyValue within GlobalLimiter `#1082`
+- Rate limit: simplify inMemoryLimiter `#1081`
+- tenant: Use frozen schema for OOB migration `#1077`
+- Make user emails soft-deletable `#1071`
+- Fix prompt duplication name `#1067`
+- sg: Add no-open flag to workspaces create `#1057`
+- Creating/Editing Prompts Re-design `#1054`
   - The prompt creation/edit page has been redesigned.
-- GraphQL: remove anonymous rate limiter [#1052](https://github.com/sourcegraph/sourcegraph/pull/1052)
-- oob: Make out of band migration runner tenant-aware [#1047](https://github.com/sourcegraph/sourcegraph/pull/1047)
-- Fix the CTA to point to chat [#1044](https://github.com/sourcegraph/sourcegraph/pull/1044)
-- Fix bug where text pushed buttons out of the container [#1043](https://github.com/sourcegraph/sourcegraph/pull/1043)
-- dev: Implement wrangler router provider [#1035](https://github.com/sourcegraph/sourcegraph/pull/1035)
-- router: Ensure HTTPS protocol on auth redirect [#1034](https://github.com/sourcegraph/sourcegraph/pull/1034)
-- workspaces: Fix race condition registering state listener [#1033](https://github.com/sourcegraph/sourcegraph/pull/1033)
-- dev: Introduce devDNS helper to resolve testdomains [#1029](https://github.com/sourcegraph/sourcegraph/pull/1029)
-- Add ability to duplicate existing prompts [#1022](https://github.com/sourcegraph/sourcegraph/pull/1022)
+- GraphQL: remove anonymous rate limiter `#1052`
+- oob: Make out of band migration runner tenant-aware `#1047`
+- Fix the CTA to point to chat `#1044`
+- Fix bug where text pushed buttons out of the container `#1043`
+- dev: Implement wrangler router provider `#1035`
+- router: Ensure HTTPS protocol on auth redirect `#1034`
+- workspaces: Fix race condition registering state listener `#1033`
+- dev: Introduce devDNS helper to resolve testdomains `#1029`
+- Add ability to duplicate existing prompts `#1022`
   - Users can now duplicate existing prompts.
-- GraphQL: simplify rate limit interface [#1021](https://github.com/sourcegraph/sourcegraph/pull/1021)
-- Add autoSubmit & includeViewerDrafts to Cody prompts [#1003](https://github.com/sourcegraph/sourcegraph/pull/1003)
+- GraphQL: simplify rate limit interface `#1021`
+- Add autoSubmit & includeViewerDrafts to Cody prompts `#1003`
   - Adds options to set prompts to "Auto Submit", which would automatically execute the prompts in one-click.
-- vsce: patch release v2.2.19 [#1002](https://github.com/sourcegraph/sourcegraph/pull/1002)
-- workspacesreconciler: fix grpc tls transport [#1000](https://github.com/sourcegraph/sourcegraph/pull/1000)
-- tenant: Move externalhttp to separate package [#996](https://github.com/sourcegraph/sourcegraph/pull/996)
-- goroutine: reenable recording when multitenancy is enabled [#995](https://github.com/sourcegraph/sourcegraph/pull/995)
-- Rename globaldbtenant to servicetenant [#994](https://github.com/sourcegraph/sourcegraph/pull/994)
-- ci/mt-router: add bazel build [#990](https://github.com/sourcegraph/sourcegraph/pull/990)
-- Search: populate rev in select repo [#989](https://github.com/sourcegraph/sourcegraph/pull/989)
-- Search: correct has.commit.after query example [#987](https://github.com/sourcegraph/sourcegraph/pull/987)
-- mt-router: import repo [#986](https://github.com/sourcegraph/sourcegraph/pull/986)
-- tenant: add mt-router to local dev [#968](https://github.com/sourcegraph/sourcegraph/pull/968)
-- tenant: Remove tenant auth redirect in monolith [#967](https://github.com/sourcegraph/sourcegraph/pull/967)
-- Do not fail if link parsing fails in relative fix processing [#966](https://github.com/sourcegraph/sourcegraph/pull/966)
-- dev/msp: improve tfc creation error message [#964](https://github.com/sourcegraph/sourcegraph/pull/964)
-- goroutine: remove unused support for concurrency [#963](https://github.com/sourcegraph/sourcegraph/pull/963)
-- ci: Bump backcompat test target to 5.8.0 [#954](https://github.com/sourcegraph/sourcegraph/pull/954)
-- tenant: Mark tenant as initialized in db [#950](https://github.com/sourcegraph/sourcegraph/pull/950)
-- bug(release): workspace cash time dance [#948](https://github.com/sourcegraph/sourcegraph/pull/948)
-- tenant: Fix missing tenant in auth check [#933](https://github.com/sourcegraph/sourcegraph/pull/933)
-- db: Use non-superuser in DB tests [#930](https://github.com/sourcegraph/sourcegraph/pull/930)
-- db: Migrator can provision RLS user permissions [#919](https://github.com/sourcegraph/sourcegraph/pull/919)
-- ci: Bump backcompat target to 5.7 [#916](https://github.com/sourcegraph/sourcegraph/pull/916)
-- sg: Add default tenant to hosts [#915](https://github.com/sourcegraph/sourcegraph/pull/915)
-- remove "Don't commit private code yet" from PR template [#908](https://github.com/sourcegraph/sourcegraph/pull/908)
-- "Prompt Library" in navbar (capitalize the L for consistency) [#907](https://github.com/sourcegraph/sourcegraph/pull/907)
-- Blob View: Ensure copy button copies full path and not displayed path [#903](https://github.com/sourcegraph/sourcegraph/pull/903)
+- vsce: patch release v2.2.19 `#1002`
+- workspacesreconciler: fix grpc tls transport `#1000`
+- tenant: Move externalhttp to separate package `#996`
+- goroutine: reenable recording when multitenancy is enabled `#995`
+- Rename globaldbtenant to servicetenant `#994`
+- ci/mt-router: add bazel build `#990`
+- Search: populate rev in select repo `#989`
+- Search: correct has.commit.after query example `#987`
+- mt-router: import repo `#986`
+- tenant: add mt-router to local dev `#968`
+- tenant: Remove tenant auth redirect in monolith `#967`
+- Do not fail if link parsing fails in relative fix processing `#966`
+- dev/msp: improve tfc creation error message `#964`
+- goroutine: remove unused support for concurrency `#963`
+- ci: Bump backcompat test target to 5.8.0 `#954`
+- tenant: Mark tenant as initialized in db `#950`
+- bug(release): workspace cash time dance `#948`
+- tenant: Fix missing tenant in auth check `#933`
+- db: Use non-superuser in DB tests `#930`
+- db: Migrator can provision RLS user permissions `#919`
+- ci: Bump backcompat target to 5.7 `#916`
+- sg: Add default tenant to hosts `#915`
+- remove "Don't commit private code yet" from PR template `#908`
+- "Prompt Library" in navbar (capitalize the L for consistency) `#907`
+- Blob View: Ensure copy button copies full path and not displayed path `#903`
   - Fixes a bug where certain copy path buttons were only copying the visible path and not the full path of a file.
-- sg: Fix reference to deleted table in localdev MT migration [#898](https://github.com/sourcegraph/sourcegraph/pull/898)
-- tenant: Separate store package and create tenant1, tenant2 via workspaces [#897](https://github.com/sourcegraph/sourcegraph/pull/897)
-- Tenant: skip some global Prometheus metrics [#892](https://github.com/sourcegraph/sourcegraph/pull/892)
-- sg: Fix startup of workspaces service [#891](https://github.com/sourcegraph/sourcegraph/pull/891)
-- ci: do not run executors e2e for eph [#886](https://github.com/sourcegraph/sourcegraph/pull/886)
-- Perforce IP enforcement integration test [#876](https://github.com/sourcegraph/sourcegraph/pull/876)
-- goroutine: Make iterator required [#875](https://github.com/sourcegraph/sourcegraph/pull/875)
-- dev/msp: add project id validation [#874](https://github.com/sourcegraph/sourcegraph/pull/874)
-- db: Drop unused user_public_repos table [#873](https://github.com/sourcegraph/sourcegraph/pull/873)
-- Deprecate long-running OOB migrations [#872](https://github.com/sourcegraph/sourcegraph/pull/872)
-- lib/cloudapi: add support for multi tenant mode [#871](https://github.com/sourcegraph/sourcegraph/pull/871)
-- event_logs: add new `aggregatedMetrics` ping [#869](https://github.com/sourcegraph/sourcegraph/pull/869)
-- Redis: refactor rcache interface [#860](https://github.com/sourcegraph/sourcegraph/pull/860)
-- Add extra reranker metrics to Gateway events [#838](https://github.com/sourcegraph/sourcegraph/pull/838)
-- Sourcegraph teammate approval GH action [#824](https://github.com/sourcegraph/sourcegraph/pull/824)
-- Redis: remove KEYS call in completions token usage [#820](https://github.com/sourcegraph/sourcegraph/pull/820)
-- tenant: Properly initialize RBAC [#754](https://github.com/sourcegraph/sourcegraph/pull/754)
-- sg: Provision RLS user during setup [#749](https://github.com/sourcegraph/sourcegraph/pull/749)
-- tenant: Add database migration to enable RLS policies [#743](https://github.com/sourcegraph/sourcegraph/pull/743)
-- tenant: Add workspace ID and display name [#741](https://github.com/sourcegraph/sourcegraph/pull/741)
-- tenant: Check that all tables have RLS policy set [#734](https://github.com/sourcegraph/sourcegraph/pull/734)
-- tenant: Simplify dev migration [#726](https://github.com/sourcegraph/sourcegraph/pull/726)
-- db: Mark tenant_id columns as non-nullable [#707](https://github.com/sourcegraph/sourcegraph/pull/707)
-- feature: add internal/tracelog: a log.Logger that only logs if tracing is enabled [#634](https://github.com/sourcegraph/sourcegraph/pull/634)
+- sg: Fix reference to deleted table in localdev MT migration `#898`
+- tenant: Separate store package and create tenant1, tenant2 via workspaces `#897`
+- Tenant: skip some global Prometheus metrics `#892`
+- sg: Fix startup of workspaces service `#891`
+- ci: do not run executors e2e for eph `#886`
+- Perforce IP enforcement integration test `#876`
+- goroutine: Make iterator required `#875`
+- dev/msp: add project id validation `#874`
+- db: Drop unused user_public_repos table `#873`
+- Deprecate long-running OOB migrations `#872`
+- lib/cloudapi: add support for multi tenant mode `#871`
+- event_logs: add new `aggregatedMetrics` ping `#869`
+- Redis: refactor rcache interface `#860`
+- Add extra reranker metrics to Gateway events `#838`
+- Sourcegraph teammate approval GH action `#824`
+- Redis: remove KEYS call in completions token usage `#820`
+- tenant: Properly initialize RBAC `#754`
+- sg: Provision RLS user during setup `#749`
+- tenant: Add database migration to enable RLS policies `#743`
+- tenant: Add workspace ID and display name `#741`
+- tenant: Check that all tables have RLS policy set `#734`
+- tenant: Simplify dev migration `#726`
+- db: Mark tenant_id columns as non-nullable `#707`
+- feature: add internal/tracelog: a log.Logger that only logs if tracing is enabled `#634`
   - Added a new `internal/tracelog` package that provides a conditional logger for tracing. This logger only logs when tracing is enabled, improving performance by reducing unnecessary logging.
-- Hackathon: SBOMs feat. bazel [#566](https://github.com/sourcegraph/sourcegraph/pull/566)
+- Hackathon: SBOMs feat. bazel `#566`
   - feature(security): Publish SBOMs for Sourcegraph releases
-- tenant: Unique constraint migration [#430](https://github.com/sourcegraph/sourcegraph/pull/430)
-- security: Auto-update package lockfiles for Sourcegraph base images [#246](https://github.com/sourcegraph/sourcegraph/pull/246)
-- (feature): site-config: add ipParseCacheSize to schema for enforce IP restrictions schema [#220](https://github.com/sourcegraph/sourcegraph/pull/220)
+- tenant: Unique constraint migration `#430`
+- security: Auto-update package lockfiles for Sourcegraph base images `#246`
+- (feature): site-config: add ipParseCacheSize to schema for enforce IP restrictions schema `#220`
   - Added a new `ipParseCacheSize` configuration option for sub-repo permissions to control the caching of Perforce "Host" to IP address translations.
-- feature/source: implement core logic for parsing / evaluating Perforce IP addresses for sub repo permissions [#46](https://github.com/sourcegraph/sourcegraph/pull/46)
+- feature/source: implement core logic for parsing / evaluating Perforce IP addresses for sub repo permissions `#46`
   - For the Perforce IP permissions implementation, this PR introduces machinery that implements the ability to parse the [IP address expressions from the perforce protections table](https://www.perforce.com/manuals/p4sag/Content/P4SAG/protections.set.html#IP_address) and compare them against the user's IP address (that's advertised from the incoming X-FORWARDED-FOR header.Namely, this PR:
   - Introduced parsePerforceIPString, which parses Perforce IP strings (e.g., CIDR expressions, specific IP addresses) into an ipMatcher for IP validation.
   - Implemented multiple ipMatcher types, including:
@@ -1451,17 +1451,17 @@ Standard ML, Visual Basic, Pkl, Hack, MATLAB etc.
   - Added toggleableIPMatcher, which either enables or disables IP enforcement based on site configuration settings.
   - Created matcherCache for caching recent IP string to ipMatcher translations, improving efficiency.
   - Updated NewRequestClientIPSource to properly derive IP from the x-forwarded-for header.
-- feature/site-config: add site configuration setting for enforcing IP restrictions [#45](https://github.com/sourcegraph/sourcegraph/pull/45)
+- feature/site-config: add site configuration setting for enforcing IP restrictions `#45`
   - Added enforceIPRestrictions setting to the SubRepoPermissions section in site configuration, allowing IP-based enforcement using the X-FORWARDED-FOR header.Updated JSON schema to require SubRepoPermissions to be enabled when enforceIPRestrictions is enabled.Added validation in Perforce external service configuration to ensure IgnoreRulesWithHost and enforceIPRestrictions cannot be enabled simultaneously.Updated internal implementation to associate each Perforce rule with an IPMatcher for IP-based rule enforcement.
-- feature/plumbing: sub_repo_perms: do pumbling to thread comparing IP addresses alongside paths [#23](https://github.com/sourcegraph/sourcegraph/pull/23)
+- feature/plumbing: sub_repo_perms: do pumbling to thread comparing IP addresses alongside paths `#23`
   -
 
 ### Untracked
 
 The following PRs were merged onto the previous release branch but could not be automatically mapped to a corresponding commit in this release:
 
-- check for external dbs (#1083) [#1121](https://github.com/sourcegraph/sourcegraph/pull/1121)
-- bug(release): workspace cash time dance (#948) [#949](https://github.com/sourcegraph/sourcegraph/pull/949)
+- check for external dbs (#1083) `#1121`
+- bug(release): workspace cash time dance (#948) `#949`
 
 {/* RSS={"version":"v5.9.0", "releasedAt": "2024-11-04"} */}
 
@@ -1479,23 +1479,23 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Telemetry
 
-- check for external dbs (#1083) [#1121](https://github.com/sourcegraph/sourcegraph/pull/1121)
+- check for external dbs (#1083) `#1121`
 
 ### Fix
 
 #### Search
 
-- Fix Apollo related error in Safari [#1016](https://github.com/sourcegraph/sourcegraph/pull/1016)
+- Fix Apollo related error in Safari `#1016`
 
 #### Others
 
-- Fix OOB migration for batch changes table [#1113](https://github.com/sourcegraph/sourcegraph/pull/1113)
+- Fix OOB migration for batch changes table `#1113`
 
 ### Chore
 
 #### Security
 
-- upgrade src-cli version to address CVE [#1117](https://github.com/sourcegraph/sourcegraph/pull/1117)
+- upgrade src-cli version to address CVE `#1117`
   - Upgrade src-cli version to 5.8.1 to address CVE-2024-24788, CVE-2024-24790, CVE-2024-34156 Backport b8da20f6fa148f30fe97d9267a536bd5a84502f1 from #1112
 
 ### Reverts
@@ -1506,9 +1506,9 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Others
 
-- Backport 566 to 5.8.x: SBOMs with Bazel [#1089](https://github.com/sourcegraph/sourcegraph/pull/1089)
+- Backport 566 to 5.8.x: SBOMs with Bazel `#1089`
   - feature(security): Publish SBOMs for Sourcegraph releases
-- [Backport 5.8.x] Update src-cli MinimumVersion from 5.5.0 to 5.8.1 [#1087](https://github.com/sourcegraph/sourcegraph/pull/1087)
+- [Backport 5.8.x] Update src-cli MinimumVersion from 5.5.0 to 5.8.1 `#1087`
   - chore(release): Update minimum supported version of src-cli to 5.8.1 Backport 8f039bdcb5425071dd6e4dfddfb2cb436e124b05 from #1079
 
 {/* RSS={"version":"sourcegraph 5 Release 8 Patch 1", "releasedAt": "2024-10-16"} */}
@@ -1525,598 +1525,598 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Accessrequests
 
-- Allow to file another request when original one has been processed [#416](https://github.com/sourcegraph/sourcegraph/pull/416)
+- Allow to file another request when original one has been processed `#416`
 
 #### Appliance
 
-- refactor install flow, status, state, stage [#352](https://github.com/sourcegraph/sourcegraph/pull/352)
+- refactor install flow, status, state, stage `#352`
 
 #### Batch Changes
 
-- verbose error logging for batch syncer with BATCH_CHANGES_SYNCER_VERBOSE_ERROR_LOGGING [#639](https://github.com/sourcegraph/sourcegraph/pull/639)
+- verbose error logging for batch syncer with BATCH_CHANGES_SYNCER_VERBOSE_ERROR_LOGGING `#639`
   - feat(batches): verbose error logging for batch syncer with BATCH_CHANGES_SYNCER_VERBOSE_ERROR_LOGGING
-- add experimental feature to add a fork name suffix to avoid name collisions [#230](https://github.com/sourcegraph/sourcegraph/pull/230)
+- add experimental feature to add a fork name suffix to avoid name collisions `#230`
   - feat(batches): add experimental feature to add a fork name suffix to avoid name collisions
 
 #### Ci
 
-- enable workflows telemetry [#774](https://github.com/sourcegraph/sourcegraph/pull/774)
+- enable workflows telemetry `#774`
   - enable aspect workflows ci telemetry
-- convert onconflict gen to bazel [#486](https://github.com/sourcegraph/sourcegraph/pull/486)
+- convert onconflict gen to bazel `#486`
   - generate `constraints.go` using bazel for onconflict linter
 
 #### Search
 
-- (new web ui) Prefill search input with selected text when pressing '/' [#577](https://github.com/sourcegraph/sourcegraph/pull/577)
+- (new web ui) Prefill search input with selected text when pressing '/' `#577`
 
 #### Code Intelligence
 
-- Updates the autoindexing images for TypeScript and Ruby [#805](https://github.com/sourcegraph/sourcegraph/pull/805)
+- Updates the autoindexing images for TypeScript and Ruby `#805`
   - TypeScript: Fixes references to object properties in various places
   - Ruby: Fixes references to `Opus::` in Ruby tests
-- Syntactic indexing go evaluation suite and fix tests on CI in general [#482](https://github.com/sourcegraph/sourcegraph/pull/482)
+- Syntactic indexing go evaluation suite and fix tests on CI in general `#482`
 
 #### Cody
 
-- update public OpenAPI spec [#796](https://github.com/sourcegraph/sourcegraph/pull/796)
-- add basic support for server-rendered prompts [#723](https://github.com/sourcegraph/sourcegraph/pull/723)
+- update public OpenAPI spec `#796`
+- add basic support for server-rendered prompts `#723`
   - `/.api/completions/stream` endpoint now accepts `"file"` and `"repo"` parts alongside `"text"` and `"image_url"`
-- add vision support [#546](https://github.com/sourcegraph/sourcegraph/pull/546)`/.api/completions/stream` now supports vision using the OpenAI-compatible base64 encoding of images. Example `"content": [{"type": "image_url", "image_url": { "url": "data:image/png;base64,{{IMAGE_BASE64}}" } }]`. Requires the query parameter `api-version=3` or higher.
-- document internal APIs with TypeSpec/OpenAPI [#505](https://github.com/sourcegraph/sourcegraph/pull/505)
+- add vision support `#546``/.api/completions/stream` now supports vision using the OpenAI-compatible base64 encoding of images. Example `"content": [{"type": "image_url", "image_url": { "url": "data:image/png;base64,{{IMAGE_BASE64}}" } }]`. Requires the query parameter `api-version=3` or higher.
+- document internal APIs with TypeSpec/OpenAPI `#505`
 
 #### Cody-Gateway
 
-- log requestinteraction in events [#814](https://github.com/sourcegraph/sourcegraph/pull/814)
+- log requestinteraction in events `#814`
 
 #### Database
 
-- bestEffortForce will kill blocking transactions in migrator [#781](https://github.com/sourcegraph/sourcegraph/pull/781)
+- bestEffortForce will kill blocking transactions in migrator `#781`
   - DB Migrator is given the ability to automatically run pg_terminate_backend on transactions blocking a migration. This is done best effort and is opt-in per migration.
 
 #### Dev
 
-- (new web UI) Make it easier to run tests without proxying [#798](https://github.com/sourcegraph/sourcegraph/pull/798)
-- add obvious 'target service' notice to `sg msp` commands [#725](https://github.com/sourcegraph/sourcegraph/pull/725)
+- (new web UI) Make it easier to run tests without proxying `#798`
+- add obvious 'target service' notice to `sg msp` commands `#725`
 
 #### Local
 
-- add cody-gateway version endpoints [#685](https://github.com/sourcegraph/sourcegraph/pull/685)
+- add cody-gateway version endpoints `#685`
   - add cody-gateway environments for subcommand `live`
-- sg - install pgvector [#520](https://github.com/sourcegraph/sourcegraph/pull/520)
+- sg - install pgvector `#520`
   - mac: install pgvector from sourcegraph/pgvector-12
   - ubuntu: install postgresql-12-pgvector
 
 #### Msp
 
-- make databasetest shared [#393](https://github.com/sourcegraph/sourcegraph/pull/393)
+- make databasetest shared `#393`
 
 #### Msp/Databaseutil
 
-- make 'upsert' package shared [#394](https://github.com/sourcegraph/sourcegraph/pull/394)
+- make 'upsert' package shared `#394`
 
 #### Release
 
-- remove test from promotion ci during release pipeline [#495](https://github.com/sourcegraph/sourcegraph/pull/495)
+- remove test from promotion ci during release pipeline `#495`
   - Remove upgradetest from the release promotion ci
-- Stop releases from going out if there's a PR with the release-blocker label [#472](https://github.com/sourcegraph/sourcegraph/pull/472)
+- Stop releases from going out if there's a PR with the release-blocker label `#472`
   - Allow PRs to block a release from going out 😈
-- use releaseregistry for release banner [REL-145] [#429](https://github.com/sourcegraph/sourcegraph/pull/429)
+- use releaseregistry for release banner [REL-145] `#429`
   - implement using the release-registry for the banner
 
 #### Search
 
-- bump Zoekt for ranking and memory improvements [#816](https://github.com/sourcegraph/sourcegraph/pull/816)
+- bump Zoekt for ranking and memory improvements `#816`
   - Reduce peak memory required for Zoekt indexing
   - Improve search ranking by using repo freshness as a scoring signal
-- (new web ui) Add split view support to commit page [#775](https://github.com/sourcegraph/sourcegraph/pull/775)
-- enable similarity search by default [#772](https://github.com/sourcegraph/sourcegraph/pull/772)
+- (new web ui) Add split view support to commit page `#775`
+- enable similarity search by default `#772`
   - With this change we rank repository search results by similarity. Before, repository search results were ordered by star count instead. This affects suggestions and repository search results. To disable this feature and return to the previous behavior, set `{ "experimentalFeatures": { "disableOrderBySimilarity": true}}` in global settings.
-- (new web ui) Add /cody/dashboard page [#764](https://github.com/sourcegraph/sourcegraph/pull/764)
-- (new web ui) Add account connection modal [#731](https://github.com/sourcegraph/sourcegraph/pull/731)
-- (new web ui) Image previews [#623](https://github.com/sourcegraph/sourcegraph/pull/623)
-- respect match order for search.results.repositories resolver [#575](https://github.com/sourcegraph/sourcegraph/pull/575)
+- (new web ui) Add /cody/dashboard page `#764`
+- (new web ui) Add account connection modal `#731`
+- (new web ui) Image previews `#623`
+- respect match order for search.results.repositories resolver `#575`
   - The GraphQL endpoint `search.results.repositories` now returns the list of repositories in the order of the matches we
 found. Before, repositories were sorted by id.
-- remove fzf star tiebreaker for repo suggestions [#541](https://github.com/sourcegraph/sourcegraph/pull/541)
-- preserve ranking for repo suggestions [#447](https://github.com/sourcegraph/sourcegraph/pull/447)
-- (Svelte) open documentation links in new tabs [#401](https://github.com/sourcegraph/sourcegraph/pull/401)
-- Open documentation links in a new tab [#359](https://github.com/sourcegraph/sourcegraph/pull/359)
+- remove fzf star tiebreaker for repo suggestions `#541`
+- preserve ranking for repo suggestions `#447`
+- (Svelte) open documentation links in new tabs `#401`
+- Open documentation links in a new tab `#359`
 
 #### Source
 
-- add ssh auth support for more code hosts [#615](https://github.com/sourcegraph/sourcegraph/pull/615)
+- add ssh auth support for more code hosts `#615`
   - BitBucket Cloud, BitBucket Server,  GitLab, Gerrit, Gitolite, AWS CodeCommit Azure DevOps code host connections now support configuring SSH key authentication from the UI instead of mounting from disk.
-- add support for ssh auth to github [#597](https://github.com/sourcegraph/sourcegraph/pull/597)
+- add support for ssh auth to github `#597`
   - GitHub and generic Git code host connections now support configuring SSH key authentication from the UI instead of mounting from disk.
-- Support Azure Devops Server (onPrem) with NTLM authentication [#217](https://github.com/sourcegraph/sourcegraph/pull/217)
+- Support Azure Devops Server (onPrem) with NTLM authentication `#217`
 
 #### Tenant
 
-- allow configuring host instance id [#826](https://github.com/sourcegraph/sourcegraph/pull/826)
-- add initial Workspaces reconciler [#594](https://github.com/sourcegraph/sourcegraph/pull/594)
+- allow configuring host instance id `#826`
+- add initial Workspaces reconciler `#594`
 
 #### Wolfi
 
-- update server + postgresql-12 images [#519](https://github.com/sourcegraph/sourcegraph/pull/519)
+- update server + postgresql-12 images `#519`
   - add pgvector to server and postgresql-12 images
-- add pgvector-12 package [#513](https://github.com/sourcegraph/sourcegraph/pull/513)
+- add pgvector-12 package `#513`
   - build and add pgvector extension
 
 #### Workspaces
 
-- implement integrations listworkspaces [#794](https://github.com/sourcegraph/sourcegraph/pull/794)
-- implement management listworkspaces [#793](https://github.com/sourcegraph/sourcegraph/pull/793)
-- delete workspace RPC [#729](https://github.com/sourcegraph/sourcegraph/pull/729)
-- add DB list workspaces [#728](https://github.com/sourcegraph/sourcegraph/pull/728)
-- add destroy state internally [#644](https://github.com/sourcegraph/sourcegraph/pull/644)
-- init database schemas, add Workspaces store handler [#395](https://github.com/sourcegraph/sourcegraph/pull/395)
-- add and demo notifications SDK [#356](https://github.com/sourcegraph/sourcegraph/pull/356)
+- implement integrations listworkspaces `#794`
+- implement management listworkspaces `#793`
+- delete workspace RPC `#729`
+- add DB list workspaces `#728`
+- add destroy state internally `#644`
+- init database schemas, add Workspaces store handler `#395`
+- add and demo notifications SDK `#356`
 
 #### Others
 
-- add reranker support to Cody Gateway [#670](https://github.com/sourcegraph/sourcegraph/pull/670)
-- Embeddings: v2 [#507](https://github.com/sourcegraph/sourcegraph/pull/507)
+- add reranker support to Cody Gateway `#670`
+- Embeddings: v2 `#507`
   - Introduce a new experimental embeddings index and context retriever.
-- make scip-syntax process multiple languages in a single invocation [#364](https://github.com/sourcegraph/sourcegraph/pull/364)
-- add OpenAI o1 models and early-access models support to Cody Gateway [#323](https://github.com/sourcegraph/sourcegraph/pull/323)
+- make scip-syntax process multiple languages in a single invocation `#364`
+- add OpenAI o1 models and early-access models support to Cody Gateway `#323`
   - [feat(code gateway): add support for OpenAI o1 models and early-access models handling.](feat: add OpenAI o1 models and early-access models support to Cody Gateway)
-- implements pagination for syntactic usages [#310](https://github.com/sourcegraph/sourcegraph/pull/310)
+- implements pagination for syntactic usages `#310`
 
 ### Fix
 
 #### Batch Changes
 
-- stamp the executor binary with version information [#665](https://github.com/sourcegraph/sourcegraph/pull/665)
+- stamp the executor binary with version information `#665`
   - override `internal/version.version` with `x_defs` at build time in executor
-- disabled "select all" checkbox if all nodes are already disabled [#483](https://github.com/sourcegraph/sourcegraph/pull/483)
+- disabled "select all" checkbox if all nodes are already disabled `#483`
   - fix(batches): disabled "select all" checkbox if all nodes are already disabled
 
 #### Ci
 
-- add runfile initialization to upgradetest file [#890](https://github.com/sourcegraph/sourcegraph/pull/890)
-- use generated json in migrations filegroup [#802](https://github.com/sourcegraph/sourcegraph/pull/802)
+- add runfile initialization to upgradetest file `#890`
+- use generated json in migrations filegroup `#802`
 
 #### Search
 
-- (new web ui) Show correct document highlights when codegraph data is available [#620](https://github.com/sourcegraph/sourcegraph/pull/620)
-- 'Save search' action on search results page does not navigate to the saved search creation page [#549](https://github.com/sourcegraph/sourcegraph/pull/549)
+- (new web ui) Show correct document highlights when codegraph data is available `#620`
+- 'Save search' action on search results page does not navigate to the saved search creation page `#549`
 
 #### Code Intelligence
 
-- Correctly escape special characters in repo names and identifiers [#710](https://github.com/sourcegraph/sourcegraph/pull/710)
+- Correctly escape special characters in repo names and identifiers `#710`
   - The new usagesForSymbol API correctly searches repos whose names contain spaces or other special characters.
-- Use multiple language: filters for search-based usages in case of ambiguity [#708](https://github.com/sourcegraph/sourcegraph/pull/708)
-- cleanup button title [#581](https://github.com/sourcegraph/sourcegraph/pull/581)
-- Fetch tags for scip-go auto-indexing jobs [#371](https://github.com/sourcegraph/sourcegraph/pull/371)
+- Use multiple language: filters for search-based usages in case of ambiguity `#708`
+- cleanup button title `#581`
+- Fetch tags for scip-go auto-indexing jobs `#371`
   - Go cross-repo navigation for tagged versions should work better when using scip-go for auto-indexing. Navigation based on SCIP indexes generated using scip-go in CI or cron jobs should be unaffected.
 
 #### Cody
 
-- return client-side model config via API [#713](https://github.com/sourcegraph/sourcegraph/pull/713)
-- Disable ModelAPIEnabled for Dotcom [#678](https://github.com/sourcegraph/sourcegraph/pull/678)
+- return client-side model config via API `#713`
+- Disable ModelAPIEnabled for Dotcom `#678`
   - `modelsAPIEnabled` is always false for dotcom
-- allow accuracy category in JSON site config [#641](https://github.com/sourcegraph/sourcegraph/pull/641)
-- use "balanced" instead of "accuracy" category for SOTA models [#640](https://github.com/sourcegraph/sourcegraph/pull/640)
-- allow empty `finish_reason` in `/.api/llm/chat/completions` [#539](https://github.com/sourcegraph/sourcegraph/pull/539)
+- allow accuracy category in JSON site config `#641`
+- use "balanced" instead of "accuracy" category for SOTA models `#640`
+- allow empty `finish_reason` in `/.api/llm/chat/completions` `#539`
   - The `/.api/llm/chat/completions` endpoint will now return an empty string `""` for `finish_reason` instead of the string `"unknown_please_report_bug()"`.
 
 #### Database
 
-- use native UUID in telemetry export queue [#669](https://github.com/sourcegraph/sourcegraph/pull/669)
+- use native UUID in telemetry export queue `#669`
 
 #### Database
 
-- correctly find CreateIndexConcurrentlyPhases in migrator [#809](https://github.com/sourcegraph/sourcegraph/pull/809)
+- correctly find CreateIndexConcurrentlyPhases in migrator `#809`
   - INFO logs for migrations that create index concurrently will always correctly report the phase we are in. Previously we sometimes would report a phase of -1.
 
 #### Dev
 
-- use 9002 for pubsubemulator, simplify shutdown [#780](https://github.com/sourcegraph/sourcegraph/pull/780)
-- give pubsub pings a more generous timeout locally [#732](https://github.com/sourcegraph/sourcegraph/pull/732)
-- use key value for PGDSN in SAMS, EP [#689](https://github.com/sourcegraph/sourcegraph/pull/689)
+- use 9002 for pubsubemulator, simplify shutdown `#780`
+- give pubsub pings a more generous timeout locally `#732`
+- use key value for PGDSN in SAMS, EP `#689`
 
 #### Graph
 
-- Prevent duplicate results when performing find references [#497](https://github.com/sourcegraph/sourcegraph/pull/497)
+- Prevent duplicate results when performing find references `#497`
 
 #### Local
 
-- add no-xattrs when running schema descriptions target locally [#905](https://github.com/sourcegraph/sourcegraph/pull/905)
-- sg - return the error when checking for remote branch/commits [#485](https://github.com/sourcegraph/sourcegraph/pull/485)
+- add no-xattrs when running schema descriptions target locally `#905`
+- sg - return the error when checking for remote branch/commits `#485`
   - dump more information out about the branch if it is out of sync
 
 #### Release
 
-- remove embeddings from promotion script (#360) [#361](https://github.com/sourcegraph/sourcegraph/pull/361)
+- remove embeddings from promotion script (#360) `#361`
   - remove embeddings in promotion script
 
 #### Sams-Notifications
 
-- make subscriber tenant-aware [#668](https://github.com/sourcegraph/sourcegraph/pull/668)
+- make subscriber tenant-aware `#668`
 
 #### Search
 
-- (new web UI) Fix cody dashboard background colors in dark mode [#845](https://github.com/sourcegraph/sourcegraph/pull/845)
-- (new web ui) Fix list styles in rich text documents [#835](https://github.com/sourcegraph/sourcegraph/pull/835)
-- (new web ui) Fix styling of rich text documents [#834](https://github.com/sourcegraph/sourcegraph/pull/834)
-- (new web ui) Show added lines content [#832](https://github.com/sourcegraph/sourcegraph/pull/832)
-- fix client-side query validation for rev: filters [#810](https://github.com/sourcegraph/sourcegraph/pull/810)
+- (new web UI) Fix cody dashboard background colors in dark mode `#845`
+- (new web ui) Fix list styles in rich text documents `#835`
+- (new web ui) Fix styling of rich text documents `#834`
+- (new web ui) Show added lines content `#832`
+- fix client-side query validation for rev: filters `#810`
   - We have updated the client-side query validation to allow combining `rev:` filters with query-based search contexts.
-- (new web ui) Clicking 'Code search' in then navbar of the old UI does not redirect to the new UI [#761](https://github.com/sourcegraph/sourcegraph/pull/761)
-- (new web ui) Use a Map to group symbol names [#721](https://github.com/sourcegraph/sourcegraph/pull/721)
-- VSCode Search extension: Update bug-reporting URL [#693](https://github.com/sourcegraph/sourcegraph/pull/693)
-- VSCode Search extension: fix and improve proxy settings [#679](https://github.com/sourcegraph/sourcegraph/pull/679)
-- in search jobs, don't time out fetches [#666](https://github.com/sourcegraph/sourcegraph/pull/666)
+- (new web ui) Clicking 'Code search' in then navbar of the old UI does not redirect to the new UI `#761`
+- (new web ui) Use a Map to group symbol names `#721`
+- VSCode Search extension: Update bug-reporting URL `#693`
+- VSCode Search extension: fix and improve proxy settings `#679`
+- in search jobs, don't time out fetches `#666`
   - For very large repositories, search jobs could time out while fetching the repository. Now, search jobs can fetch and search over repositories, even if they take a long time to fetch.
-- (new web ui) Use CodeGraph data to validate hover occurence [#656](https://github.com/sourcegraph/sourcegraph/pull/656)
-- (new web ui) User menu feature parity [#628](https://github.com/sourcegraph/sourcegraph/pull/628)
-- add index for search jobs janitor [#624](https://github.com/sourcegraph/sourcegraph/pull/624)
+- (new web ui) Use CodeGraph data to validate hover occurence `#656`
+- (new web ui) User menu feature parity `#628`
+- add index for search jobs janitor `#624`
   - We added a new database index to speed up a janitor job which is run as part of Search Jobs. Before, the janitor job might have significantly delayed migrations during an upgrade.
-- (new web ui) Respect 'experimentalFeatures.structuralSearch' setting [#621](https://github.com/sourcegraph/sourcegraph/pull/621)
-- VSCode Search extension forgetting endpoint URL and PAT [#560](https://github.com/sourcegraph/sourcegraph/pull/560)
-- fix logo links in the VSCode Search extension [#547](https://github.com/sourcegraph/sourcegraph/pull/547)
-- Update help router for local development [#271](https://github.com/sourcegraph/sourcegraph/pull/271)
+- (new web ui) Respect 'experimentalFeatures.structuralSearch' setting `#621`
+- VSCode Search extension forgetting endpoint URL and PAT `#560`
+- fix logo links in the VSCode Search extension `#547`
+- Update help router for local development `#271`
 
 #### Sg
 
-- Config.GetEnv uses GetEnv for os.Expand [#380](https://github.com/sourcegraph/sourcegraph/pull/380)
+- Config.GetEnv uses GetEnv for os.Expand `#380`
 
 #### Sg/Msp
 
-- make embed template fmt-compliant, add docstring [#412](https://github.com/sourcegraph/sourcegraph/pull/412)
+- make embed template fmt-compliant, add docstring `#412`
 
 #### Telemetry
 
-- ensure telemetry export only occurs once at a time [#565](https://github.com/sourcegraph/sourcegraph/pull/565)
+- ensure telemetry export only occurs once at a time `#565`
   - Fix an issue where duplicate telemetry can be exported when the `worker` service is scaled horizontally
 
 #### Tenant
 
-- prevent race condition in MockEnforceTenant [#837](https://github.com/sourcegraph/sourcegraph/pull/837)
-- stop Iterate if it breaks [#387](https://github.com/sourcegraph/sourcegraph/pull/387)
+- prevent race condition in MockEnforceTenant `#837`
+- stop Iterate if it breaks `#387`
 
 #### Test
 
-- make workspaces waitforupdate test more reliable [#813](https://github.com/sourcegraph/sourcegraph/pull/813)
+- make workspaces waitforupdate test more reliable `#813`
 
 #### Others
 
-- make rerank metric name distinguishable [#846](https://github.com/sourcegraph/sourcegraph/pull/846)
-- Use correct label in splitting metric in embeddings indexing [#771](https://github.com/sourcegraph/sourcegraph/pull/771)
-- Add rerank API token variable to sg.config.yaml [#716](https://github.com/sourcegraph/sourcegraph/pull/716)
-- adjust formatting when using unix sockets [#653](https://github.com/sourcegraph/sourcegraph/pull/653)
+- make rerank metric name distinguishable `#846`
+- Use correct label in splitting metric in embeddings indexing `#771`
+- Add rerank API token variable to sg.config.yaml `#716`
+- adjust formatting when using unix sockets `#653`
   - fix PGDATASOURCE format when using unix sockets
-- move deletion inside nil check [#556](https://github.com/sourcegraph/sourcegraph/pull/556)
-- incrementally updating embeddings index [#555](https://github.com/sourcegraph/sourcegraph/pull/555)
-- Decrease parallelism in embeddings indexing [#543](https://github.com/sourcegraph/sourcegraph/pull/543)
-- Filter out empty context items in resolver [#537](https://github.com/sourcegraph/sourcegraph/pull/537)
-- VIP user access to allowed models in Cody Gateway [#528](https://github.com/sourcegraph/sourcegraph/pull/528)
-- properly escape email in URL query [#426](https://github.com/sourcegraph/sourcegraph/pull/426)
-- use preferred mermaid APIs [#397](https://github.com/sourcegraph/sourcegraph/pull/397)
+- move deletion inside nil check `#556`
+- incrementally updating embeddings index `#555`
+- Decrease parallelism in embeddings indexing `#543`
+- Filter out empty context items in resolver `#537`
+- VIP user access to allowed models in Cody Gateway `#528`
+- properly escape email in URL query `#426`
+- use preferred mermaid APIs `#397`
   - Fixes a bug that can cause errors when rendering many mermaid diagrams on a page.
 
 ### Chore
 
 #### All
 
-- use constraint names in ON CONFLICT statements [#473](https://github.com/sourcegraph/sourcegraph/pull/473)
+- use constraint names in ON CONFLICT statements `#473`
 
 #### Batch Changes
 
-- add description for env var [#652](https://github.com/sourcegraph/sourcegraph/pull/652)
+- add description for env var `#652`
 
 #### Ci
 
-- Remove stale CODENOTIFY entries [#439](https://github.com/sourcegraph/sourcegraph/pull/439)
-- bump Go to 1.23.1 [#391](https://github.com/sourcegraph/sourcegraph/pull/391)
-- update gomod lint [#382](https://github.com/sourcegraph/sourcegraph/pull/382)
+- Remove stale CODENOTIFY entries `#439`
+- bump Go to 1.23.1 `#391`
+- update gomod lint `#382`
   - remove lint that checks  for promotheus/common 0.32.1 since we are using 0.48
-- upgrade golang.org/x/tools to 0.24 [#373](https://github.com/sourcegraph/sourcegraph/pull/373)
+- upgrade golang.org/x/tools to 0.24 `#373`
   - address printf linter flagged issues
-- add annotation for no merge base [#345](https://github.com/sourcegraph/sourcegraph/pull/345)
+- add annotation for no merge base `#345`
   - post an annotation if there is no merge base
 
 #### Code Intelligence
 
-- Bump autoindexing image SHAs [#831](https://github.com/sourcegraph/sourcegraph/pull/831)
+- Bump autoindexing image SHAs `#831`
   - Upgrades default auto-indexing images to the latest versions (1) scip-go to v0.1.21 (2) scip-typescript to v0.3.14
-- Initialize test to consistent state [#825](https://github.com/sourcegraph/sourcegraph/pull/825)
-- Unify GetUsages logic at Service level [#752](https://github.com/sourcegraph/sourcegraph/pull/752)
-- Unify local phase usage extraction logic [#748](https://github.com/sourcegraph/sourcegraph/pull/748)
-- Document code nav logic & limitations [#742](https://github.com/sourcegraph/sourcegraph/pull/742)
-- Factor out & document package mentions code [#740](https://github.com/sourcegraph/sourcegraph/pull/740)
-- Bump autoindexing image SHAs [#681](https://github.com/sourcegraph/sourcegraph/pull/681)
+- Initialize test to consistent state `#825`
+- Unify GetUsages logic at Service level `#752`
+- Unify local phase usage extraction logic `#748`
+- Document code nav logic & limitations `#742`
+- Factor out & document package mentions code `#740`
+- Bump autoindexing image SHAs `#681`
   - Upgrades the default scip-go auto-indexing image to v0.1.20
-- Log number of paths in auto-inference logic [#635](https://github.com/sourcegraph/sourcegraph/pull/635)
-- Add context to timeout error for commit listing [#607](https://github.com/sourcegraph/sourcegraph/pull/607)
-- Clarify doc comment for NewCanonicalDocument [#480](https://github.com/sourcegraph/sourcegraph/pull/480)
-- Document scip.Document and range canonicalization code [#459](https://github.com/sourcegraph/sourcegraph/pull/459)
-- Split inverted ranges extraction code & add comments [#458](https://github.com/sourcegraph/sourcegraph/pull/458)
-- Use UploadRelPath instead of string [#438](https://github.com/sourcegraph/sourcegraph/pull/438)
-- Bump auto-indexing image SHAs [#403](https://github.com/sourcegraph/sourcegraph/pull/403)
+- Log number of paths in auto-inference logic `#635`
+- Add context to timeout error for commit listing `#607`
+- Clarify doc comment for NewCanonicalDocument `#480`
+- Document scip.Document and range canonicalization code `#459`
+- Split inverted ranges extraction code & add comments `#458`
+- Use UploadRelPath instead of string `#438`
+- Bump auto-indexing image SHAs `#403`
   - Bumps default auto-indexing scip-go image to use Go 1.23.1 and scip-go v0.1.19
 
 #### Cody
 
-- add HTTP record/replay test case for AWS Bedrock backend [#452](https://github.com/sourcegraph/sourcegraph/pull/452)
-- add HTTP record/replay test case for Anthropic LLM backend [#448](https://github.com/sourcegraph/sourcegraph/pull/448)
-- add HTTP record/replay test case for Azure OpenAI [#446](https://github.com/sourcegraph/sourcegraph/pull/446)
-- add HTTP record/replay test case for OpenAI LLM backend [#445](https://github.com/sourcegraph/sourcegraph/pull/445)
-- add HTTP record/replay test case for Fireworks LLM backend [#441](https://github.com/sourcegraph/sourcegraph/pull/441)
-- add HTTP record/replay test case for Google LLM backend [#410](https://github.com/sourcegraph/sourcegraph/pull/410)
+- add HTTP record/replay test case for AWS Bedrock backend `#452`
+- add HTTP record/replay test case for Anthropic LLM backend `#448`
+- add HTTP record/replay test case for Azure OpenAI `#446`
+- add HTTP record/replay test case for OpenAI LLM backend `#445`
+- add HTTP record/replay test case for Fireworks LLM backend `#441`
+- add HTTP record/replay test case for Google LLM backend `#410`
 
 #### Database
 
-- set app.current_tenant outside of multitenant [#502](https://github.com/sourcegraph/sourcegraph/pull/502)
+- set app.current_tenant outside of multitenant `#502`
 
 #### Database
 
-- remove unused redis_key_value table [#688](https://github.com/sourcegraph/sourcegraph/pull/688)
-- update oobmigration min version to 4.0 [#540](https://github.com/sourcegraph/sourcegraph/pull/540)
-- getRepositoriesForIndexScanQuery uses constraint [#534](https://github.com/sourcegraph/sourcegraph/pull/534)
-- handle failed transactions in setTenant [#533](https://github.com/sourcegraph/sourcegraph/pull/533)
-- use new constraints for on conflict [#510](https://github.com/sourcegraph/sourcegraph/pull/510)
-- constraint for unique indexes used in on conflict [#504](https://github.com/sourcegraph/sourcegraph/pull/504)
+- remove unused redis_key_value table `#688`
+- update oobmigration min version to 4.0 `#540`
+- getRepositoriesForIndexScanQuery uses constraint `#534`
+- handle failed transactions in setTenant `#533`
+- use new constraints for on conflict `#510`
+- constraint for unique indexes used in on conflict `#504`
 
 #### Dev
 
-- Bump Go version to 1.23.2 [#830](https://github.com/sourcegraph/sourcegraph/pull/830)
+- Bump Go version to 1.23.2 `#830`
 
 #### Frontend
 
-- sync.Once to sync.OnceValue in service connections [#376](https://github.com/sourcegraph/sourcegraph/pull/376)
+- sync.Once to sync.OnceValue in service connections `#376`
 
 #### Gomod
 
-- update zoekt's dependencies [#462](https://github.com/sourcegraph/sourcegraph/pull/462)
+- update zoekt's dependencies `#462`
 
 #### Local
 
-- Fix ill-formed go.mod file [#434](https://github.com/sourcegraph/sourcegraph/pull/434)
-- update sg installation docs [#390](https://github.com/sourcegraph/sourcegraph/pull/390)
+- Fix ill-formed go.mod file `#434`
+- update sg installation docs `#390`
 
 #### Release
 
-- prepare stitch graph for 5.8 [#852](https://github.com/sourcegraph/sourcegraph/pull/852)
+- prepare stitch graph for 5.8 `#852`
   -  Backport 6b58d4b62bba8f558c097fa97a751e51b178c537 from #850
 
 #### Release
 
-- clarify backport error [#784](https://github.com/sourcegraph/sourcegraph/pull/784)
+- clarify backport error `#784`
 
 #### Reranker
 
-- clean up resolvers, improve perf, add more useful spans [#776](https://github.com/sourcegraph/sourcegraph/pull/776)
+- clean up resolvers, improve perf, add more useful spans `#776`
 
 #### Search
 
-- (new web ui) Add telemetry for opt-out/in [#766](https://github.com/sourcegraph/sourcegraph/pull/766)
-- remove codeintel ranking code [#719](https://github.com/sourcegraph/sourcegraph/pull/719)
-- remove cursor based repo pagination [#663](https://github.com/sourcegraph/sourcegraph/pull/663)
-- VSCode Search extension: remove "SOURCEGRAPH SEARCH" stutter in favor of "Info" [#559](https://github.com/sourcegraph/sourcegraph/pull/559)
-- update wording from "Sourcegraph extension" to "Sourcegraph Search extension" [#558](https://github.com/sourcegraph/sourcegraph/pull/558)
+- (new web ui) Add telemetry for opt-out/in `#766`
+- remove codeintel ranking code `#719`
+- remove cursor based repo pagination `#663`
+- VSCode Search extension: remove "SOURCEGRAPH SEARCH" stutter in favor of "Info" `#559`
+- update wording from "Sourcegraph extension" to "Sourcegraph Search extension" `#558`
 
 #### Semgrep
 
-- add upload artifact step [#616](https://github.com/sourcegraph/sourcegraph/pull/616)
+- add upload artifact step `#616`
 
 #### Sg
 
-- remove enforce-tenant-id --disable [#705](https://github.com/sourcegraph/sourcegraph/pull/705)
+- remove enforce-tenant-id --disable `#705`
 
 #### Tenant
 
-- restructure tenant package into internal subpackages [#587](https://github.com/sourcegraph/sourcegraph/pull/587)
+- restructure tenant package into internal subpackages `#587`
 
 #### Trace
 
-- prevent parallel calls to ConfigureStaticTracerProvider [#467](https://github.com/sourcegraph/sourcegraph/pull/467)
+- prevent parallel calls to ConfigureStaticTracerProvider `#467`
 
 #### Others
 
-- enable reranker by default [#804](https://github.com/sourcegraph/sourcegraph/pull/804)
+- enable reranker by default `#804`
   - Reranker for context retrieval is turned on by default
-- disable IDF jobs [#783](https://github.com/sourcegraph/sourcegraph/pull/783)
-- Clean up visible uploads initialization [#739](https://github.com/sourcegraph/sourcegraph/pull/739)
-- Rename gatherLocations -> gatherUsages [#737](https://github.com/sourcegraph/sourcegraph/pull/737)
-- Cleanup metadata generation code in Gateway [#714](https://github.com/sourcegraph/sourcegraph/pull/714)
-- Remove unused endpoints from 969 prototype [#712](https://github.com/sourcegraph/sourcegraph/pull/712)
-- trigger changelog audit on label event [#562](https://github.com/sourcegraph/sourcegraph/pull/562)
+- disable IDF jobs `#783`
+- Clean up visible uploads initialization `#739`
+- Rename gatherLocations -> gatherUsages `#737`
+- Cleanup metadata generation code in Gateway `#714`
+- Remove unused endpoints from 969 prototype `#712`
+- trigger changelog audit on label event `#562`
 
 ### Refactor
 
 #### Svelte
 
-- Introduce extensible GraphQL store [#309](https://github.com/sourcegraph/sourcegraph/pull/309)
+- Introduce extensible GraphQL store `#309`
 
 #### Others
 
-- move cody context business logic outside of resolvers [#647](https://github.com/sourcegraph/sourcegraph/pull/647)
-- remove search mode [#629](https://github.com/sourcegraph/sourcegraph/pull/629)
-- rename NonLocal -> Global in scip_strict parser [#366](https://github.com/sourcegraph/sourcegraph/pull/366)
+- move cody context business logic outside of resolvers `#647`
+- remove search mode `#629`
+- rename NonLocal -> Global in scip_strict parser `#366`
 
 ### Reverts
 
-- Revert "pgdsn: Allow to fall back to default variables and overwrite … [#-1](https://github.com/sourcegraph/sourcegraph/pull/369)
+- Revert "pgdsn: Allow to fall back to default variables and overwrite … `#369`
 
 ### Uncategorized
 
 #### Others
 
-- bug(release): workspace cash time dance (#948) [#949](https://github.com/sourcegraph/sourcegraph/pull/949)
-- [Backport 5.8.x] tenant: Improve OOB migration from learnings [#939](https://github.com/sourcegraph/sourcegraph/pull/939)
-- [Backport 5.8.x] Revert "migrator: Backfill IDs from overrides into right schema only" [#914](https://github.com/sourcegraph/sourcegraph/pull/914)
-- [Backport 5.8.x] migrator: Backfill IDs from overrides into right schema only [#894](https://github.com/sourcegraph/sourcegraph/pull/894)
-- [Backport 5.8.x] Revert "fix(migration-graph): add no op migration to backfill overrides" [#888](https://github.com/sourcegraph/sourcegraph/pull/888)
-- [Backport 5.8.x] Update lockfiles with newer version of apko [#882](https://github.com/sourcegraph/sourcegraph/pull/882)
+- bug(release): workspace cash time dance (#948) `#949`
+- [Backport 5.8.x] tenant: Improve OOB migration from learnings `#939`
+- [Backport 5.8.x] Revert "migrator: Backfill IDs from overrides into right schema only" `#914`
+- [Backport 5.8.x] migrator: Backfill IDs from overrides into right schema only `#894`
+- [Backport 5.8.x] Revert "fix(migration-graph): add no op migration to backfill overrides" `#888`
+- [Backport 5.8.x] Update lockfiles with newer version of apko `#882`
   -  Backport 7f2c3bacf6778fef5f2ef444db2ebd873903c5e6 from #881
-- [Backport 5.8.x] Revert "Update rules_apko and fix issues with `sg wolfi` (#696)" [#880](https://github.com/sourcegraph/sourcegraph/pull/880)
-- [Backport 5.8.x] db: Bump date for schema migrations stitch date [#878](https://github.com/sourcegraph/sourcegraph/pull/878)
-- tenant: OOB migrator covers more tables [#842](https://github.com/sourcegraph/sourcegraph/pull/842)
-- tenant: Default to ID 1 for inserts [#840](https://github.com/sourcegraph/sourcegraph/pull/840)
-- migrator: Correctly render indexing progress [#812](https://github.com/sourcegraph/sourcegraph/pull/812)
-- adding code qwen 2p5 and deepseek long prompt optimized model [#811](https://github.com/sourcegraph/sourcegraph/pull/811)
-  - adding code qwen 2p5 and deepseek long prompt optimized model [#811](https://github.com/sourcegraph/sourcegraph/pull/811)
-- security: Update docker dind to latest release [#808](https://github.com/sourcegraph/sourcegraph/pull/808)
-- saml: Record requests [#788](https://github.com/sourcegraph/sourcegraph/pull/788)
-- saml: Return error instead of appending to it [#787](https://github.com/sourcegraph/sourcegraph/pull/787)
-- Add password for sourcegraph-rls [#786](https://github.com/sourcegraph/sourcegraph/pull/786)
-- cmd/workspaces: setup routes during ws creation [#782](https://github.com/sourcegraph/sourcegraph/pull/782)
-- db: Fix missing globaldbtenant [#779](https://github.com/sourcegraph/sourcegraph/pull/779)
-- trace: Fix span pollution in authenticateByCookie [#753](https://github.com/sourcegraph/sourcegraph/pull/753)
-- sg: Make sure sourcegraph_rls user also has permissions on future tables [#750](https://github.com/sourcegraph/sourcegraph/pull/750)
-- tenant: Fix license check missing tenant [#747](https://github.com/sourcegraph/sourcegraph/pull/747)
-- migration: Skip CREATE TABLE if possible [#746](https://github.com/sourcegraph/sourcegraph/pull/746)
-- tenant: Fix more tenant-less contexts [#745](https://github.com/sourcegraph/sourcegraph/pull/745)
-- tenant: Mark tenants tables as data tables [#738](https://github.com/sourcegraph/sourcegraph/pull/738)
-- feat(Cody Reranker): clean up site config and add license-based auth for Cody Gateway [#724](https://github.com/sourcegraph/sourcegraph/pull/724)
-- sg: Fix go generate [#722](https://github.com/sourcegraph/sourcegraph/pull/722)
-- tenant/db: Safer ordering of migration statements [#718](https://github.com/sourcegraph/sourcegraph/pull/718)
-- gitserver: Fix some missing tenant contexts [#717](https://github.com/sourcegraph/sourcegraph/pull/717)
-- refactor(cody gateway): update model list for autocompletes [#711](https://github.com/sourcegraph/sourcegraph/pull/711)
-- db: Add tenant_id to last remaining columns [#709](https://github.com/sourcegraph/sourcegraph/pull/709)
-- db: Add OOB migration to backfill tenant ID [#706](https://github.com/sourcegraph/sourcegraph/pull/706)
-- tenant: pass correct context to SetCloneStatus [#701](https://github.com/sourcegraph/sourcegraph/pull/701)
-- sg: Reject empty workspace names [#700](https://github.com/sourcegraph/sourcegraph/pull/700)
-- sg: Fix enforce-tenant-id after redis_key_value was dropped [#697](https://github.com/sourcegraph/sourcegraph/pull/697)
-- Update rules_apko and fix issues with `sg wolfi` [#696](https://github.com/sourcegraph/sourcegraph/pull/696)
-- Redis: don't check tenant for system commands [#695](https://github.com/sourcegraph/sourcegraph/pull/695)
-- tenant: only skip goroutine recording if tenancy is enabled [#694](https://github.com/sourcegraph/sourcegraph/pull/694)
-- Search jobs: set high timeout to protect against stuck jobs [#692](https://github.com/sourcegraph/sourcegraph/pull/692)
-- tenant: fix remaining goroutine recorder errors [#691](https://github.com/sourcegraph/sourcegraph/pull/691)
-- Reapply "feat(cody): add vision support (#546)" (#686) [#687](https://github.com/sourcegraph/sourcegraph/pull/687)
-- Add detailed intent-score pairs to chat intent response [#682](https://github.com/sourcegraph/sourcegraph/pull/682)
-- Jsm/disable model api [#680](https://github.com/sourcegraph/sourcegraph/pull/680)
-- Site admin: simplify goroutine recording [#677](https://github.com/sourcegraph/sourcegraph/pull/677)
-- Update client/vscode/CHANGELOG.md for PR #560 [#676](https://github.com/sourcegraph/sourcegraph/pull/676)
-- tenant: Mapper returns more precise error [#675](https://github.com/sourcegraph/sourcegraph/pull/675)
-- tenant: add missing IteratorFactory [#674](https://github.com/sourcegraph/sourcegraph/pull/674)
-- tenant: Make migrations on startup pass in local dev [#667](https://github.com/sourcegraph/sourcegraph/pull/667)
-- msp: report error when PGDSN does not have expected template variable [#664](https://github.com/sourcegraph/sourcegraph/pull/664)
-- final ranker config for context v2 [#659](https://github.com/sourcegraph/sourcegraph/pull/659)
+- [Backport 5.8.x] Revert "Update rules_apko and fix issues with `sg wolfi` (#696)" `#880`
+- [Backport 5.8.x] db: Bump date for schema migrations stitch date `#878`
+- tenant: OOB migrator covers more tables `#842`
+- tenant: Default to ID 1 for inserts `#840`
+- migrator: Correctly render indexing progress `#812`
+- adding code qwen 2p5 and deepseek long prompt optimized model `#811`
+  - adding code qwen 2p5 and deepseek long prompt optimized model `#811`
+- security: Update docker dind to latest release `#808`
+- saml: Record requests `#788`
+- saml: Return error instead of appending to it `#787`
+- Add password for sourcegraph-rls `#786`
+- cmd/workspaces: setup routes during ws creation `#782`
+- db: Fix missing globaldbtenant `#779`
+- trace: Fix span pollution in authenticateByCookie `#753`
+- sg: Make sure sourcegraph_rls user also has permissions on future tables `#750`
+- tenant: Fix license check missing tenant `#747`
+- migration: Skip CREATE TABLE if possible `#746`
+- tenant: Fix more tenant-less contexts `#745`
+- tenant: Mark tenants tables as data tables `#738`
+- feat(Cody Reranker): clean up site config and add license-based auth for Cody Gateway `#724`
+- sg: Fix go generate `#722`
+- tenant/db: Safer ordering of migration statements `#718`
+- gitserver: Fix some missing tenant contexts `#717`
+- refactor(cody gateway): update model list for autocompletes `#711`
+- db: Add tenant_id to last remaining columns `#709`
+- db: Add OOB migration to backfill tenant ID `#706`
+- tenant: pass correct context to SetCloneStatus `#701`
+- sg: Reject empty workspace names `#700`
+- sg: Fix enforce-tenant-id after redis_key_value was dropped `#697`
+- Update rules_apko and fix issues with `sg wolfi` `#696`
+- Redis: don't check tenant for system commands `#695`
+- tenant: only skip goroutine recording if tenancy is enabled `#694`
+- Search jobs: set high timeout to protect against stuck jobs `#692`
+- tenant: fix remaining goroutine recorder errors `#691`
+- Reapply "feat(cody): add vision support (#546)" (#686) `#687`
+- Add detailed intent-score pairs to chat intent response `#682`
+- Jsm/disable model api `#680`
+- Site admin: simplify goroutine recording `#677`
+- Update client/vscode/CHANGELOG.md for PR #560 `#676`
+- tenant: Mapper returns more precise error `#675`
+- tenant: add missing IteratorFactory `#674`
+- tenant: Make migrations on startup pass in local dev `#667`
+- msp: report error when PGDSN does not have expected template variable `#664`
+- final ranker config for context v2 `#659`
   - Changing the ranker configuration -- number of items fetched from zoekt
-- sg: Make enforce-tenant-id idempotent again [#655](https://github.com/sourcegraph/sourcegraph/pull/655)
-- refactor(cody gateway): add deprecated models back to dotcom model list [#649](https://github.com/sourcegraph/sourcegraph/pull/649)
-- gomod: bump Zoekt for memory debugging [#646](https://github.com/sourcegraph/sourcegraph/pull/646)
-- Dev: ensure multi-tenant migration has been run [#645](https://github.com/sourcegraph/sourcegraph/pull/645)
-- refactor(cody gateway): update dotcom models list [#643](https://github.com/sourcegraph/sourcegraph/pull/643)
+- sg: Make enforce-tenant-id idempotent again `#655`
+- refactor(cody gateway): add deprecated models back to dotcom model list `#649`
+- gomod: bump Zoekt for memory debugging `#646`
+- Dev: ensure multi-tenant migration has been run `#645`
+- refactor(cody gateway): update dotcom models list `#643`
   - Cody Gateway: update default model list for dotcom.
-- Bump Cody Web to 0.9.0 version [#642](https://github.com/sourcegraph/sourcegraph/pull/642)
-- sg cloud eph deploy:  --wait flag [#637](https://github.com/sourcegraph/sourcegraph/pull/637)
-- executors: Check for rows affected instead of running into unique constraint error [#632](https://github.com/sourcegraph/sourcegraph/pull/632)
-- Symbols: hide scary error messages from users [#631](https://github.com/sourcegraph/sourcegraph/pull/631)
-- Add postgres as datasource for Grafana [#627](https://github.com/sourcegraph/sourcegraph/pull/627)
-- add time to first token for upstream as header [#618](https://github.com/sourcegraph/sourcegraph/pull/618)
-- workspaces: implement `managementv1.UpdateWorkspaceMembership` RPC [#613](https://github.com/sourcegraph/sourcegraph/pull/613)
-- ci: add cloud ephemeral pipeline [#611](https://github.com/sourcegraph/sourcegraph/pull/611)
-- add sourcegraph ranker [#610](https://github.com/sourcegraph/sourcegraph/pull/610)
-- workspaces: implement GetWorkspaceMembership rpc [#609](https://github.com/sourcegraph/sourcegraph/pull/609)
-- workspaces: implement `ReportInstanceState` RPC [#604](https://github.com/sourcegraph/sourcegraph/pull/604)
-- workspaces: implement `ListWorkspaceMemberships` RPC [#603](https://github.com/sourcegraph/sourcegraph/pull/603)
-- tenant: Add method to create a new tenant in database [#593](https://github.com/sourcegraph/sourcegraph/pull/593)
-- workspaces: support []iam.Role in WorkspaceMembership [#590](https://github.com/sourcegraph/sourcegraph/pull/590)
-- Cody Web: bump cody web to 0.8.3 [#589](https://github.com/sourcegraph/sourcegraph/pull/589)
-- Cody context: fix bug in 'archived' change [#588](https://github.com/sourcegraph/sourcegraph/pull/588)
-- workspaces: Add WorkspaceState to GetWorkspace rpc [#585](https://github.com/sourcegraph/sourcegraph/pull/585)
-- tenant: Add support for reading tenant by hostname from database instead of hard-coded [#580](https://github.com/sourcegraph/sourcegraph/pull/580)
-- workspaces: implement user `CreateWorkspace` API [#574](https://github.com/sourcegraph/sourcegraph/pull/574)
-- workspaces: implement GetWorkspace RPC [#573](https://github.com/sourcegraph/sourcegraph/pull/573)
-- gomod: bump Zoekt for indexing memory optimization (again) [#572](https://github.com/sourcegraph/sourcegraph/pull/572)
-- use direct routing by default if present in the backend [#571](https://github.com/sourcegraph/sourcegraph/pull/571)
-- workspaces: database get/upsert instances [#568](https://github.com/sourcegraph/sourcegraph/pull/568)
-- workspaces: implement `ReportWorkspaceState` RPC [#564](https://github.com/sourcegraph/sourcegraph/pull/564)
-- gomod: bump Zoekt for indexing memory optimization [#557](https://github.com/sourcegraph/sourcegraph/pull/557)
-- Bump Cody Web to 0.8.2 version [#545](https://github.com/sourcegraph/sourcegraph/pull/545)
-- clean up rerankers for Cody Context [#544](https://github.com/sourcegraph/sourcegraph/pull/544)
-- sg(tenant): Add migration for constraints to local dev [#542](https://github.com/sourcegraph/sourcegraph/pull/542)
-- rockskip: use full ctx from emitIndexRequest [#532](https://github.com/sourcegraph/sourcegraph/pull/532)
-- Add billing metadata for core search, batch, and insights events [#529](https://github.com/sourcegraph/sourcegraph/pull/529)
-- Cody context: support archived and forked repos [#527](https://github.com/sourcegraph/sourcegraph/pull/527)
-- vsce: patch release v2.2.18 [#526](https://github.com/sourcegraph/sourcegraph/pull/526)
-- fix context v2 zoekt subqueries [#523](https://github.com/sourcegraph/sourcegraph/pull/523)
-- Repo-updater: continue start-up if hydration fails [#521](https://github.com/sourcegraph/sourcegraph/pull/521)
-- Cody Web: bump cody web to 0.8.1 [#518](https://github.com/sourcegraph/sourcegraph/pull/518)
-- cody-gateway: do not PING Redis too often [#517](https://github.com/sourcegraph/sourcegraph/pull/517)
-- rockskip: Remove another duplicative BTREE index [#516](https://github.com/sourcegraph/sourcegraph/pull/516)
-- rockskip: Remove duplicative BTREE index [#515](https://github.com/sourcegraph/sourcegraph/pull/515)
-- db(tenant): lock between setTenant and exec to ensure session variable is set atomically [#512](https://github.com/sourcegraph/sourcegraph/pull/512)
-- perf: reduce allocations in `evalKeywordExpansions` [#506](https://github.com/sourcegraph/sourcegraph/pull/506)
-- local/nix: add pgvector extension [#503](https://github.com/sourcegraph/sourcegraph/pull/503)
+- Bump Cody Web to 0.9.0 version `#642`
+- sg cloud eph deploy:  --wait flag `#637`
+- executors: Check for rows affected instead of running into unique constraint error `#632`
+- Symbols: hide scary error messages from users `#631`
+- Add postgres as datasource for Grafana `#627`
+- add time to first token for upstream as header `#618`
+- workspaces: implement `managementv1.UpdateWorkspaceMembership` RPC `#613`
+- ci: add cloud ephemeral pipeline `#611`
+- add sourcegraph ranker `#610`
+- workspaces: implement GetWorkspaceMembership rpc `#609`
+- workspaces: implement `ReportInstanceState` RPC `#604`
+- workspaces: implement `ListWorkspaceMemberships` RPC `#603`
+- tenant: Add method to create a new tenant in database `#593`
+- workspaces: support []iam.Role in WorkspaceMembership `#590`
+- Cody Web: bump cody web to 0.8.3 `#589`
+- Cody context: fix bug in 'archived' change `#588`
+- workspaces: Add WorkspaceState to GetWorkspace rpc `#585`
+- tenant: Add support for reading tenant by hostname from database instead of hard-coded `#580`
+- workspaces: implement user `CreateWorkspace` API `#574`
+- workspaces: implement GetWorkspace RPC `#573`
+- gomod: bump Zoekt for indexing memory optimization (again) `#572`
+- use direct routing by default if present in the backend `#571`
+- workspaces: database get/upsert instances `#568`
+- workspaces: implement `ReportWorkspaceState` RPC `#564`
+- gomod: bump Zoekt for indexing memory optimization `#557`
+- Bump Cody Web to 0.8.2 version `#545`
+- clean up rerankers for Cody Context `#544`
+- sg(tenant): Add migration for constraints to local dev `#542`
+- rockskip: use full ctx from emitIndexRequest `#532`
+- Add billing metadata for core search, batch, and insights events `#529`
+- Cody context: support archived and forked repos `#527`
+- vsce: patch release v2.2.18 `#526`
+- fix context v2 zoekt subqueries `#523`
+- Repo-updater: continue start-up if hydration fails `#521`
+- Cody Web: bump cody web to 0.8.1 `#518`
+- cody-gateway: do not PING Redis too often `#517`
+- rockskip: Remove another duplicative BTREE index `#516`
+- rockskip: Remove duplicative BTREE index `#515`
+- db(tenant): lock between setTenant and exec to ensure session variable is set atomically `#512`
+- perf: reduce allocations in `evalKeywordExpansions` `#506`
+- local/nix: add pgvector extension `#503`
   - enable pgvector in nix managed postgres db
-- redispool: allow call sites to custmoize their `TestOnBorrow` and `Dial` [#499](https://github.com/sourcegraph/sourcegraph/pull/499)
-- cody-gateway: wait for Redis connection [#498](https://github.com/sourcegraph/sourcegraph/pull/498)
-- cody-gateway: set `MaxActive` for Redis [#496](https://github.com/sourcegraph/sourcegraph/pull/496)
-- Bump Cody Web to 0.8.0 version [#492](https://github.com/sourcegraph/sourcegraph/pull/492)
-- Recorder: remove RegistrationDone method [#489](https://github.com/sourcegraph/sourcegraph/pull/489)
-- Repo-updater: add tenancy [#479](https://github.com/sourcegraph/sourcegraph/pull/479)
-- tenant: Basic support in worker [#476](https://github.com/sourcegraph/sourcegraph/pull/476)
-- Cody context: return matched ranges of chunks [#474](https://github.com/sourcegraph/sourcegraph/pull/474)
-- add(cody): `api-version=2` for incremental streaming LLM responses [#470](https://github.com/sourcegraph/sourcegraph/pull/470)
+- redispool: allow call sites to custmoize their `TestOnBorrow` and `Dial` `#499`
+- cody-gateway: wait for Redis connection `#498`
+- cody-gateway: set `MaxActive` for Redis `#496`
+- Bump Cody Web to 0.8.0 version `#492`
+- Recorder: remove RegistrationDone method `#489`
+- Repo-updater: add tenancy `#479`
+- tenant: Basic support in worker `#476`
+- Cody context: return matched ranges of chunks `#474`
+- add(cody): `api-version=2` for incremental streaming LLM responses `#470`
   - The `/.api/completions/stream` endpoint now accepts an `api-version=2` query parameter that returns incremental text text responses when using `"stream": true` to improve performance and reduce bandwidth.
-- Remove Neovim from Cody dashboard [#469](https://github.com/sourcegraph/sourcegraph/pull/469)
-- Fix flaky test by bringing down memory utilization of POS filter [#468](https://github.com/sourcegraph/sourcegraph/pull/468)
-- msp/iam: fixup checks for `ErrNoRows` [#465](https://github.com/sourcegraph/sourcegraph/pull/465)
-- gomod: bump Zoekt for zoekt-git-index profiling [#453](https://github.com/sourcegraph/sourcegraph/pull/453)
-- worker: Make resetter a periodic goroutine [#450](https://github.com/sourcegraph/sourcegraph/pull/450)
-- gomod: bump Zoekt for index optimization [#449](https://github.com/sourcegraph/sourcegraph/pull/449)
-- http: Add context to more requests [#437](https://github.com/sourcegraph/sourcegraph/pull/437)
-- conf: Remove alias for ExternalURL [#436](https://github.com/sourcegraph/sourcegraph/pull/436)
-- frontend: Drop unused orgs_open_beta_stats table [#435](https://github.com/sourcegraph/sourcegraph/pull/435)
-- msp/iam: do not close connection pool on startup [#433](https://github.com/sourcegraph/sourcegraph/pull/433)
-- Filter out terms based on POS and expand Zoekt queries [#432](https://github.com/sourcegraph/sourcegraph/pull/432)
-- authn: Create providers on the fly with current request context [#424](https://github.com/sourcegraph/sourcegraph/pull/424)
-- tenant: Use request context when creating OIDC provider [#422](https://github.com/sourcegraph/sourcegraph/pull/422)
-- redis: Add optional tenant isolation [#421](https://github.com/sourcegraph/sourcegraph/pull/421)
-- tenant: Add context to LogBackendEvent [#420](https://github.com/sourcegraph/sourcegraph/pull/420)
-- Remove debug log statement [#418](https://github.com/sourcegraph/sourcegraph/pull/418)
-- minor doc change [#413](https://github.com/sourcegraph/sourcegraph/pull/413)
-- sg: Use custom site-config for multitenant runset [#405](https://github.com/sourcegraph/sourcegraph/pull/405)
-- Retrieve and display change log during upgrades. [#400](https://github.com/sourcegraph/sourcegraph/pull/400)
+- Remove Neovim from Cody dashboard `#469`
+- Fix flaky test by bringing down memory utilization of POS filter `#468`
+- msp/iam: fixup checks for `ErrNoRows` `#465`
+- gomod: bump Zoekt for zoekt-git-index profiling `#453`
+- worker: Make resetter a periodic goroutine `#450`
+- gomod: bump Zoekt for index optimization `#449`
+- http: Add context to more requests `#437`
+- conf: Remove alias for ExternalURL `#436`
+- frontend: Drop unused orgs_open_beta_stats table `#435`
+- msp/iam: do not close connection pool on startup `#433`
+- Filter out terms based on POS and expand Zoekt queries `#432`
+- authn: Create providers on the fly with current request context `#424`
+- tenant: Use request context when creating OIDC provider `#422`
+- redis: Add optional tenant isolation `#421`
+- tenant: Add context to LogBackendEvent `#420`
+- Remove debug log statement `#418`
+- minor doc change `#413`
+- sg: Use custom site-config for multitenant runset `#405`
+- Retrieve and display change log during upgrades. `#400`
   - [Appliance] Retrieve live changelog and display information about the release to be upgraded.
-- Svelte: fix text wrapping for file popover [#399](https://github.com/sourcegraph/sourcegraph/pull/399)
+- Svelte: fix text wrapping for file popover `#399`
   - Fixed a bug in the web app rewrite where long paths would cause file popovers to wrap
-- Svelte: fix loading for ref panel [#398](https://github.com/sourcegraph/sourcegraph/pull/398)
+- Svelte: fix loading for ref panel `#398`
   - Fix loading behavior for the reference panel in the web app rewrite
-- gomod: bump Zoekt for index optimization [#389](https://github.com/sourcegraph/sourcegraph/pull/389)
-- Svelte: SymbolTree followups [#388](https://github.com/sourcegraph/sourcegraph/pull/388)
-- repo-updater: hack so it uses tenant 1 for now [#386](https://github.com/sourcegraph/sourcegraph/pull/386)
-- gitserver: inherit tenant for repoUpdateOrClone [#385](https://github.com/sourcegraph/sourcegraph/pull/385)
-- Chore: close rows [#379](https://github.com/sourcegraph/sourcegraph/pull/379)
-- database: use keyword value format if connecting via unix socket [#378](https://github.com/sourcegraph/sourcegraph/pull/378)
-- frontend: always use DSN from ServiceConnections [#375](https://github.com/sourcegraph/sourcegraph/pull/375)
-- Reapply "pgdsn: Allow to fall back to default variables and overwrite..." [#374](https://github.com/sourcegraph/sourcegraph/pull/374)
-- postgresdsn: support PGHOST as a filepath [#372](https://github.com/sourcegraph/sourcegraph/pull/372)
-- release: specifiy download directory for changelog [#365](https://github.com/sourcegraph/sourcegraph/pull/365)
+- gomod: bump Zoekt for index optimization `#389`
+- Svelte: SymbolTree followups `#388`
+- repo-updater: hack so it uses tenant 1 for now `#386`
+- gitserver: inherit tenant for repoUpdateOrClone `#385`
+- Chore: close rows `#379`
+- database: use keyword value format if connecting via unix socket `#378`
+- frontend: always use DSN from ServiceConnections `#375`
+- Reapply "pgdsn: Allow to fall back to default variables and overwrite..." `#374`
+- postgresdsn: support PGHOST as a filepath `#372`
+- release: specifiy download directory for changelog `#365`
   - specify download directory for changelog
-- frontend: Don't double-close readiness channel during auto upgrades [#358](https://github.com/sourcegraph/sourcegraph/pull/358)
-- workspaces: initial IAM schema and implement `iam.Store` [#353](https://github.com/sourcegraph/sourcegraph/pull/353)
-- enterprise-portal: implement `iam.Store` and add tests [#351](https://github.com/sourcegraph/sourcegraph/pull/351)
-- enterprise-portal: create `internal/iam` package and run schema tests in CI [#350](https://github.com/sourcegraph/sourcegraph/pull/350)
-- tenant: Add tenants 1 and 2 in localdev [#340](https://github.com/sourcegraph/sourcegraph/pull/340)
-- sg: Introduce first multitenant runset [#335](https://github.com/sourcegraph/sourcegraph/pull/335)
-- pgdsn: Allow to fall back to default variables and overwrite frontend [#332](https://github.com/sourcegraph/sourcegraph/pull/332)
-- Remove k8s utils dependency [#320](https://github.com/sourcegraph/sourcegraph/pull/320)
-- msp/iam: fixup migration PG 12 compatibility and sanity test migrations [#301](https://github.com/sourcegraph/sourcegraph/pull/301)
-- Tree-sitter based chunker for embeddings indexing [#298](https://github.com/sourcegraph/sourcegraph/pull/298)
-- Context: return multiple chunks per file from Zoekt results [#294](https://github.com/sourcegraph/sourcegraph/pull/294)
+- frontend: Don't double-close readiness channel during auto upgrades `#358`
+- workspaces: initial IAM schema and implement `iam.Store` `#353`
+- enterprise-portal: implement `iam.Store` and add tests `#351`
+- enterprise-portal: create `internal/iam` package and run schema tests in CI `#350`
+- tenant: Add tenants 1 and 2 in localdev `#340`
+- sg: Introduce first multitenant runset `#335`
+- pgdsn: Allow to fall back to default variables and overwrite frontend `#332`
+- Remove k8s utils dependency `#320`
+- msp/iam: fixup migration PG 12 compatibility and sanity test migrations `#301`
+- Tree-sitter based chunker for embeddings indexing `#298`
+- Context: return multiple chunks per file from Zoekt results `#294`
   - We can improve recall by fetching multiple chunks per file from Zoekt results by turning on the `cody-reranker` feature flag.
-- add(cody): `api-version=2` incremental streaming LLM response [#293](https://github.com/sourcegraph/sourcegraph/pull/293)
+- add(cody): `api-version=2` incremental streaming LLM response `#293`
   - The `/.api/completions/stream` endpoint now accepts an `api-version=2` query parameter that returns incremental text text responses when using `"stream": true` to improve performance and reduce bandwidth.
-- Context: improve ranker integration + loosen the tap [#291](https://github.com/sourcegraph/sourcegraph/pull/291)
+- Context: improve ranker integration + loosen the tap `#291`
   - Ranker for chat context is now available behind `use-reranker` feature flag.
-- Hook Upgrade page to Release Registry API [#276](https://github.com/sourcegraph/sourcegraph/pull/276)
-- Move IDF repository stats into Postgres and compute them with the background worker [#270](https://github.com/sourcegraph/sourcegraph/pull/270)
-- Svelte: add symbol tree [#209](https://github.com/sourcegraph/sourcegraph/pull/209)
+- Hook Upgrade page to Release Registry API `#276`
+- Move IDF repository stats into Postgres and compute them with the background worker `#270`
+- Svelte: add symbol tree `#209`
   - Adds a symbol tree to file page in the experimental webapp
-- Redis: respect context when connecting [#194](https://github.com/sourcegraph/sourcegraph/pull/194)
-- Appliance Admin UI [#168](https://github.com/sourcegraph/sourcegraph/pull/168)
+- Redis: respect context when connecting `#194`
+- Appliance Admin UI `#168`
   - [Appliance]: Adds the upgrade path for the Appliance Admin UX
 
 ### Untracked
 
 The following PRs were merged onto the previous release branch but could not be automatically mapped to a corresponding commit in this release:
 
-- remove the other embedding reference [#362](https://github.com/sourcegraph/sourcegraph/pull/362)
+- remove the other embedding reference `#362`
   - n/a
 
 {/* RSS={"version":"v5.8.0", "releasedAt": "2024-10-08"} */}
@@ -2133,18 +2133,18 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Batch Changes
 
-- workaround for a bug in GitHub [#584](https://github.com/sourcegraph/sourcegraph/pull/584)
+- workaround for a bug in GitHub `#584`
   - fix(batches): workaround for a bug in GitHub
   Backport aad3a04f8c93561a61c404e69132e70a22d0acba from #576
 
 #### Release
 
-- remove the other embedding reference [#362](https://github.com/sourcegraph/sourcegraph/pull/362)
+- remove the other embedding reference `#362`
   - n/a
 
 #### Search
 
-- remove query expansion [#586](https://github.com/sourcegraph/sourcegraph/pull/586)
+- remove query expansion `#586`
   - This fixes a bug where we added &quot;readme&quot; too often to the context.    Backport 28ff196a663f537c6cb6340f976a91431509a90e from #582
 
 ### Reverts
@@ -2155,7 +2155,7 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Others
 
-- [Backport 5.7.x] Search: allow queries with only lang filters [#583](https://github.com/sourcegraph/sourcegraph/pull/583)
+- [Backport 5.7.x] Search: allow queries with only lang filters `#583`
 
 {/* RSS={"version":"v5.7.2474", "releasedAt": "2024-09-18"} */}
 
@@ -2171,433 +2171,433 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Appliance
 
-- enable frontend form and stub out, no backend routes yet [#80](https://github.com/sourcegraph/sourcegraph/pull/80)
+- enable frontend form and stub out, no backend routes yet `#80`
 
 #### Batch Changes
 
-- Add a container registry deny list [#109](https://github.com/sourcegraph/sourcegraph/pull/109)
+- Add a container registry deny list `#109`
   - Add a container registry deny list to complement the allow list.
   - Configure in site config via `"batchChanges.containerRegistryDenylist"`.
   - Mutually exclusive with `"batchChanges.containerRegistryAllowlist"`.
-- add support for registry allowlist [#105](https://github.com/sourcegraph/sourcegraph/pull/105)
+- add support for registry allowlist `#105`
   - Add support to configure container registry allowlist for containers use from batch changes via `batchChanges.containerRegistryAllowlist` in Site Configuration.
 
 #### Cody
 
-- add `/.api/cody/context` API [#66](https://github.com/sourcegraph/sourcegraph/pull/66)
+- add `/.api/cody/context` API `#66`
   - New `POST /.api/cody/context` REST endpoint to retrieve a list of relevant source locations given a natural language query.
 
 #### Dotcom
 
-- add account ID in subscriptions list view [#192](https://github.com/sourcegraph/sourcegraph/pull/192)
-- forward license check to Enterprise Portal [#19](https://github.com/sourcegraph/sourcegraph/pull/19)
+- add account ID in subscriptions list view `#192`
+- forward license check to Enterprise Portal `#19`
 
 #### Enterpriseportal
 
-- use file-based migrations with `goose` [#216](https://github.com/sourcegraph/sourcegraph/pull/216)
-- add Salesforce Account ID [#176](https://github.com/sourcegraph/sourcegraph/pull/176)
-- internal instances record detected instance [#139](https://github.com/sourcegraph/sourcegraph/pull/139)
-- return unknown license as result [#134](https://github.com/sourcegraph/sourcegraph/pull/134)
+- use file-based migrations with `goose` `#216`
+- add Salesforce Account ID `#176`
+- internal instances record detected instance `#139`
+- return unknown license as result `#134`
 
 #### Licensecheck
 
-- check against Enterprise Portal directly [#22](https://github.com/sourcegraph/sourcegraph/pull/22)
+- check against Enterprise Portal directly `#22`
 
 #### Msp/Runtime
 
-- standardised migrations [#242](https://github.com/sourcegraph/sourcegraph/pull/242)
-- first-class redis support [#241](https://github.com/sourcegraph/sourcegraph/pull/241)
+- standardised migrations `#242`
+- first-class redis support `#241`
 
 #### Releases
 
-- scoped releases [#33](https://github.com/sourcegraph/sourcegraph/pull/33)
+- scoped releases `#33`
   - feat(release): scoped releases
 
 #### Sg
 
-- MSP database migrations with `goose` [#215](https://github.com/sourcegraph/sourcegraph/pull/215)
+- MSP database migrations with `goose` `#215`
 
 #### Site Admin
 
-- monitoring/telemetry: add v1 teestore write alerts and v2 export queue write alerts [#321](https://github.com/sourcegraph/sourcegraph/pull/321)
+- monitoring/telemetry: add v1 teestore write alerts and v2 export queue write alerts `#321`
 
 #### Svelte
 
-- Add repository sync status indicator to search results [#260](https://github.com/sourcegraph/sourcegraph/pull/260)
-- Sentry: Ignore errors from third party scripts [#171](https://github.com/sourcegraph/sourcegraph/pull/171)
-- Add status notifications [#141](https://github.com/sourcegraph/sourcegraph/pull/141)
-- Add support for indent-based code folding [#75](https://github.com/sourcegraph/sourcegraph/pull/75)
+- Add repository sync status indicator to search results `#260`
+- Sentry: Ignore errors from third party scripts `#171`
+- Add status notifications `#141`
+- Add support for indent-based code folding `#75`
 
 #### Telemetry/Sensitivemetadataallowlist
 
-- allow string list and nulls [#27](https://github.com/sourcegraph/sourcegraph/pull/27)
+- allow string list and nulls `#27`
 
 #### Others
 
-- Syntactic support for go [#328](https://github.com/sourcegraph/sourcegraph/pull/328)
+- Syntactic support for go `#328`
 
 ### Fix
 
 #### Batch Changes
 
-- omit headRepositoryId if empty [#200](https://github.com/sourcegraph/sourcegraph/pull/200)
-- avoid "Name already exists on this account" from creating fork by fetching the repo when the error happens [#159](https://github.com/sourcegraph/sourcegraph/pull/159)
+- omit headRepositoryId if empty `#200`
+- avoid "Name already exists on this account" from creating fork by fetching the repo when the error happens `#159`
   - fix(batches): avoid "Name already exists on this account" from creating fork by fetching the repo when the error happens
 
 #### Code Intelligence
 
-- ensure syntactic worker marks itself as "ready" on startup [#341](https://github.com/sourcegraph/sourcegraph/pull/341)
+- ensure syntactic worker marks itself as "ready" on startup `#341`
 
 #### Code Nav
 
-- Return ALL references in the same file as the definition [#240](https://github.com/sourcegraph/sourcegraph/pull/240)
+- Return ALL references in the same file as the definition `#240`
 
 #### Cody
 
-- correctly parse queries containing 'or' [#267](https://github.com/sourcegraph/sourcegraph/pull/267)
+- correctly parse queries containing 'or' `#267`
   - Fixes a regression in Cody context where questions containing the word 'or' could return noisy or no results.
-- use reverse proxy for Gemini API [#208](https://github.com/sourcegraph/sourcegraph/pull/208)
-- address critical bug from code review [#179](https://github.com/sourcegraph/sourcegraph/pull/179)
-- return valid `finish_reason` in `/.api/llm/chat/completions` [#154](https://github.com/sourcegraph/sourcegraph/pull/154)
+- use reverse proxy for Gemini API `#208`
+- address critical bug from code review `#179`
+- return valid `finish_reason` in `/.api/llm/chat/completions` `#154`
   - LLM API `/.api/chat/completions` now returns OpenAI-compatible `finish_reason`.
-- fix error handling in LLM API [#153](https://github.com/sourcegraph/sourcegraph/pull/153)
+- fix error handling in LLM API `#153`
   - LLM API endpoints (`/.api/llm`) now return JSON-encoded HTTP bodies for non-200 status codes.
-- use `testdata` instead of `golly-recordings` directory name [#152](https://github.com/sourcegraph/sourcegraph/pull/152)
-- give names to LLM API handlers [#151](https://github.com/sourcegraph/sourcegraph/pull/151)
-- allow `Bearer TOKEN` header for all LLM APIs [#150](https://github.com/sourcegraph/sourcegraph/pull/150)
+- use `testdata` instead of `golly-recordings` directory name `#152`
+- give names to LLM API handlers `#151`
+- allow `Bearer TOKEN` header for all LLM APIs `#150`
   - For compatibility with OpenAI clients, it's possible to use `Bearer TOKEN` header with all API endpoints that start with the prefix `/.api/llm`.
-- deepseek-coder-v2-lite-base model name mapping for dotcom users [#135](https://github.com/sourcegraph/sourcegraph/pull/135)
+- deepseek-coder-v2-lite-base model name mapping for dotcom users `#135`
 
 #### Cody-Gateway
 
-- ignore schema errors on otel init [#237](https://github.com/sourcegraph/sourcegraph/pull/237)
+- ignore schema errors on otel init `#237`
 
 #### Enterpriseportal
 
-- normalize instance domain on create subscription [#163](https://github.com/sourcegraph/sourcegraph/pull/163)
-- add subscription ID to trace, other diagnostics improvements [#130](https://github.com/sourcegraph/sourcegraph/pull/130)
+- normalize instance domain on create subscription `#163`
+- add subscription ID to trace, other diagnostics improvements `#130`
 
 #### Enterpriseportal/E2e
 
-- fix test case for check license [#162](https://github.com/sourcegraph/sourcegraph/pull/162)
+- fix test case for check license `#162`
 
 #### Frontend
 
-- Do not sign-out users when accessing a file path containing /login [#57](https://github.com/sourcegraph/sourcegraph/pull/57)
+- Do not sign-out users when accessing a file path containing /login `#57`
 
 #### Local
 
-- check for rogue files and folders in svelte routes [#337](https://github.com/sourcegraph/sourcegraph/pull/337)
+- check for rogue files and folders in svelte routes `#337`
   - prevent `web-sveltekit` commands from running if there are untracked files under src/routes
-- expand _after_ accumulating the whole env [#257](https://github.com/sourcegraph/sourcegraph/pull/257)
+- expand _after_ accumulating the whole env `#257`
 
 #### Oobmigration
 
-- remove migrations targeting licenses/subscriptions [#263](https://github.com/sourcegraph/sourcegraph/pull/263)
+- remove migrations targeting licenses/subscriptions `#263`
 
 #### Repo-Updater
 
-- add WARN level logs every time we sync a code host [#44](https://github.com/sourcegraph/sourcegraph/pull/44)
+- add WARN level logs every time we sync a code host `#44`
   - repo-updater now emits logs that log the result of every code host sync.
 
 #### Sams-Notifications
 
-- mockrequire.Values incorrectly used [#315](https://github.com/sourcegraph/sourcegraph/pull/315)
+- mockrequire.Values incorrectly used `#315`
 
 #### Search
 
-- skip if git diff not found in hybrid [#333](https://github.com/sourcegraph/sourcegraph/pull/333)
+- skip if git diff not found in hybrid `#333`
   - When searching an unindexed commit we would consult indexed commits for speeding up results. If our index contained a commit that no longer existed in git we would error out due to a regression in v5.4.5099. This is now fixed.
-- add "Create batch change" back to Actions dropdown in search results [#143](https://github.com/sourcegraph/sourcegraph/pull/143)
+- add "Create batch change" back to Actions dropdown in search results `#143`
 
 #### Sg
 
-- make start commands cancel fn be sync.OnceFunc [#319](https://github.com/sourcegraph/sourcegraph/pull/319)
+- make start commands cancel fn be sync.OnceFunc `#319`
   - the cancel funcs used by sg commands are now wrapped in `sync.OnceFunc` to prevent duplicate execution
-- add deprecation notice to sg wolfi update-hashes [#289](https://github.com/sourcegraph/sourcegraph/pull/289)
+- add deprecation notice to sg wolfi update-hashes `#289`
   - sg: fix panic when using `wolfi update-hashes`
   - sg: add deprecation notice for `wolfi update-hashes`
-- check if we are ephemeral before getting lease time [#256](https://github.com/sourcegraph/sourcegraph/pull/256)
+- check if we are ephemeral before getting lease time `#256`
   - sg - fix panic in Cloud Ephemeral listing when listing instances that are not Ephemeral
-- clamp deployment name consistently in cloud ephemeral [#117](https://github.com/sourcegraph/sourcegraph/pull/117)
+- clamp deployment name consistently in cloud ephemeral `#117`
   - ensure deployment / instance names are clamped in all places for cloud ephemeral
-- implement env priority to improve env var ordering [#31](https://github.com/sourcegraph/sourcegraph/pull/31)
+- implement env priority to improve env var ordering `#31`
 
 #### Svelte
 
-- Preserve history panel scroll position after selecting an entry [#251](https://github.com/sourcegraph/sourcegraph/pull/251)
-- Update existing query filters when including suggested filters [#115](https://github.com/sourcegraph/sourcegraph/pull/115)
-- Remove 'Code Ownership' top navigation [#87](https://github.com/sourcegraph/sourcegraph/pull/87)
-- Update main navigation to match React app [#74](https://github.com/sourcegraph/sourcegraph/pull/74)
-- Fix regex generation for routes that contain parameters [#73](https://github.com/sourcegraph/sourcegraph/pull/73)
-- Fix Bazel production build [#43](https://github.com/sourcegraph/sourcegraph/pull/43)
-- Workaround for handling client-side redirections in production [#14](https://github.com/sourcegraph/sourcegraph/pull/14)
+- Preserve history panel scroll position after selecting an entry `#251`
+- Update existing query filters when including suggested filters `#115`
+- Remove 'Code Ownership' top navigation `#87`
+- Update main navigation to match React app `#74`
+- Fix regex generation for routes that contain parameters `#73`
+- Fix Bazel production build `#43`
+- Workaround for handling client-side redirections in production `#14`
 
 #### Others
 
-- Switch to larger runner for scip-go jobs [#221](https://github.com/sourcegraph/sourcegraph/pull/221)
-- add deepseek virtual model string [#211](https://github.com/sourcegraph/sourcegraph/pull/211)
-- set webRoot to /client/web in launch.json [#83](https://github.com/sourcegraph/sourcegraph/pull/83)
-- Speed up auto-index job expiration query [#3](https://github.com/sourcegraph/sourcegraph/pull/3)
+- Switch to larger runner for scip-go jobs `#221`
+- add deepseek virtual model string `#211`
+- set webRoot to /client/web in launch.json `#83`
+- Speed up auto-index job expiration query `#3`
 
 ### Chore
 
 #### Dotcom
 
-- fix typo in subscriptions page [#195](https://github.com/sourcegraph/sourcegraph/pull/195)
-- delete subscriptions, licensing, and cody gateway usage [#21](https://github.com/sourcegraph/sourcegraph/pull/21)
+- fix typo in subscriptions page `#195`
+- delete subscriptions, licensing, and cody gateway usage `#21`
 
 #### Dotcom/Subscriptions
 
-- minor UX tweaks [#175](https://github.com/sourcegraph/sourcegraph/pull/175)
+- minor UX tweaks `#175`
 
 #### Embedding
 
-- delete cmd/embeddings [#181](https://github.com/sourcegraph/sourcegraph/pull/181)
+- delete cmd/embeddings `#181`
 
 #### Enterpriseportal
 
-- declare required scopes in schema and use schema-based enforcement [#305](https://github.com/sourcegraph/sourcegraph/pull/305)
-- add Cody Access override case to manual E2E tests [#224](https://github.com/sourcegraph/sourcegraph/pull/224)
-- improve formatting of duplicate usage message [#177](https://github.com/sourcegraph/sourcegraph/pull/177)
-- remove dotcomdb connection and testing infra [#20](https://github.com/sourcegraph/sourcegraph/pull/20)
+- declare required scopes in schema and use schema-based enforcement `#305`
+- add Cody Access override case to manual E2E tests `#224`
+- improve formatting of duplicate usage message `#177`
+- remove dotcomdb connection and testing infra `#20`
 
 #### Gomod
 
-- update for a bunch of CVEs [#343](https://github.com/sourcegraph/sourcegraph/pull/343)
+- update for a bunch of CVEs `#343`
 
 #### Local
 
-- stop using deprecated `docker-compose` command [#206](https://github.com/sourcegraph/sourcegraph/pull/206)
+- stop using deprecated `docker-compose` command `#206`
 
 #### Pubsub
 
-- upgrade to disable OpenTelemetry tracing [#210](https://github.com/sourcegraph/sourcegraph/pull/210)
+- upgrade to disable OpenTelemetry tracing `#210`
 
 #### Pubsubemulator
 
-- init tool [#272](https://github.com/sourcegraph/sourcegraph/pull/272)
+- init tool `#272`
 
 #### Release
 
-- simplify changelog download in release [#227](https://github.com/sourcegraph/sourcegraph/pull/227)
+- simplify changelog download in release `#227`
   - simplify `changelog` cli download by using `gh` cli
 
 #### Search
 
-- Tell EditorConfig to stop messing with snapshot files [#275](https://github.com/sourcegraph/sourcegraph/pull/275)
-- Remove Beta label from code monitors webhooks option. [#274](https://github.com/sourcegraph/sourcegraph/pull/274)
+- Tell EditorConfig to stop messing with snapshot files `#275`
+- Remove Beta label from code monitors webhooks option. `#274`
 
 #### Search-Jobs
 
-- deprecate experimental site setting [#122](https://github.com/sourcegraph/sourcegraph/pull/122)
+- deprecate experimental site setting `#122`
   - The site setting `experimentalFeatures.searchJobs` is not read anymore. To disable Search Jobs, set `DISABLE_SEARCH_JOBS=true` for the "frontend" and "worker" services.
-- remove EXPERIMENTAL from gql API [#116](https://github.com/sourcegraph/sourcegraph/pull/116)
-- remove beta badge [#114](https://github.com/sourcegraph/sourcegraph/pull/114)
+- remove EXPERIMENTAL from gql API `#116`
+- remove beta badge `#114`
 
 #### Svelte
 
-- Upgrade dependencies and cleanup configs [#279](https://github.com/sourcegraph/sourcegraph/pull/279)
-- Fix type import [#277](https://github.com/sourcegraph/sourcegraph/pull/277)
-- Reduce build log noise [#252](https://github.com/sourcegraph/sourcegraph/pull/252)
-- Ingore 'RepoNotFoundError's in Sentry [#113](https://github.com/sourcegraph/sourcegraph/pull/113)
+- Upgrade dependencies and cleanup configs `#279`
+- Fix type import `#277`
+- Reduce build log noise `#252`
+- Ingore 'RepoNotFoundError's in Sentry `#113`
 
 #### Tenant
 
-- Iterate does not enforce no tenant unlike Inherit [#334](https://github.com/sourcegraph/sourcegraph/pull/334)
+- Iterate does not enforce no tenant unlike Inherit `#334`
 
 #### Tooling
 
-- bump Go to 1.23.0 [#126](https://github.com/sourcegraph/sourcegraph/pull/126)
+- bump Go to 1.23.0 `#126`
 
 #### Wofli
 
-- update images [#290](https://github.com/sourcegraph/sourcegraph/pull/290)
+- update images `#290`
   - update images to use latest p4-fusion binary
 
 #### Workspaces
 
-- define initial Workspaces proto schemas [#262](https://github.com/sourcegraph/sourcegraph/pull/262)
-- stub service and directory [#244](https://github.com/sourcegraph/sourcegraph/pull/244)
+- define initial Workspaces proto schemas `#262`
+- stub service and directory `#244`
 
 #### Others
 
-- fix onUserRolesChanged `has SiteAdmin role` test name [#314](https://github.com/sourcegraph/sourcegraph/pull/314)
-- update github.com/openfga/openfga to v1.6.0 [#295](https://github.com/sourcegraph/sourcegraph/pull/295)
-- updates Rust toolchain to 1.80.1 [#287](https://github.com/sourcegraph/sourcegraph/pull/287)
-- Re-enable SCIP uploads to Demo [#222](https://github.com/sourcegraph/sourcegraph/pull/222)
-- create github action for changelog audit [#198](https://github.com/sourcegraph/sourcegraph/pull/198)
-- undo unneeded upgrades [#164](https://github.com/sourcegraph/sourcegraph/pull/164)
-- upgrade sourcegraph-accounts-sdk-go version [#160](https://github.com/sourcegraph/sourcegraph/pull/160)
-- Simplify semaphore-based code using conc.Iterator [#146](https://github.com/sourcegraph/sourcegraph/pull/146)
-- Bump autoindexing image SHAs [#131](https://github.com/sourcegraph/sourcegraph/pull/131)
-- migrate httpserver to use sg/log [#112](https://github.com/sourcegraph/sourcegraph/pull/112)
+- fix onUserRolesChanged `has SiteAdmin role` test name `#314`
+- update github.com/openfga/openfga to v1.6.0 `#295`
+- updates Rust toolchain to 1.80.1 `#287`
+- Re-enable SCIP uploads to Demo `#222`
+- create github action for changelog audit `#198`
+- undo unneeded upgrades `#164`
+- upgrade sourcegraph-accounts-sdk-go version `#160`
+- Simplify semaphore-based code using conc.Iterator `#146`
+- Bump autoindexing image SHAs `#131`
+- migrate httpserver to use sg/log `#112`
   - update httpserver to use sourcegraph/log instead of log15
-- Updates tree-sitter version [#93](https://github.com/sourcegraph/sourcegraph/pull/93)
-- Delete a bunch of unused LSIF-related code [#77](https://github.com/sourcegraph/sourcegraph/pull/77)
-- clean up CODENOTIFY for Joe [#28](https://github.com/sourcegraph/sourcegraph/pull/28)
+- Updates tree-sitter version `#93`
+- Delete a bunch of unused LSIF-related code `#77`
+- clean up CODENOTIFY for Joe `#28`
 
 ### Refactor
 
 #### Svelte
 
-- Make repo page integration test setups reusable [#249](https://github.com/sourcegraph/sourcegraph/pull/249)
-- Refactor temporary settings to remove Apollo dependency [#156](https://github.com/sourcegraph/sourcegraph/pull/156)
-- Lazy load mermaid [#16](https://github.com/sourcegraph/sourcegraph/pull/16)
+- Make repo page integration test setups reusable `#249`
+- Refactor temporary settings to remove Apollo dependency `#156`
+- Lazy load mermaid `#16`
 
 ### Reverts
 
-- revert reverse proxy usage to access Gemini API [#-1](https://github.com/sourcegraph/sourcegraph/pull/236)
+- revert reverse proxy usage to access Gemini API `#236`
 
 ### Uncategorized
 
 #### Others
 
-- Bump Cody Web to 0.7.7 version [#347](https://github.com/sourcegraph/sourcegraph/pull/347)
-- bug: fix slice init length [#339](https://github.com/sourcegraph/sourcegraph/pull/339)
-- Add migration to create sourcegraph_rls user in local dev [#331](https://github.com/sourcegraph/sourcegraph/pull/331)
-- Add tenant1 and tenant2 hostnames to caddy setup [#330](https://github.com/sourcegraph/sourcegraph/pull/330)
-- Deglobalize SiteID [#329](https://github.com/sourcegraph/sourcegraph/pull/329)
-- gomod: bump zoekt for indexing observability improvements [#327](https://github.com/sourcegraph/sourcegraph/pull/327)
-- searcher: check for zoekt empty repo commit in hybrid search [#326](https://github.com/sourcegraph/sourcegraph/pull/326)
-- conf: do not log missing tenant [#318](https://github.com/sourcegraph/sourcegraph/pull/318)
-- database: introduce globaldbtenant package [#317](https://github.com/sourcegraph/sourcegraph/pull/317)
-- database: rm unused Transact, Done, ShareableStore from ConfStore [#316](https://github.com/sourcegraph/sourcegraph/pull/316)
-- [perforce] Store label cache file in .p4home [#308](https://github.com/sourcegraph/sourcegraph/pull/308)
-- Convert trivial chunk/batching functions to use slices.Chunk [#307](https://github.com/sourcegraph/sourcegraph/pull/307)
-- Bump cody web to 0.7.6 [#304](https://github.com/sourcegraph/sourcegraph/pull/304)
-- handle error case where anthropic api returns an empty response [#303](https://github.com/sourcegraph/sourcegraph/pull/303)
-- msp/iam: use runtime standardized migrations mechanism [#300](https://github.com/sourcegraph/sourcegraph/pull/300)
-- frontend: update permissions runs per tenant [#299](https://github.com/sourcegraph/sourcegraph/pull/299)
-- tenant: avoid FromContext logging in Inherit [#297](https://github.com/sourcegraph/sourcegraph/pull/297)
-- validation: pass in ctx for validateAuthzProviders [#296](https://github.com/sourcegraph/sourcegraph/pull/296)
-- siteadmin: Make recoverUsers idempotent [#292](https://github.com/sourcegraph/sourcegraph/pull/292)
+- Bump Cody Web to 0.7.7 version `#347`
+- bug: fix slice init length `#339`
+- Add migration to create sourcegraph_rls user in local dev `#331`
+- Add tenant1 and tenant2 hostnames to caddy setup `#330`
+- Deglobalize SiteID `#329`
+- gomod: bump zoekt for indexing observability improvements `#327`
+- searcher: check for zoekt empty repo commit in hybrid search `#326`
+- conf: do not log missing tenant `#318`
+- database: introduce globaldbtenant package `#317`
+- database: rm unused Transact, Done, ShareableStore from ConfStore `#316`
+- [perforce] Store label cache file in .p4home `#308`
+- Convert trivial chunk/batching functions to use slices.Chunk `#307`
+- Bump cody web to 0.7.6 `#304`
+- handle error case where anthropic api returns an empty response `#303`
+- msp/iam: use runtime standardized migrations mechanism `#300`
+- frontend: update permissions runs per tenant `#299`
+- tenant: avoid FromContext logging in Inherit `#297`
+- validation: pass in ctx for validateAuthzProviders `#296`
+- siteadmin: Make recoverUsers idempotent `#292`
   - The recoverUsers endpoint failed with a spurious error when some of the given users were already active. It is now idempotent.
-- Remove (old friend) storm project [#286](https://github.com/sourcegraph/sourcegraph/pull/286)
-- all: skip slow tests when -short [#284](https://github.com/sourcegraph/sourcegraph/pull/284)
-- licensing: fix flaky uses of MockGetConfiguredProductLicenseInfo [#283](https://github.com/sourcegraph/sourcegraph/pull/283)
-- gitserver: fix RemoveBadRefs on darwin [#280](https://github.com/sourcegraph/sourcegraph/pull/280)
-- Cody Web: Remove old cody web logic [#273](https://github.com/sourcegraph/sourcegraph/pull/273)
-- Move package [#269](https://github.com/sourcegraph/sourcegraph/pull/269)
-- add unit test for idf index [#268](https://github.com/sourcegraph/sourcegraph/pull/268)
-- Worker: fix flake in repo syncer test [#266](https://github.com/sourcegraph/sourcegraph/pull/266)
-- clean unused flag [#265](https://github.com/sourcegraph/sourcegraph/pull/265)
-- Bump own and repos test timeouts to long [#258](https://github.com/sourcegraph/sourcegraph/pull/258)
-- Upgrade SCIM package to allow Microsoft Entra string values [#253](https://github.com/sourcegraph/sourcegraph/pull/253)
-- add(cody): support for Sonnet 3.5 "fast edit" model [#250](https://github.com/sourcegraph/sourcegraph/pull/250)
-- Enable route outside Site Admin into Appliance service. [#247](https://github.com/sourcegraph/sourcegraph/pull/247)
-- add common access token for direct routing [#245](https://github.com/sourcegraph/sourcegraph/pull/245)
-- Redis: pass context through remaining methods [#239](https://github.com/sourcegraph/sourcegraph/pull/239)
-- Bump Cody Web to 0.7.3 for react version [#238](https://github.com/sourcegraph/sourcegraph/pull/238)
-- dev: remove compare-hash.sh [#234](https://github.com/sourcegraph/sourcegraph/pull/234)
-- doc: update search links for monorepo to be on s2 [#233](https://github.com/sourcegraph/sourcegraph/pull/233)
-- change the default model from starcoder to deepseek [#232](https://github.com/sourcegraph/sourcegraph/pull/232)
-- database: capture missing tenant for queries [#231](https://github.com/sourcegraph/sourcegraph/pull/231)
-- goroutine: support tenants [#229](https://github.com/sourcegraph/sourcegraph/pull/229)
-- Rearrange auth provider middlewares [#228](https://github.com/sourcegraph/sourcegraph/pull/228)
-- Add option to cache label data with p4-fusion [#225](https://github.com/sourcegraph/sourcegraph/pull/225)
+- Remove (old friend) storm project `#286`
+- all: skip slow tests when -short `#284`
+- licensing: fix flaky uses of MockGetConfiguredProductLicenseInfo `#283`
+- gitserver: fix RemoveBadRefs on darwin `#280`
+- Cody Web: Remove old cody web logic `#273`
+- Move package `#269`
+- add unit test for idf index `#268`
+- Worker: fix flake in repo syncer test `#266`
+- clean unused flag `#265`
+- Bump own and repos test timeouts to long `#258`
+- Upgrade SCIM package to allow Microsoft Entra string values `#253`
+- add(cody): support for Sonnet 3.5 "fast edit" model `#250`
+- Enable route outside Site Admin into Appliance service. `#247`
+- add common access token for direct routing `#245`
+- Redis: pass context through remaining methods `#239`
+- Bump Cody Web to 0.7.3 for react version `#238`
+- dev: remove compare-hash.sh `#234`
+- doc: update search links for monorepo to be on s2 `#233`
+- change the default model from starcoder to deepseek `#232`
+- database: capture missing tenant for queries `#231`
+- goroutine: support tenants `#229`
+- Rearrange auth provider middlewares `#228`
+- Add option to cache label data with p4-fusion `#225`
   - Perforce connections now support a `cacheLabels` option to cache Perforce label data from the server, speeding up consecutive syncs on systems with a large number of labels.
-- lib/cloudapi: introduce features config [#223](https://github.com/sourcegraph/sourcegraph/pull/223)
-- lib/cloudapi: add auth pkg [#214](https://github.com/sourcegraph/sourcegraph/pull/214)
-- shortcut noop [#213](https://github.com/sourcegraph/sourcegraph/pull/213)
-- dev/msp: expose more runtime values to gotmpl [#212](https://github.com/sourcegraph/sourcegraph/pull/212)
-- worker: add OnUserRolesUpdated SAMS notification handler [#204](https://github.com/sourcegraph/sourcegraph/pull/204)
-- tenant: use marshal method instead of strconv [#203](https://github.com/sourcegraph/sourcegraph/pull/203)
-- [fix] Perforce auth provider panics when only IP is provided [#199](https://github.com/sourcegraph/sourcegraph/pull/199)
-- Redis: pass context to hash and ttl methods [#196](https://github.com/sourcegraph/sourcegraph/pull/196)
-- Redis: introduce KeyValue.Info() [#193](https://github.com/sourcegraph/sourcegraph/pull/193)
-- Respect context in Stop methods [#191](https://github.com/sourcegraph/sourcegraph/pull/191)
-- telemetry: wait for v1 writes in tests on teestore [#190](https://github.com/sourcegraph/sourcegraph/pull/190)
-- tenant: factor out marshalling [#189](https://github.com/sourcegraph/sourcegraph/pull/189)
-- Allow AWS tokens in the repository [#188](https://github.com/sourcegraph/sourcegraph/pull/188)
+- lib/cloudapi: introduce features config `#223`
+- lib/cloudapi: add auth pkg `#214`
+- shortcut noop `#213`
+- dev/msp: expose more runtime values to gotmpl `#212`
+- worker: add OnUserRolesUpdated SAMS notification handler `#204`
+- tenant: use marshal method instead of strconv `#203`
+- [fix] Perforce auth provider panics when only IP is provided `#199`
+- Redis: pass context to hash and ttl methods `#196`
+- Redis: introduce KeyValue.Info() `#193`
+- Respect context in Stop methods `#191`
+- telemetry: wait for v1 writes in tests on teestore `#190`
+- tenant: factor out marshalling `#189`
+- Allow AWS tokens in the repository `#188`
   -
-- tenant: prevent parallel test runs when mocking enforcement [#187](https://github.com/sourcegraph/sourcegraph/pull/187)
-- Configure and activate Admin UI [#186](https://github.com/sourcegraph/sourcegraph/pull/186)
+- tenant: prevent parallel test runs when mocking enforcement `#187`
+- Configure and activate Admin UI `#186`
   - [Appliance] Activate appliance updates on Code Search admin UI
-- sg: skip dev-private check if OFFLINE set [#185](https://github.com/sourcegraph/sourcegraph/pull/185)
-- Updating owner tag [#183](https://github.com/sourcegraph/sourcegraph/pull/183)
-- security: Ensure sourcegraph will run with uid randomisation [#182](https://github.com/sourcegraph/sourcegraph/pull/182)
-- tenant: add context to gitserver's filesystem interface [#178](https://github.com/sourcegraph/sourcegraph/pull/178)
-- change re-ranking method from public to private [#173](https://github.com/sourcegraph/sourcegraph/pull/173)
-- Web: encode file path for blame [#172](https://github.com/sourcegraph/sourcegraph/pull/172)
+- sg: skip dev-private check if OFFLINE set `#185`
+- Updating owner tag `#183`
+- security: Ensure sourcegraph will run with uid randomisation `#182`
+- tenant: add context to gitserver's filesystem interface `#178`
+- change re-ranking method from public to private `#173`
+- Web: encode file path for blame `#172`
   - Fixes an issue that would cause blame view to fail on files that contain some special characters.
-- Fix main lint [#169](https://github.com/sourcegraph/sourcegraph/pull/169)
+- Fix main lint `#169`
   - [Fix] code linting
-- Redis: add context to httpcache and rcache [#167](https://github.com/sourcegraph/sourcegraph/pull/167)
-- fixing the limit text for autocompletes [#166](https://github.com/sourcegraph/sourcegraph/pull/166)
-- Bug: Fix file/directory popover regression [#165](https://github.com/sourcegraph/sourcegraph/pull/165)
+- Redis: add context to httpcache and rcache `#167`
+- fixing the limit text for autocompletes `#166`
+- Bug: Fix file/directory popover regression `#165`
   - Fix File and directory popovers in the file tree when code search is scoped to a perforce depot.
-- ci/srcgql-compat: fix workflow [#161](https://github.com/sourcegraph/sourcegraph/pull/161)
-- guardrails: temporary cache for incident [#158](https://github.com/sourcegraph/sourcegraph/pull/158)
-- security: Remove root from some containers, and make it clearer which containers run as root [#157](https://github.com/sourcegraph/sourcegraph/pull/157)
-- Update site.schema.json [#155](https://github.com/sourcegraph/sourcegraph/pull/155)
-- all: update OWNERS and CODENOTIFY to match new team names [#148](https://github.com/sourcegraph/sourcegraph/pull/148)
-- migrations: remove read on pg_attribute for tenant_id [#147](https://github.com/sourcegraph/sourcegraph/pull/147)
-- Cody Web: Update cody web to 0.7.1 [#144](https://github.com/sourcegraph/sourcegraph/pull/144)
-- dev/cloud-relay: add msp delivery target for rollout [#142](https://github.com/sourcegraph/sourcegraph/pull/142)
-- Cody Web: fix cody web in svelte safari [#138](https://github.com/sourcegraph/sourcegraph/pull/138)
-- Instrument request latency in Cody Gateway [#136](https://github.com/sourcegraph/sourcegraph/pull/136)
-- dev/cloud-relay: import repo [#132](https://github.com/sourcegraph/sourcegraph/pull/132)
-- all: upgrade staticcheck and unparam [#128](https://github.com/sourcegraph/sourcegraph/pull/128)
-- Cody Web: Update cody web to 0.6.1 (svelte and react) [#127](https://github.com/sourcegraph/sourcegraph/pull/127)
-- ci/cloud-gql-compat: only report error on remote workflow failure [#125](https://github.com/sourcegraph/sourcegraph/pull/125)
-- add perforce support for git references table and labels [#124](https://github.com/sourcegraph/sourcegraph/pull/124)
+- ci/srcgql-compat: fix workflow `#161`
+- guardrails: temporary cache for incident `#158`
+- security: Remove root from some containers, and make it clearer which containers run as root `#157`
+- Update site.schema.json `#155`
+- all: update OWNERS and CODENOTIFY to match new team names `#148`
+- migrations: remove read on pg_attribute for tenant_id `#147`
+- Cody Web: Update cody web to 0.7.1 `#144`
+- dev/cloud-relay: add msp delivery target for rollout `#142`
+- Cody Web: fix cody web in svelte safari `#138`
+- Instrument request latency in Cody Gateway `#136`
+- dev/cloud-relay: import repo `#132`
+- all: upgrade staticcheck and unparam `#128`
+- Cody Web: Update cody web to 0.6.1 (svelte and react) `#127`
+- ci/cloud-gql-compat: only report error on remote workflow failure `#125`
+- add perforce support for git references table and labels `#124`
   - Code Search now supports labels for Perforce Depots
-- iterator: add Map function [#123](https://github.com/sourcegraph/sourcegraph/pull/123)
-- symbols: skip rockskipintegration on dev if missing binaries [#121](https://github.com/sourcegraph/sourcegraph/pull/121)
-- syntactic-indexing: skip tests on dev if scip-syntax is missing [#120](https://github.com/sourcegraph/sourcegraph/pull/120)
-- keyring: t.Parallel safe MockDefault [#119](https://github.com/sourcegraph/sourcegraph/pull/119)
-- appliance: inject os.Getenv to ensure clean environment [#118](https://github.com/sourcegraph/sourcegraph/pull/118)
-- db: add event_logs_export_allowlist and own_signal_configurations to DataTables [#111](https://github.com/sourcegraph/sourcegraph/pull/111)
-- expand special case handlers for context endpoint [#110](https://github.com/sourcegraph/sourcegraph/pull/110)
-- More context improvements [#104](https://github.com/sourcegraph/sourcegraph/pull/104)
-- adding cohere reRanker in the cody context [#102](https://github.com/sourcegraph/sourcegraph/pull/102)
-- Don't use markdown header symbols in graphql docs [#99](https://github.com/sourcegraph/sourcegraph/pull/99)
-- appliance: check ShouldRunSetupEnvTests in integrationtest [#97](https://github.com/sourcegraph/sourcegraph/pull/97)
-- Fix hardcoded version number in security release approval message [#96](https://github.com/sourcegraph/sourcegraph/pull/96)
-- blobstore: support tenant isolation [#94](https://github.com/sourcegraph/sourcegraph/pull/94)
-- Make syntactic indexing policies non exclusive to precise indexing [#92](https://github.com/sourcegraph/sourcegraph/pull/92)
-- Add --build flag to `sg cloud ephemeral upgrade` [#91](https://github.com/sourcegraph/sourcegraph/pull/91)
-- Turn off minification for cody web worker [#90](https://github.com/sourcegraph/sourcegraph/pull/90)
-- Redis: add context arg for list methods [#89](https://github.com/sourcegraph/sourcegraph/pull/89)
-- Basic custom context handler [#86](https://github.com/sourcegraph/sourcegraph/pull/86)
-- security: Auto-update package lockfiles for Sourcegraph base images [#85](https://github.com/sourcegraph/sourcegraph/pull/85)
-- React: Bump Cody Web to 0.5.1 [#79](https://github.com/sourcegraph/sourcegraph/pull/79)
-- lib/cloudapi: restructure pkg to reduce nesting [#68](https://github.com/sourcegraph/sourcegraph/pull/68)
-- nix flake update to go 1.23 [#62](https://github.com/sourcegraph/sourcegraph/pull/62)
-- nix: local is a string for GOTOOLCHAIN [#61](https://github.com/sourcegraph/sourcegraph/pull/61)
-- sg CLI: Use correct pipeline when retrieving annotations [#60](https://github.com/sourcegraph/sourcegraph/pull/60)
-- security: Auto-update package lockfiles for Sourcegraph base images [#56](https://github.com/sourcegraph/sourcegraph/pull/56)
-- nix: set GOTOOLCHAIN=local [#55](https://github.com/sourcegraph/sourcegraph/pull/55)
-- Search: improve indexing delay dashboards [#54](https://github.com/sourcegraph/sourcegraph/pull/54)
-- telemetry: always best-effort write to v1 store [#53](https://github.com/sourcegraph/sourcegraph/pull/53)
-- database: limit concurrent event log inserts [#52](https://github.com/sourcegraph/sourcegraph/pull/52)
-- Only commits in policy commitmap [#49](https://github.com/sourcegraph/sourcegraph/pull/49)
-- lib/cloudapi: import cloud-api proto def [#40](https://github.com/sourcegraph/sourcegraph/pull/40)
-- ctags/6.1.0 package update [#38](https://github.com/sourcegraph/sourcegraph/pull/38)
-- redis_exporter/1.62.0 package update [#37](https://github.com/sourcegraph/sourcegraph/pull/37)
-- docker-client/27.1.2 package update [#36](https://github.com/sourcegraph/sourcegraph/pull/36)
-- p4-fusion/1.13 package update [#35](https://github.com/sourcegraph/sourcegraph/pull/35)
-- jaeger/1.60.0 package update [#34](https://github.com/sourcegraph/sourcegraph/pull/34)
-- [Stream API]: Add external_service_type field to the SearchedRepo type [#32](https://github.com/sourcegraph/sourcegraph/pull/32)
+- iterator: add Map function `#123`
+- symbols: skip rockskipintegration on dev if missing binaries `#121`
+- syntactic-indexing: skip tests on dev if scip-syntax is missing `#120`
+- keyring: t.Parallel safe MockDefault `#119`
+- appliance: inject os.Getenv to ensure clean environment `#118`
+- db: add event_logs_export_allowlist and own_signal_configurations to DataTables `#111`
+- expand special case handlers for context endpoint `#110`
+- More context improvements `#104`
+- adding cohere reRanker in the cody context `#102`
+- Don't use markdown header symbols in graphql docs `#99`
+- appliance: check ShouldRunSetupEnvTests in integrationtest `#97`
+- Fix hardcoded version number in security release approval message `#96`
+- blobstore: support tenant isolation `#94`
+- Make syntactic indexing policies non exclusive to precise indexing `#92`
+- Add --build flag to `sg cloud ephemeral upgrade` `#91`
+- Turn off minification for cody web worker `#90`
+- Redis: add context arg for list methods `#89`
+- Basic custom context handler `#86`
+- security: Auto-update package lockfiles for Sourcegraph base images `#85`
+- React: Bump Cody Web to 0.5.1 `#79`
+- lib/cloudapi: restructure pkg to reduce nesting `#68`
+- nix flake update to go 1.23 `#62`
+- nix: local is a string for GOTOOLCHAIN `#61`
+- sg CLI: Use correct pipeline when retrieving annotations `#60`
+- security: Auto-update package lockfiles for Sourcegraph base images `#56`
+- nix: set GOTOOLCHAIN=local `#55`
+- Search: improve indexing delay dashboards `#54`
+- telemetry: always best-effort write to v1 store `#53`
+- database: limit concurrent event log inserts `#52`
+- Only commits in policy commitmap `#49`
+- lib/cloudapi: import cloud-api proto def `#40`
+- ctags/6.1.0 package update `#38`
+- redis_exporter/1.62.0 package update `#37`
+- docker-client/27.1.2 package update `#36`
+- p4-fusion/1.13 package update `#35`
+- jaeger/1.60.0 package update `#34`
+- [Stream API]: Add external_service_type field to the SearchedRepo type `#32`
   - Searched repo, commit, path, symbol and file match responses will now include external service type.
--  Directory mentions: extract and test buildKeywordQuery [#30](https://github.com/sourcegraph/sourcegraph/pull/30)
-- lib/background: fix flaky test of monitor routines with context cancel [#29](https://github.com/sourcegraph/sourcegraph/pull/29)
-- direct route for fireworks models [#26](https://github.com/sourcegraph/sourcegraph/pull/26)
-- repos: use passed in ctx for SystemsInfo [#18](https://github.com/sourcegraph/sourcegraph/pull/18)
-- Removing featureflag for expanded audit logs [#15](https://github.com/sourcegraph/sourcegraph/pull/15)
+-  Directory mentions: extract and test buildKeywordQuery `#30`
+- lib/background: fix flaky test of monitor routines with context cancel `#29`
+- direct route for fireworks models `#26`
+- repos: use passed in ctx for SystemsInfo `#18`
+- Removing featureflag for expanded audit logs `#15`
   - More auditlogs for sensitive admin actions will be automatically logged.
-- Perforce UI Elements: Add perforce UI elements to history panel [#12](https://github.com/sourcegraph/sourcegraph/pull/12)
-- Add typescript parser for SCIP symbols [#10](https://github.com/sourcegraph/sourcegraph/pull/10)
-- migrations: run squash targetting v5.3.0 [#9](https://github.com/sourcegraph/sourcegraph/pull/9)
+- Perforce UI Elements: Add perforce UI elements to history panel `#12`
+- Add typescript parser for SCIP symbols `#10`
+- migrations: run squash targetting v5.3.0 `#9`
 
 ### Untracked
 
 The following PRs were merged onto the previous release branch but could not be automatically mapped to a corresponding commit in this release:
 
-- Support SAST Scanning with both GHAS and Custom post processing scrip… [#67](https://github.com/sourcegraph/sourcegraph/pull/67)
+- Support SAST Scanning with both GHAS and Custom post processing scrip… `#67`
   - sast scans are reported without any issues
-- added better GHAS check (#64537) [#65](https://github.com/sourcegraph/sourcegraph/pull/65)
+- added better GHAS check (#64537) `#65`
   - chore(security): Fix GHAS check as non-zero exit code
 
 {/* RSS={"version":"v5.7.0", "releasedAt": "2024-09-04"} */}
@@ -2617,21 +2617,21 @@ The following PRs were merged onto the previous release branch but could not be 
 
 #### Security
 
-- security: added better GHAS check (#64537) [#65](https://github.com/sourcegraph/sourcegraph/pull/65)
+- security: added better GHAS check (#64537) `#65`
   - chore(security): Fix GHAS check as non-zero exit code
 
 ### Uncategorized
 
-- Support SAST Scanning with both GHAS and Custom post processing scrip… [#67](https://github.com/sourcegraph/sourcegraph/pull/67)
+- Support SAST Scanning with both GHAS and Custom post processing scrip… `#67`
   - sast scans are reported without any issues
-- [Backport 5.6.x] fix(search): fix query parsing bug around quoted phrases #59 [#70](https://github.com/sourcegraph/sourcegraph/pull/70)
-- [Backport 5.6.x] fix(batches): fix broken forking workflow [#81](https://github.com/sourcegraph/sourcegraph/pull/81)fix(batches): fix broken forking workflow
+- [Backport 5.6.x] fix(search): fix query parsing bug around quoted phrases #59 `#70`
+- [Backport 5.6.x] fix(batches): fix broken forking workflow `#81`fix(batches): fix broken forking workflow
   Backport f833c4a3bf2210c127ffbf1146be69e1f461a449 from #48
-- [Backport 5.6.x] svelte: add slash to path scope [#98](https://github.com/sourcegraph/sourcegraph/pull/98)
+- [Backport 5.6.x] svelte: add slash to path scope `#98`
   - Fixes a bug in the new web app that causes incorrect links to be generated for collapsed file names
  Backport 23dad06bb2af1e7eb6a2f3847ad7f2c76c2a89a5 from #95
-- [Backport 5.6.x] feat(cody): add deepseek-coder-v2-lite-base support [#103](https://github.com/sourcegraph/sourcegraph/pull/103) Backport f71fe081aa43ca40fef66c067c8eaf49d62d491e from #4
-- backporting #106 [#107](https://github.com/sourcegraph/sourcegraph/pull/107)
+- [Backport 5.6.x] feat(cody): add deepseek-coder-v2-lite-base support `#103` Backport f71fe081aa43ca40fef66c067c8eaf49d62d491e from #4
+- backporting #106 `#107`
 
 # 5.6 Patch 1
 


### PR DESCRIPTION
The sourcegraph/sourcegraph repo is now private, so all links to it are 404 for anyone not logged in to GitHub as a Sourcegraph employee. Knowing the PR is useful for Sourcegraph internally, but including a link that doesn't resolve is not useful for customers, and possibly detrimental.

The format of the PR non-link we settled on is `(PR #1234)`

Before:

- remove 5.10 deprecation dates on out of band migrations [#1996](https://github.com/sourcegraph/sourcegraph/pull/1996)

After:

- remove 5.10 deprecation dates on out of band migrations `(PR #1996)`
