### PR TITLE
fix: mention pgsslmode in the docs for external db

### DIFF
--- a/docs/admin/deploy/kubernetes/index.mdx
+++ b/docs/admin/deploy/kubernetes/index.mdx
@@ -103,6 +103,7 @@ data:
   password: ""
   port: ""
   user: ""
+  pgsslmode: "require" # optional, enable if using SSL
 ---
 apiVersion: v1
 kind: Secret
@@ -115,6 +116,7 @@ data:
   password: ""
   port: ""
   user: ""
+  pgsslmode: "require" # optional, enable if using SSL
 ---
 apiVersion: v1
 kind: Secret
@@ -127,6 +129,7 @@ data:
   password: ""
   port: ""
   user: ""
+  pgsslmode: "require" # optional, enable if using SSL
 ```
 
 The above Secrets should be deployed to the same namespace as the existing Sourcegraph deployment.
@@ -163,6 +166,7 @@ pgsql:
     user: "new-user"
     password: "new-password"
     port: "5432"
+    pgsslmode: "require" # optional, enable if using SSL
 ```
 
 #### Using external Redis instances


### PR DESCRIPTION
This is particularly for the helm chart, since a customer was asking
about this. Docs applied from @marcleblanc2's recommendation in the
[linear thread](https://linear.app/sourcegraph/issue/REL-638/configure-aws-rds-databases-for-tls-connections-in-helm-chart)

<!-- Explain the changes introduced in your PR -->

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
