### PR TITLE
chore(docs): Add AWS account IDs for AMI publishing

### DIFF
--- a/docs/admin/deploy/machine-images/aws-ami.mdx
+++ b/docs/admin/deploy/machine-images/aws-ami.mdx
@@ -8,6 +8,14 @@ Following these docs will provision the following resources:
 - A root EBS volume with 50GB of storage
 - An additional EBS volume with 500GB of storage for storing code and search indices
 
+### Sourcegraph AMI account ID
+
+All Sourcegraph AMIs are published from one of the following AWS accounts:
+
+- Account ID: `840044800169`
+- Account ID: `870751268155`
+
+
 ### Instance size chart
 
 Select an AMI according and instance type to the number of users and repositories you have using this table. If you fall between two sizes, choose the larger of the two.


### PR DESCRIPTION
Add Sourcegraph AWS account IDs to docs for easier customer verification when pulling AMI images.