### PR TITLE
Add troubleshooting steps for Kaspersky Antivirus sign-in issue (#908)

### DIFF
--- a/docs/cody/faq.mdx
+++ b/docs/cody/faq.mdx
@@ -137,6 +137,22 @@ cody chat --model '$name_of_the_model' -m 'Hi Cody!'
 
 For example, to use Claude 3.5 Sonnet, you'd pass the following command in your terminal, `cody chat --model 'claude-3.5-sonnet' -m 'Hi Cody!'
 
+### Sign-in dialog gets stuck with Kaspersky Antivirus
+
+**Problem:** When attempting to sign in, users may encounter a perpetual `"Signing in to Sourcegraph..."` dialog that never completes. This issue persists across different VS Code extension versions (e.g. 1.40-1.48) and browsers (Chrome, Edge, Firefox). In the browser console at `accounts.sourcegraph.com/sign-in`, you might see an error: `"Uncaught ApolloError: value.toString is not a function"`.
+
+**Solution:** This issue is typically caused by Kaspersky Antivirus interfering with the authentication process. To resolve:
+
+- Locate the Kaspersky icon in your system tray
+- Right-click on the Kaspersky icon
+- Select "Stop Protection"
+- Right-click the icon again
+- Select "Exit"
+
+<Callout type="warning">
+Once you are signed in make sure to re-enable protection.
+</Callout>
+
 ## OpenAI o1
 
 ### What are OpenAI o1 best practices?


### PR DESCRIPTION
The new content provides guidance for users experiencing a stuck sign-in dialog due to Kaspersky Antivirus interference. It includes the problem description, solution steps, and a warning to re-enable protection after signing in.

<!-- Explain the changes introduced in your PR -->

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
