### PR TITLE
search jobs: mention download button

### DIFF
--- a/docs/code-search/types/search-jobs.mdx
+++ b/docs/code-search/types/search-jobs.mdx
@@ -17,6 +17,7 @@ To use Search Jobs, you need to:
 
 - If your query is valid, click **Create a search job** to initiate the search job
 - You will be redirected to the "Search Jobs UI" page at `/search-jobs`, where you can view all your created search jobs. If you're a site admin, you can also view search jobs from other users on the instance
+- For each search job, you can download the results by clicking the **Download** button. The results are formatted as JSON lines, see [Search results format](#search-results-format) for more details.
 
 ![view-search-jobs](https://storage.googleapis.com/sourcegraph-assets/Docs/search-jobs/search-jobs-manage.png)
 

--- a/docs/code-search/types/search-jobs.mdx
+++ b/docs/code-search/types/search-jobs.mdx
@@ -19,7 +19,7 @@ To use Search Jobs, you need to:
 - You will be redirected to the "Search Jobs UI" page at `/search-jobs`, where you can view all your created search jobs. If you're a site admin, you can also view search jobs from other users on the instance
 - For each search job, you can download the results by clicking the **Download** button. The results are formatted as JSON lines, see [Search results format](#search-results-format) for more details.
 
-![view-search-jobs](https://storage.googleapis.com/sourcegraph-assets/Docs/search-jobs/search-jobs-manage.png)
+![view-search-jobs](https://storage.googleapis.com/sourcegraph-assets/Docs/search-jobs/search-jobs-manage-with-frame.png)
 
 ## Search results format
 


### PR DESCRIPTION
This is based on internal feedback that the documentation doesn't describe how to consume the results.

Test plan:
N/A
