### PR TITLE
Preserve the path when redirecting the latest version

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -48,15 +48,15 @@ export function middleware(request: NextRequest) {
   if (pathWithoutBase.startsWith(`/v/${docsConfig.DOCS_LATEST_VERSION}/`)) {
     return NextResponse.redirect(createRedirectUrl(
       request,
-      `https://sourcegraph.com/docs/:slug*`,
-      pathWithoutBase
+      pathWithoutBase.substring(`/v/${docsConfig.DOCS_LATEST_VERSION}/`.length - 1),
+      ""
     ))
   }
   if (pathWithoutBase.startsWith(`/@${docsConfig.DOCS_LATEST_VERSION}/`)) {
     return NextResponse.redirect(createRedirectUrl(
       request,
-      `https://sourcegraph.com/docs/:slug*`,
-      pathWithoutBase
+      pathWithoutBase.substring(`/@${docsConfig.DOCS_LATEST_VERSION}/`.length - 1),
+      ""
     ))
   }
   const versionMatch = pathWithoutBase.match(/^\/v\/(\d+\.\d+)\/(.*)/)


### PR DESCRIPTION
When redirecting links that contain the latest version in the path, only the slug was being preserved, and the redirect was going to sourcegraph.com.

Change that to preserve the whole path (except the version), and to preserve the current host.

For example:

`http://localhost:3000/docs/v/5.11/code_search/reference/queries` should redirect to `/docs/code_search/reference/queries`, which should finally redirect to `/docs/code-search/queries`

Behavior of `/@5.11/` should be the same as `/v/5.11/`.