### PR TITLE
feat(docs): add additional configuration options

### DIFF
--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -410,16 +410,20 @@ Example VS Code user settings JSON configuration:
 
 ### Provider configuration options
 
-- `provider`: `"google"`, `"groq"` or `"ollama"`
-  - The LLM provider type.
-- `model`: `string`
-  - The ID of the model, e.g. `"gemini-1.5-pro-latest"`
-- `tokens`: `number` - optional
-  - The context window size of the model. Default: `7000`.
-- `apiKey`: `string` - optional
-  - The API key for the endpoint. Required if the provider is `"google"` or `"groq"`.
-- `apiEndpoint`: `string` - optional
-  - The endpoint URL, if you don't want to use the provider’s default endpoint.
+- `"provider"`: `"google"`, `"groq"`, `"ollama"` or `"openai"`
+    - The LLM provider type.
+- `"model"`: `string`
+    - The ID of the model, e.g. "gemini-2.0-flash-exp"
+- `"inputTokens"`: `number` - optional
+    - The context window size of the model's input. Default: 7000.
+- `"outputTokens"`: `number` - optional
+    - The context window size of the model's output. Default: 4000.
+- `"apiKey"`: `string` - optional
+    - The API key for the endpoint. Required if the provider is "google", "groq" or "OpenAI".
+- `"apiEndpoint"`: `string` - optional
+    - The endpoint URL, if you don't want to use the provider’s default endpoint.
+- `"options"` : `object` - optional
+    - Additional parameters like `temperature`, `topK`, `topP` based on provider documentation.
 
 ### Debugging experimental models
 

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -413,13 +413,13 @@ Example VS Code user settings JSON configuration:
 - `"provider"`: `"google"`, `"groq"`, `"ollama"` or `"openai"`
     - The LLM provider type.
 - `"model"`: `string`
-    - The ID of the model, e.g. "gemini-2.0-flash-exp"
+    - The ID of the model, e.g. `"gemini-2.0-flash-exp"`
 - `"inputTokens"`: `number` - optional
     - The context window size of the model's input. Default: 7000.
 - `"outputTokens"`: `number` - optional
     - The context window size of the model's output. Default: 4000.
 - `"apiKey"`: `string` - optional
-    - The API key for the endpoint. Required if the provider is "google", "groq" or "OpenAI".
+    - The API key for the endpoint. Required if the provider is `"google"`, `"groq"`, `"ollama"` or `"openai"`.
 - `"apiEndpoint"`: `string` - optional
     - The endpoint URL, if you don't want to use the provider’s default endpoint.
 - `"options"` : `object` - optional


### PR DESCRIPTION
The changes introduce support for the OpenAI provider in the Cody VS Code extension configuration, along with additional configuration options for input and output token sizes, and provider-specific options. This provides more flexibility and options for users when configuring their Cody integration.

<!-- Explain the changes introduced in your PR -->

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
