### PR TITLE
chore(docs): remove another warning for docker

### DIFF
--- a/docs/admin/deploy/docker-compose/aws.mdx
+++ b/docs/admin/deploy/docker-compose/aws.mdx
@@ -2,8 +2,6 @@
 
 This guide will take you through how to deploy Sourcegraph with [Docker Compose](https://docs.docker.com/compose/) to a single EC2 instance on Amazon Web Services (AWS).
 
-Deploy a Sourcegraph instance with an [AWS AMI](/admin/deploy/machine-images/aws-ami) or [AWS One-Click](/admin/deploy/machine-images/aws-oneclick). (Recommended)
-
 
 ## Configure
 


### PR DESCRIPTION
Remove another warning telling customers not to use docker compose in a part of the docs that customers would already be running or have chosen docker compose.