### PR TITLE
Add a warning that auto-migrate to pg16 is not supported.

### DIFF
--- a/docs/admin/deploy/docker-single-container/index.mdx
+++ b/docs/admin/deploy/docker-single-container/index.mdx
@@ -138,6 +138,11 @@ SELECT * FROM users;
 
 ## Upgrade
 
+> Warning: The 5.11 release updates the database container images from Postgres 12 to Postgres 16. Customers are advised to have a database backup before upgrading! See our [postgres 12 end of life](https://sourcegraph.com/docs/admin/postgres12_end_of_life_notice#postgres-12-end-of-life) notice!
+>
+> Single-container *does not* support auto migration to postgres 16. If you are planning to upgrade to 5.11.0 and beyond on single-container, you will need to dump the postgres databases and restore them after the upgrade.
+> In this event, we highly recommend you migrate to a production supported deployment method, or switch to our cloud offering.
+
 ### Standard upgrades
 
 A [standard upgrade](/admin/updates/#standard-upgrades) occurs between two minor versions of Sourcegraph. If you are looking to jump forward several versions, you must perform a [multi-version upgrade](#multi-version-upgrades) instead.


### PR DESCRIPTION
<!-- Explain the changes introduced in your PR -->

Relates to [REL-491](https://linear.app/sourcegraph/issue/REL-491/postgres-sourcegraph-server-aka-single-image-handles-postgres-16)
I think we should not support auto-migration of the database to pg16, since single container is not production capable deployment type, and the customers using it are explicitly trials.
