### PR TITLE
chore(docs): remove incorrect customer redirect in gcp docker

### DIFF
--- a/docs/admin/deploy/docker-compose/digitalocean.mdx
+++ b/docs/admin/deploy/docker-compose/digitalocean.mdx
@@ -1,7 +1,5 @@
 # Install Sourcegraph on DigitalOcean
 
-> ⚠️ We recommend new users use our [machine image](/admin/deploy/machine-images/) or [script-install](/admin/deploy/single-node/script) instructions, which are easier and offer more flexibility when configuring Sourcegraph. Existing customers can reach out to our Customer Engineering team support@sourcegraph.com if they wish to migrate to these deployment models.
-
 ---
 
 This guide will take you through how to deploy a Sourcegraph instance to a single DigitalOcean Droplet with [Docker Compose](https://docs.docker.com/compose/).

--- a/docs/admin/deploy/docker-compose/google_cloud.mdx
+++ b/docs/admin/deploy/docker-compose/google_cloud.mdx
@@ -1,7 +1,5 @@
 # Install Sourcegraph on Google Cloud
 
-> ⚠️ We recommend new users use our [GCE machine image](/admin/deploy/machine-images/gce) or [script-install](/admin/deploy/single-node/script) instructions, which are easier and offer more flexibility when configuring Sourcegraph. Existing customers can reach out to our Customer Engineering team support@sourcegraph.com if they wish to migrate to these deployment models.
-
 This guide will take you through how to deploy Sourcegraph with [Docker Compose](https://docs.docker.com/compose/) to a single node running on Google Cloud.
 
 ## Configure


### PR DESCRIPTION
Remove incorrect customer advisement to not use docker compose and instead use an install script or machine images