### PR TITLE
Update Amazon Bedrock auth

### DIFF
--- a/docs/cody/enterprise/completions-configuration.mdx
+++ b/docs/cody/enterprise/completions-configuration.mdx
@@ -87,9 +87,19 @@ For `endpoint`, you can either:
 
 For `accessToken`, you can either:
 
-- Leave it empty and rely on instance role bindings or other AWS configurations in the `frontend` service
-- Set it to `<ACCESS_KEY_ID>:<SECRET_ACCESS_KEY>` if directly configuring the credentials
-- Set it to `<ACCESS_KEY_ID>:<SECRET_ACCESS_KEY>:<SESSION_TOKEN>` if a session token is also required
+-   Leave it empty and rely on instance role bindings or other AWS configurations in the `frontend` service
+-   Set it to `<ACCESS_KEY_ID>:<SECRET_ACCESS_KEY>` if directly configuring the credentials
+-   Set it to `<ACCESS_KEY_ID>:<SECRET_ACCESS_KEY>:<SESSION_TOKEN>` if a session token is also required
+
+<Callout type="warning">
+	We only recommend configuring AWS Bedrock to use an accessToken for
+	authentication. Specifying no accessToken (e.g. to use [IAM roles for EC2 /
+	instance role
+	binding](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html))
+	is not currently recommended (there is a known performance bug with this
+	method which will prevent autocomplete from working correctly. (internal
+	issue: PRIME-662)
+</Callout>
 
 ### Example: Using GCP Vertex AI
 

--- a/docs/cody/enterprise/model-config-examples.mdx
+++ b/docs/cody/enterprise/model-config-examples.mdx
@@ -682,4 +682,14 @@ Provider override `serverSideConfig` fields:
 
 Provisioned throughput for Amazon Bedrock models can be configured using the `"awsBedrockProvisionedThroughput"` server-side configuration type. Refer to the [Model Overrides](/cody/enterprise/model-configuration#model-overrides) section for more details.
 
+<Callout type="warning">
+	We only recommend configuring AWS Bedrock to use an accessToken for
+	authentication. Specifying no accessToken (e.g. to use [IAM roles for EC2 /
+	instance role
+	binding](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html))
+	is not currently recommended (there is a known performance bug with this
+	method which will prevent autocomplete from working correctly. (internal
+	issue: PRIME-662)
+</Callout>
+
 </Accordion>


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/PRIME-658/add-small-warning-to-aws-bedrock-docs-that-access-token-configuration
