### PR TITLE
chore(docs): Note dynamic AWS sizing

### DIFF
--- a/docs/admin/deploy/machine-images/aws-ami.mdx
+++ b/docs/admin/deploy/machine-images/aws-ami.mdx
@@ -34,7 +34,7 @@ Click [here](https://github.com/sourcegraph/deploy#amazon-ec2-amis) to see the c
 
 **The default AMI username is `ec2-user`.**
 
-<Callout type="note">AMIs are optimized for the specific set of resources provided by the instance type, please ensure you use the correct AMI for the associated EC2 instance type. You can [resize your EC2 instance anytime](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-resize.html), but your Sourcegraph AMI must match accordingly. If needed, follow the [upgrade steps](#upgrade) to switch to the correct AMI image that is optimized for your EC2 instance type.</Callout>
+<Callout type="note">While we recommend certain image types in our sizing chart, AMIs will dynamically use the resources available on the EC2 instance type they are deployed to, provided the minimum amount of resources needed is available. If you would like to resize your EC2 instance, follow the [upgrade steps](#upgrade) to switch to the correct AMI image that is optimized for your EC2 instance type.</Callout>
 
 ---
 
@@ -43,7 +43,7 @@ Click [here](https://github.com/sourcegraph/deploy#amazon-ec2-amis) to see the c
 1. In the [instance size chart](#instance-size-chart), click the link for the AMI that matches your deployment size.
 2. Choose **Launch instance from AMI**.
 3. Name your instance.
-4. Select an **instance type** according to [the sizing chart](#instance-size-chart).
+4. Select an **instance type** according to [the sizing chart](#instance-size-chart) or your needs.
 5. **Key pair (login)**: Select or create a new Key Pair for connecting to your instance securely (this may be required in the event you need support).
 6. **Network settings**:
    - Under "Auto-assign public IP" select "Enable".


### PR DESCRIPTION
Change AMI docs to reference AWS AMI dynamic sizing that is no longer strictly tied to T-Shirt sizes and pre-defined EC2 instance sizes