### PR TITLE
search-jobs: update defaults

### DIFF
--- a/docs/admin/search.mdx
+++ b/docs/admin/search.mdx
@@ -153,8 +153,8 @@ Shard merging can be fine-tuned by setting ENV variables for Zoekt indexserver:
 | ---------------------- | ---------------------------------------------------------------------------------------------- | -------- |
 | SRC_VACUUM_INTERVAL    | Run vacuum this often, specified as a duration                                                 | 24 hours |
 | SRC_MERGE_INTERVAL     | Run merge this often, specified as a duration                                                  | 8 hours  |
-| SRC_MERGE_TARGET_SIZE  | The target size of compound shards in MiB                                                      | 2000     |
-| SRC_MERGE_MIN_SIZE     | The minimum size of a compound shard in MiB                                                    | 1800     |
+| SRC_MERGE_TARGET_SIZE  | The target size of compound shards in MiB                                                      | 1000     |
+| SRC_MERGE_MIN_SIZE     | The minimum size of a compound shard in MiB                                                    | 800      |
 | SRC_MERGE_MIN_AGE      | The time since the last commit in days. Shards with newer commits are excluded from merging.   | 7        |
 
 When repostiories receive udpates, Zoekt reindexes them and tombstones their old index data. As a result, compound shards can shrink and be dismantled into individual shards once they reach a critical minimum size. These individual


### PR DESCRIPTION
The defaults were changed in https://github.com/sourcegraph/zoekt/pull/850.

Test plan:
N/A
