### PR TITLE
chore(docs): remove incorrect customer redirect in aws docker

### DIFF
--- a/docs/admin/deploy/docker-compose/aws.mdx
+++ b/docs/admin/deploy/docker-compose/aws.mdx
@@ -1,9 +1,5 @@
 # Install Sourcegraph on Amazon Web Services (AWS)
 
-> ⚠️ We recommend new users use our [AWS AMI](/admin/deploy/machine-images/aws-oneclick) or [script-install](/admin/deploy/single-node/script) instructions, which are easier and offer more flexibility when configuring Sourcegraph. Existing customers can reach out to our Customer Engineering team support@sourcegraph.com if they wish to migrate to these deployment models.
-
-
-
 This guide will take you through how to deploy Sourcegraph with [Docker Compose](https://docs.docker.com/compose/) to a single EC2 instance on Amazon Web Services (AWS).
 
 Deploy a Sourcegraph instance with an [AWS AMI](/admin/deploy/machine-images/aws-ami) or [AWS One-Click](/admin/deploy/machine-images/aws-oneclick). (Recommended)


### PR DESCRIPTION
Remove incorrect customer advisement to not use docker compose and instead use an install script or machine images