### PR TITLE
Update site_config.mdx

### DIFF
--- a/docs/admin/config/site_config.mdx
+++ b/docs/admin/config/site_config.mdx
@@ -201,7 +201,7 @@ All site configuration options and their default values are shown below.
 	// Disk usage threshold at which to display warning notification. Value is a percentage.
 	"gitserver.diskUsageWarningThreshold": 90,
 
-	// Configuration for logging and alerting, including to external s.
+	// Configuration for logging and alerting, including to external services.
 	"log": null,
 
 	// Notifications recieved from Sourcegraph.com to display in Sourcegraph.

--- a/docs/admin/config/site_config.mdx
+++ b/docs/admin/config/site_config.mdx
@@ -201,7 +201,7 @@ All site configuration options and their default values are shown below.
 	// Disk usage threshold at which to display warning notification. Value is a percentage.
 	"gitserver.diskUsageWarningThreshold": 90,
 
-	// Configuration for logging and alerting, including to external services.
+	// Configuration for logging and alerting, including to external s.
 	"log": null,
 
 	// Notifications recieved from Sourcegraph.com to display in Sourcegraph.
@@ -220,7 +220,7 @@ All site configuration options and their default values are shown below.
 	//     "notifier": {
 	//       "channel": "#alerts",
 	//       "type": "slack",
-	//       "url": "https://hooks.slack.com/services/..."
+	//       "url": "https://hooks.slack.com/s/..."
 	//     }
 	//   }
 	// - {
@@ -304,10 +304,10 @@ All site configuration options and their default values are shown below.
 	// Don't sync a user's permissions if they have synced within the last n seconds.
 	"permissions.syncUsersBackoffSeconds": 60,
 
-	// The maximum number of user-centric permissions syncing jobs that can be spawned concurrently. Service restart is required to take effect for changes.
+	// The maximum number of user-centric permissions syncing jobs that can be spawned concurrently. Server restart is required for changes to take effect.
 	"permissions.syncUsersMaxConcurrency": 1,
 
-	// The maximum number of repo-centric permissions syncing jobs that can be spawned concurrently. Service restart is required to take effect for changes.
+	// The maximum number of repo-centric permissions syncing jobs that can be spawned concurrently. Server restart is required for changes to take effect.
 	"permissions.syncReposMaxConcurrency": 5,
 
 	"rateLimits": null,

--- a/docs/admin/config/site_config.mdx
+++ b/docs/admin/config/site_config.mdx
@@ -220,7 +220,7 @@ All site configuration options and their default values are shown below.
 	//     "notifier": {
 	//       "channel": "#alerts",
 	//       "type": "slack",
-	//       "url": "https://hooks.slack.com/s/..."
+	//       "url": "https://hooks.slack.com/services/..."
 	//     }
 	//   }
 	// - {

--- a/docs/admin/config/site_config.mdx
+++ b/docs/admin/config/site_config.mdx
@@ -307,6 +307,9 @@ All site configuration options and their default values are shown below.
 	// The maximum number of user-centric permissions syncing jobs that can be spawned concurrently. Service restart is required to take effect for changes.
 	"permissions.syncUsersMaxConcurrency": 1,
 
+	// The maximum number of repo-centric permissions syncing jobs that can be spawned concurrently. Service restart is required to take effect for changes.
+	"permissions.syncReposMaxConcurrency": 5,
+
 	"rateLimits": null,
 
 	// Enables redacting sensitive information from outbound requests. Important: We only respect this setting in development environments. In production, we always redact outbound requests.


### PR DESCRIPTION
Added The maximum number of repo-centric permissions syncing jobs that can be spawned concurrently in the site config doc .


