### PR TITLE
fix(docs): Update broken links for kustomize deployment

### DIFF
--- a/docs/technical-changelog.mdx
+++ b/docs/technical-changelog.mdx
@@ -18,7 +18,7 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 
 - [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.10.2832)
 
-- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.10.2832)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-k8s/releases/tag/v5.10.2832)
 
 ### Features
 
@@ -85,7 +85,7 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 
 - [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.10.1164)
 
-- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.10.1164)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-k8s/releases/tag/v5.10.1164)
 
 ### Fix
 
@@ -130,7 +130,7 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 
 - [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.10.0)
 
-- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.10.0)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-k8s/releases/tag/v5.10.0)
 
 ### Features
 
@@ -777,7 +777,7 @@ The following PRs were merged onto the previous release branch but could not be 
 
 - [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.9.1590)
 
-- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.9.1590)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-k8s/releases/tag/v5.9.1590)
 
 ### Fix
 
@@ -828,7 +828,7 @@ The following PRs were merged onto the previous release branch but could not be 
 
 - [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.9.347)
 
-- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.9.347)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-k8s/releases/tag/v5.9.347)
 
 ### Fix
 
@@ -853,7 +853,7 @@ The following PRs were merged onto the previous release branch but could not be 
 
 - [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.9.45)
 
-- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.9.45)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-k8s/releases/tag/v5.9.45)
 
 ### Reverts
 
@@ -878,7 +878,7 @@ The following PRs were merged onto the previous release branch but could not be 
 
 - [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.9.0)
 
-- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.9.0)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-k8s/releases/tag/v5.9.0)
 
 ### Features
 
@@ -1538,7 +1538,7 @@ The following PRs were merged onto the previous release branch but could not be 
 - [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.8.1579)
 - [docker-compose](https://github.com/sourcegraph/deploy-sourcegraph-docker/releases/tag/v5.8.1579)
 - [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.8.1579)
-- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.8.1579)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-k8s/releases/tag/v5.8.1579)
 
 ### Features
 
@@ -1584,7 +1584,7 @@ The following PRs were merged onto the previous release branch but could not be 
 - [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.8.0)
 - [docker-compose](https://github.com/sourcegraph/deploy-sourcegraph-docker/releases/tag/v5.8.0)
 - [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.8.0)
-- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.8.0)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-k8s/releases/tag/v5.8.0)
 
 ### Features
 
@@ -2192,7 +2192,7 @@ The following PRs were merged onto the previous release branch but could not be 
 - [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.7.2474)
 - [docker-compose](https://github.com/sourcegraph/deploy-sourcegraph-docker/releases/tag/v5.7.2474)
 - [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.7.2474)
-- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.7.2474)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-k8s/releases/tag/v5.7.2474)
 
 ### Fix
 
@@ -2230,7 +2230,7 @@ The following PRs were merged onto the previous release branch but could not be 
 - [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.7.0)
 - [docker-compose](https://github.com/sourcegraph/deploy-sourcegraph-docker/releases/tag/v5.7.0)
 - [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.7.0)
-- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.7.0)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-k8s/releases/tag/v5.7.0)
 
 ### Features
 
@@ -2673,7 +2673,7 @@ The following PRs were merged onto the previous release branch but could not be 
 - [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.6.2535)
 - [docker-compose](https://github.com/sourcegraph/deploy-sourcegraph-docker/releases/tag/v5.6.2535)
 - [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.6.2535)
-- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.6.2535)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-k8s/releases/tag/v5.6.2535)
 
 {/* RSS={"version":"v5.6.2535", "releasedAt": "2024-08-22"} */}
 
@@ -2704,7 +2704,7 @@ The following PRs were merged onto the previous release branch but could not be 
 - [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.6.185)
 - [docker-compose](https://github.com/sourcegraph/deploy-sourcegraph-docker/releases/tag/v5.6.185)
 - [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.6.185)
-- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.6.185)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-k8s/releases/tag/v5.6.185)
 
 {/* RSS={"version":"v5.6.185", "releasedAt": "2024-08-08"} */}
 
@@ -2720,7 +2720,7 @@ The following PRs were merged onto the previous release branch but could not be 
 - [sourcegraph](https://github.com/sourcegraph/sourcegraph/releases/tag/v5.6.0)
 - [docker-compose](https://github.com/sourcegraph/deploy-sourcegraph-docker/releases/tag/v5.6.0)
 - [helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/releases/tag/v5.6.0)
-- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-kustomize/releases/tag/v5.6.0)
+- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-k8s/releases/tag/v5.6.0)
 
 {/* RSS={"version":"v5.6.0", "releasedAt": "2024-08-07"} */}
 


### PR DESCRIPTION
Update broken links pointing to the kustomize deployment in the technical changelog.

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
