### PR TITLE
docs: add missing word to rectify sentence fragment

### DIFF
--- a/docs/code-search/features.mdx
+++ b/docs/code-search/features.mdx
@@ -65,7 +65,7 @@ The Sourcegraph search language supports [RE2](https://golang.org/s/re2syntax) s
 - It's well-supported in Go, allowing us to take advantage of a rich ecosystem (notably including [Zoekt](https://github.com/sourcegraph/zoekt))
 - Our API and tooling makes it straightforward to use Sourcegraph with other tools that provide facilities not built in to the search language.
 
-As an example of how you can use Sourcegraph tooling with other tools, we can use `jq` (which supports Perl regexes) along with `src` to post-filter search results. In this case, we want to use backreferences to find go functions take a single pointer argument and return a non-pointer of the same type as the input.
+As an example of how you can use Sourcegraph tooling with other tools, we can use `jq` (which supports Perl regexes) along with `src` to post-filter search results. In this case, we want to use backreferences to find go functions that take a single pointer argument and return a non-pointer of the same type as the input.
 
 ```shell
 re2_regex='func \w+\(\w+ \*\w+\) \w+'


### PR DESCRIPTION
Inserted "that" into "find go functions take" within `docs/docs/code-search/features.mdx`.

<!-- Explain the changes introduced in your PR -->

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
