### PR TITLE
Update batch spec search result looping example

### DIFF
--- a/docs/batch-changes/batch-spec-cheat-sheet.mdx
+++ b/docs/batch-changes/batch-spec-cheat-sheet.mdx
@@ -14,9 +14,11 @@ on:
 
 steps:
   - run: |
-      for file in "${{ join repository.search_result_paths " " }}";
+      IFS=$'\n'
+      files="${{ join repository.search_result_paths "\n" }}"
+      for file in $files;
       do
-        sed -i 's/OLD-VALUE/NEW-VALUE/g;' ${file}
+        sed -i 's/OLD-VALUE/NEW-VALUE/g;' "${file}"
       done
     container: alpine:3
 ```


### PR DESCRIPTION
The original snippet has some issues:
The loop will not handle spaces correctly and may misinterpret the path.
The entire string is treated as one entity due to the quotes, leading to incorrect processing.

Updated the loop handling in the script to correctly process file paths by switching from space-delimited to newline-delimited entries. This ensures the handling of paths with spaces or special characters. Added IFS=$'\n' for proper splitting and quoting of paths in the loop for safety.

![Screenshot 2024-12-19 at 3 10 35 PM](https://github.com/user-attachments/assets/4f10c4bb-cba2-4659-862f-4980c2c0b7c1)
Spaces in file names
![Screenshot 2024-12-19 at 3 09 23 PM](https://github.com/user-attachments/assets/771935b7-6d84-4bf7-bc0e-f7fe1b01959c)

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
