### PR TITLE
Fix: Version numbering automatically updates again

### DIFF
--- a/src/components/PreCodeBlock.tsx
+++ b/src/components/PreCodeBlock.tsx
@@ -72,8 +72,15 @@ export async function PreCodeBlock({ children, ...props }: PreProps) {
 
   const version = await getLatestVersion()
   const version_no_v = trimPrefix(version, "v")
+  let mustReplaceVersions = false
+  if (codeContent.includes("{CURRENT_VERSION}") || codeContent.includes("{CURRENT_VERSION_NO_V}")) {
+    mustReplaceVersions = true
+  }
   codeContent = codeContent.replace(/{CURRENT_VERSION}/g, version)
   codeContent = codeContent.replace(/{CURRENT_VERSION_NO_V}/g, version_no_v)
+  if (mustReplaceVersions) {
+    children = codeContent
+  }
 
   return (
     <div className="relative">


### PR DESCRIPTION
We only conditionally replace this _if_ there is a version number in the
code block, because this breaks syntax highlighting.

This is kind of a cheap hack, and we should really be replacing the
strings with version numbers further upstream before they get broken
into syntax highlighting chunks, that way we get to keep both working
version numbers, as well as syntax highlighting.

I tried messing around with contentlayer to replace these strings further upstream, but I couldn't figure it out within my timeboxed session. Hence leaving this PR as it is, because it's fairly important that correct version numbers be displayed and copied by our customers.

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
