### PR TITLE
chore: Remove 'Indexers' entry from side menu

### DIFF
--- a/docs/code-search/code-navigation/precise_code_navigation.mdx
+++ b/docs/code-search/code-navigation/precise_code_navigation.mdx
@@ -67,6 +67,6 @@ The following repositories have precise code navigation enabled:
 ## More resources
 
 <QuickLinks>
-    <QuickLink href="/code-search/code-navigation/writing_an_indexer" icon="installation" imgAlt="Code Navigation" title="Writing a SCIP indexer" description="Learn how you can write an indexer to emit SCIP with Sourcegraph." />
+    <QuickLink href="/code-search/code-navigation/writing_an_indexer" icon="installation" imgAlt="Code Navigation" title="Writing a SCIP indexer" description="Learn how you can write an indexer to emit SCIP for code navigation in Sourcegraph." />
     <QuickLink href="/code-search/code-navigation/how-to/adding_lsif_to_workflows" icon="lightbulb" imgAlt="Code Navigation" title="Adding precise code navigation to CI/CD workflows" description="Learn how to add precise code navigation to CI/CD workflows to Sourcegraph." />
 </QuickLinks>

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -102,7 +102,6 @@ export const navigation: NavigationItem[] = [
 							{ title: "Features", href: "/code-search/code-navigation/features", },
 							{ title: "Search-based code navigation", href: "/code-search/code-navigation/search_based_code_navigation", },
 							{ title: "Precise code navigation", href: "/code-search/code-navigation/precise_code_navigation", },
-							{ title: "Indexers", href: "/code-search/code-navigation/writing_an_indexer", },
 							{ title: "Auto-indexing", href: "/code-search/code-navigation/auto_indexing", },
 							{ title: "Environment Variables", href: "/code-search/code-navigation/envvars", },
 							{ title: "Troubleshooting", href: "/code-search/code-navigation/troubleshooting", },


### PR DESCRIPTION
The Writing an Indexer page is linked from the Precise Code Nav page.
It doesn't make sense to link it from the overall Nav with the label
'Indexers' because the 'Indexers' title makes it seems like the page
will describe the available indexers.