### PR TITLE
feat(docs): update auto-edit availability details

### DIFF
--- a/docs/cody/capabilities/auto-edit.mdx
+++ b/docs/cody/capabilities/auto-edit.mdx
@@ -2,7 +2,7 @@
 
 <p className="subtitle">Auto-edit suggests code changes by analyzing cursor movements and typing. After you've made at least one character edit in your codebase, it begins proposing contextual modifications based on your cursor position and recent changes.</p>
 
-<Callout type="info">Auto-edit is currently available in VS Code extension in the Experimental stage for all Cody Pro users and Enterprise users on Cody Gateway.</Callout>
+<Callout type="info">Auto-edits is currently in experimental rollout within the VS Code extension. Access is limited to selected Enterprise Starter (Cody Pro) and Enterprise users on Cody Gateway. We will expand availability as we validate the feature's performance.</Callout>
 
 ## Capabilities of auto-edit
 


### PR DESCRIPTION
The updated callout message provides more details on the current experimental rollout of the auto-edit feature, including the limited access for Enterprise Starter (Cody Pro) and Enterprise users on Cody Gateway. This change aims to set clearer expectations around the feature's availability.

<!-- Explain the changes introduced in your PR -->

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
