### PR TITLE
Update syncing.mdx

### DIFF
--- a/docs/admin/permissions/syncing.mdx
+++ b/docs/admin/permissions/syncing.mdx
@@ -255,6 +255,9 @@ scheduled. Default values are shown below:
   // The maximum number of user-centric permissions syncing jobs that can be spawned concurrently.
   // Service restart is required to take effect for changes.
   "permissions.syncUsersMaxConcurrency": 1,
+  // The maximum number of repo-centric permissions syncing jobs that can be spawned concurrently.
+  // Service restart is required to take effect for changes.
+  "permissions.syncReposMaxConcurrency": 5,
 }
 ```
 


### PR DESCRIPTION
Added The maximum number of repo-centric permissions syncing jobs that can be spawned concurrently in the doc config.


