### PR TITLE
6.0.0 MVU upgrade docs update

### DIFF
--- a/docs/admin/deploy/docker-compose/upgrade-6.0.mdx
+++ b/docs/admin/deploy/docker-compose/upgrade-6.0.mdx
@@ -1,0 +1,90 @@
+import { CURRENT_VERSION_STRING } from 'src/components/PreCodeBlock'
+
+# Upgrade Sourcegraph on Docker Compose to v6.0 and beyond
+
+This document describes the process to update a Docker Compose Sourcegraph instance, specifically if you are targetting versions 6.0 and above, particularly if you are running in cluster databases from before v5.10. This document provides details on the steps required to also upgrade the Postgres containers to version 16.
+If you are unfamiliar with sourcegraph versioning or releases see our [general concepts documentation](/admin/updates/).
+
+> ***⚠️ Attention: Always consult the [release notes](/admin/updates/docker_compose) for the versions your upgrade will pass over and end on.***
+
+### Multi-version upgrades to the 6.0 release and beyond
+
+---
+
+> **⚠️ Attention:** please see our [cautionary note](/admin/updates/#best-practices) on upgrades, if you have any concerns about running a multiversion upgrade, please reach out to us at [support@sourcegraph.com](mailto:support@sourcegraph.com) for advisement.
+
+To perform a **manual** multi-version upgrade on a Sourcegraph instance running on Docker compose follow the procedure below:
+
+1. **Check Upgrade Readiness**:
+   - Check the [upgrade notes](/admin/updates/docker_compose#docker-compose-upgrade-notes) for the version range you're passing through.
+   - Check the `Site Admin > Updates` page to determine [upgrade readiness](/admin/updates/#upgrade-readiness).
+
+2. **Shutdown your instance of Sourcegraph**:
+   - In order to upgrade the databess, we must first shut down your instance of Sourcegraph. In particular, you should be in the directory containing your `docker-compose.yaml` file.
+   ```sh
+   $ pwd
+   /cloned/repo/location/deploy-sourcegraph-docker/docker-compose
+   $ docker-compose down
+   ```
+
+3. **Switch to the new release version**:
+   - Run the following command in local clone of your repository.
+  ```sh
+  $ git checkout v6.0.0
+  ```
+
+4. **Start up _only_ the database containers**:
+    - The database containers contain a self-executing, upgrade in place script that needs to be perfomed before starting up the remaining containers.
+    - Note that the names of the underlying images have changed in version 5.10, if you're manually changing the image references, be sure to checkout the correct version of the underlying image. This can be done by checking the official deployment repo [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker/)
+    ```sh
+    $ docker-compose up -d pgsql codeintel-db codeinsights-db
+    ```
+
+5. **Run Migrator with the `upgrade` command**:
+   - The following procedure describes running migrator in brief, for more detailed instructions and available command flags see our [migrator docs](/admin/updates/migrator/migrator-operations#docker-compose).
+    > *Note: Always use the latest image version of migrator for migrator commands, except the startup command `up`*
+    1. Set the migrator `image:` in your `docker-compose.yaml` to the **latest** release of `migrator`. **Example:**
+    - You may be able to skip this step if you're using the latest version of the migrator image, by upgrading to the latest version of Sourcegraph.
+    ```yaml
+    migrator:
+      container_name: migrator
+      image: 'index.docker.io/sourcegraph/migrator:6.0.0'
+    ```
+    2. Set the migrator `command:` to `upgrade` you'll need to supply a `--to=` argument. **Example:**
+    ```yaml
+    command: ['upgrade', '--from=v5.8.0', '--to=v6.0.0']
+    ```
+    > *Note: you may add the `--dry-run` flag to the `command:` to test things out before altering the dbs*
+    3. Run migrator with `docker-compose up migrator` **Example:**
+    ```sh
+    $ ~/deploy-sourcegraph-docker/docker-compose/ docker-compose up migrator
+    codeintel-db is up-to-date
+    codeinsights-db is up-to-date
+    pgsql is up-to-date
+    Recreating migrator ... done
+    Attaching to migrator
+    migrator                         | ❗️ An error was returned when detecting the terminal size and capabilities:
+    migrator                         |
+    migrator                         |    GetWinsize: inappropriate ioctl for device
+    migrator                         |
+    migrator                         |    Execution will continue, but please report this, along with your operating
+    migrator                         |    system, terminal, and any other details, to:
+    migrator                         |      https://github.com/sourcegraph/sourcegraph/issues/new
+    migrator                         |
+    migrator                         | ✱ Sourcegraph migrator 6.0.0
+    migrator                         | 👉 Migrating to v6.0 (step 1 of 2)
+    migrator                         | 👉 Running schema migrations
+    migrator                         | ✅ Schema migrations complete
+    migrator                         | 👉 Running out of band migrations [23 24]
+    ✅ Out of band migrations complete
+    migrator                         | 👉 Migrating to v6.0 (step 2 of 2)
+    migrator                         | 👉 Running schema migrations
+    migrator                         | ✅ Schema migrations complete
+    migrator                         | migrator exited with code 0
+    ```
+
+6. **Start your containers again**:
+   - run `docker-compose up -d` in the folder containing your `docker-compose.yaml` file.
+   ```sh
+   $ docker-compose up -d
+   ```

--- a/docs/admin/deploy/docker-compose/upgrade.mdx
+++ b/docs/admin/deploy/docker-compose/upgrade.mdx
@@ -72,6 +72,7 @@ To perform a **manual** multi-version upgrade on a Sourcegraph instance running 
    - Check the `Site Admin > Updates` page to determine [upgrade readiness](/admin/updates/#upgrade-readiness).
 
 2. **Disable Connections to the Database**:
+   > **⚠️ Attention:** If your database is still running Postgres 12, upgrade your database to Postgres 16 in this step. For our built-in databases offerings, this can be accomplished by starting the databases using our `postgresql-16` images packaged in the deploy repos starting in version `5.10.0`. Learn more [here](/admin/postgres).
    - Run the following command in the directory containing your `docker-compose.yaml` file.
   ```sh
   $ docker-compose stop && docker-compose up -d pgsql codeintel-db codeinsights-db

--- a/docs/admin/deploy/docker-compose/upgrade.mdx
+++ b/docs/admin/deploy/docker-compose/upgrade.mdx
@@ -78,14 +78,15 @@ To perform a multi-version upgrade via migrators [upgrade](/admin/updates/migrat
 
 4. **Run Migrator with the `upgrade` command**:
    - *For more detailed instructions and available command flags see our [migrator docs](/admin/updates/migrator/migrator-operations#docker-compose).*
-    1. If the migrator `image:` in your `docker-compose.yaml` wasn't updated to in the **latest** release of `migrator` in step 2 set migrator's image to the latest release. **Example:**
+    1. If the migrator `image:` in your `docker-compose.yaml` wasn't updated to in the **latest** release of `migrator` in step 2 set migrator's image to the latest release.
+    **Example:**
     ```yaml
     migrator:
       container_name: migrator
       image: 'index.docker.io/sourcegraph/migrator:6.0.0'
     ```
-    > *Note: Always use the latest image version of migrator for migrator commands, except the startup command `up`*
-    2. Set the migrator `command:` to `upgrade` you'll need to supply a `--to=` argument. **Example:**
+    2. Set the migrator `command:` to `upgrade` you'll need to supply a `--to=` argument to the version you're upgrading to. 
+    **Example:**
     ```yaml
     command: ['upgrade', '--from=v5.9.0', '--to=v6.0.0']
     ```
@@ -122,7 +123,7 @@ To perform a multi-version upgrade via migrators [upgrade](/admin/updates/migrat
     migrator | ✅ Schema migrations complete
     migrator exited with code 0
     ```
-5. **Set Migrator to `up`**
+5. **Run Migrator with the `up` command**
    - Set your migrator `command:` to `up`
    > *Note: If you aren't upgrading to the latest release remember to set the migrator image back to the version you are upgrading to.*
    **Example:**

--- a/docs/admin/deploy/docker-compose/upgrade.mdx
+++ b/docs/admin/deploy/docker-compose/upgrade.mdx
@@ -59,91 +59,83 @@ $ docker-compose up -d --remove-orphans
 
 ### Multi-version upgrades
 
-If you are upgrading to **Sourcegraph 5.1 or later**, we encourage you to perform an [**automatic multi-version upgrade**](/admin/updates/automatic). The following procedure has been automated, but is still applicable should errors occur in an automated upgrade.
+> **⚠️ Attention:** Multiversion upgrades **require downtime**, please see our [cautionary note](/admin/updates/#best-practices) on upgrades, if you have any concerns about running a multiversion upgrade, please reach out to us at [support@sourcegraph.com](mailto:support@sourcegraph.com) for advisement.
 
----
-
-> **⚠️ Attention:** please see our [cautionary note](/admin/updates/#best-practices) on upgrades, if you have any concerns about running a multiversion upgrade, please reach out to us at [support@sourcegraph.com](mailto:support@sourcegraph.com) for advisement.
-
-To perform a **manual** multi-version upgrade on a Sourcegraph instance running on Docker compose follow the procedure below:
+To perform a multi-version upgrade via migrators [upgrade](/admin/updates/migrator/migrator-operations#upgrade) command on a Sourcegraph instance running on Docker compose follow the procedure below:
 
 1. **Check Upgrade Readiness**:
    - Check the [upgrade notes](/admin/updates/docker_compose#docker-compose-upgrade-notes) for the version range you're passing through.
    - Check the `Site Admin > Updates` page to determine [upgrade readiness](/admin/updates/#upgrade-readiness).
 
-2. **Disable Connections to the Database**:
-   > **⚠️ Attention:** If your database is still running Postgres 12, upgrade your database to Postgres 16 in this step. For our built-in databases offerings, this can be accomplished by starting the databases using our `postgresql-16` images packaged in the deploy repos starting in version `5.10.0`. Learn more [here](/admin/postgres).
-   - **NOTE**: Names of the images have changed with the release of Sourcegraph 5.10.0. If you are using a version prior to 5.10.0, please ensure you use the following image names going forward:
-      - `postgres-12` -> `postgresql-16`
-      - `codeintel-db` -> `postgresql-16`
-      - `codeinsights-db` -> `postgresql-16-codeinsights`
+2. **Pull and merge upstream changes**:
+   - Follow the [standard upgrade procedure](#standard-upgrades) to pull and merge upstream changes from the version you are upgrading to to your `release` branch.
 
-   - Change the `image:` in your `docker-compose.yaml` to the release of `pgsql`, `codeinsights-db`, and `codeintel-db`. **Example:**
-    ```yaml
-    pgsql:
-      container_name: pgsql
-      image: 'index.docker.io/sourcegraph/postgresql-16:6.0.0'
-    ...
-    codeintel-db:
-      container_name: codeintel-db
-      image: 'index.docker.io/sourcegraph/postgresql-16:6.0.0'
-    ...
-    codeinsights-db:
-      container_name: codeintel-db
-      image: 'index.docker.io/sourcegraph/postgresql-16-codeinsights:6.0.0'
-    ```
+3. **Disable Connections to the Database**:
+   - Stop running containers connected to the databases and the databases:
+   ```
+   $ docker-compose down --remove-orphans
+   ```
 
-   - Run the following command in the directory containing your `docker-compose.yaml` file.
-  ```sh
-  $ docker-compose stop && docker-compose up -d pgsql codeintel-db codeinsights-db
-  ```
-3. **Run Migrator with the `upgrade` command**:
-   - The following procedure describes running migrator in brief, for more detailed instructions and available command flags see our [migrator docs](/admin/updates/migrator/migrator-operations#docker-compose).
-    1. Set the migrator `image:` in your `docker-compose.yaml` to the **latest** release of `migrator`. **Example:**
+4. **Run Migrator with the `upgrade` command**:
+   - *For more detailed instructions and available command flags see our [migrator docs](/admin/updates/migrator/migrator-operations#docker-compose).*
+    1. If the migrator `image:` in your `docker-compose.yaml` wasn't updated to in the **latest** release of `migrator` in step 2 set migrator's image to the latest release. **Example:**
     ```yaml
     migrator:
       container_name: migrator
-      image: 'index.docker.io/sourcegraph/migrator:5.0.4'
+      image: 'index.docker.io/sourcegraph/migrator:6.0.0'
     ```
     > *Note: Always use the latest image version of migrator for migrator commands, except the startup command `up`*
     2. Set the migrator `command:` to `upgrade` you'll need to supply a `--to=` argument. **Example:**
     ```yaml
-    command: ['upgrade', '--from=v4.1.2', '--to=v4.4.0']
+    command: ['upgrade', '--from=v5.9.0', '--to=v6.0.0']
     ```
     > *Note: you may add the `--dry-run` flag to the `command:` to test things out before altering the dbs*
-    3. Run migrator with `docker-compose up migrator` **Example:**
+    3. Run migrator with `docker-compose up migrator` 
+    
+    - Migrator `depends_on:` will ensure that the databases are ready before attempting to run migrator. Ensuring that database entrypoint scripts are run before migrator attempts to connect to the databases. For users upgrading from a version earliar than `5.10.0` a PostrgreSQL version is required and will be performed automatically here. For more details see [Upgradeing PostgreSQL](/admin/postgresql#upgrading-postgresql).
+    
+    **Example:**
     ```sh
     $ ~/deploy-sourcegraph-docker/docker-compose/ docker-compose up migrator
-    codeintel-db is up-to-date
-    codeinsights-db is up-to-date
-    pgsql is up-to-date
-    Recreating migrator ... done
+    ✔ Network docker-compose_sourcegraph Create... 0.1s
+    ✔ Container pgsql Created 0.1s
+    ✔ Container codeinsights-db Created 0.1s
+    ✔ Container codeintel-db Created 0.1s
+    ! codeinsights-db The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested 0.0s
+    ! pgsql The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested 0.0s
+    ! codeintel-db The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested 0.0s
+    ✔ Container migrator Created 0.0s
+    ! migrator The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested 0.0s
     Attaching to migrator
-    migrator                         | ❗️ An error was returned when detecting the terminal size and capabilities:
-    migrator                         |
-    migrator                         |    GetWinsize: inappropriate ioctl for device
-    migrator                         |
-    migrator                         |    Execution will continue, but please report this, along with your operating
-    migrator                         |    system, terminal, and any other details, to:
-    migrator                         |      https://github.com/sourcegraph/sourcegraph/issues/new
-    migrator                         |
-    migrator                         | ✱ Sourcegraph migrator 4.4.0
-    migrator                         | 👉 Migrating to v4.3 (step 1 of 2)
-    migrator                         | 👉 Running schema migrations
-    migrator                         | ✅ Schema migrations complete
-    migrator                         | 👉 Running out of band migrations [17 18]
-    ✅ Out of band migrations complete
-    migrator                         | 👉 Migrating to v4.4 (step 2 of 2)
-    migrator                         | 👉 Running schema migrations
-    migrator                         | ✅ Schema migrations complete
-    migrator                         | migrator exited with code 0
+    migrator | ✱ Sourcegraph migrator 6.0.0
+    migrator | ⚠️ Failed to check for migrator update: unexpected status code 404. Continuing...
+    migrator | Attempting connection to frontend...
+    migrator | ✅ Connection to frontend succeeded
+    migrator | Attempting connection to frontend...
+    migrator | ✅ Connection to frontend succeeded
+    migrator | Attempting connection to codeintel...
+    migrator | ✅ Connection to codeintel succeeded
+    migrator | Attempting connection to codeinsights...
+    migrator | ✅ Connection to codeinsights succeeded
+    migrator | 👉 Migrating to v6.0 (step 1 of 1)
+    migrator | 👉 Running schema migrations
+    migrator | ✅ Schema migrations complete
+    migrator exited with code 0
     ```
+5. **Set Migrator to `up`**
+   - Set your migrator `command:` to `up`
+   > *Note: If you aren't upgrading to the latest release remember to set the migrator image back to the version you are upgrading to.*
+   **Example:**
+   ```yaml
+   migrator:
+     container_name: migrator
+     image: 'index.docker.io/sourcegraph/migrator:6.0.0@sha256:ec295eb0b743da6bf56777ca6524972267a5c442b0288095e2fe12fce38ebacc'
+     cpus: 0.5
+     mem_limit: '500m'
+     command: ['up']
+   ```
 
-4. **Pull and merge upstream changes**:
-   - Follow the [standard upgrade procedure](#standard-upgrades) to pull and merge upstream changes from the version you are upgrading to to your `release` branch.
-   - **⚠️ Attention:** *merging upstream changes should set the migrator `image:` version back to the release you are upgrading to, and the `command:` should be set back to `up`, this is necessary to start your instance again.*
-
-5. **Start your containers again**:
+6. **Start your containers again**:
    - run `docker-compose up -d` in the folder containing your `docker-compose.yaml` file.
    ```sh
    $ docker-compose up -d

--- a/docs/admin/deploy/docker-compose/upgrade.mdx
+++ b/docs/admin/deploy/docker-compose/upgrade.mdx
@@ -73,6 +73,26 @@ To perform a **manual** multi-version upgrade on a Sourcegraph instance running 
 
 2. **Disable Connections to the Database**:
    > **⚠️ Attention:** If your database is still running Postgres 12, upgrade your database to Postgres 16 in this step. For our built-in databases offerings, this can be accomplished by starting the databases using our `postgresql-16` images packaged in the deploy repos starting in version `5.10.0`. Learn more [here](/admin/postgres).
+   - **NOTE**: Names of the images have changed with the release of Sourcegraph 5.10.0. If you are using a version prior to 5.10.0, please ensure you use the following image names going forward:
+      - `postgres-12` -> `postgresql-16`
+      - `codeintel-db` -> `postgresql-16`
+      - `codeinsights-db` -> `postgresql-16-codeinsights`
+
+   - Change the `image:` in your `docker-compose.yaml` to the release of `pgsql`, `codeinsights-db`, and `codeintel-db`. **Example:**
+    ```yaml
+    pgsql:
+      container_name: pgsql
+      image: 'index.docker.io/sourcegraph/postgresql-16:6.0.0'
+    ...
+    codeintel-db:
+      container_name: codeintel-db
+      image: 'index.docker.io/sourcegraph/postgresql-16:6.0.0'
+    ...
+    codeinsights-db:
+      container_name: codeintel-db
+      image: 'index.docker.io/sourcegraph/postgresql-16-codeinsights:6.0.0'
+    ```
+
    - Run the following command in the directory containing your `docker-compose.yaml` file.
   ```sh
   $ docker-compose stop && docker-compose up -d pgsql codeintel-db codeinsights-db

--- a/docs/admin/deploy/kubernetes/index.mdx
+++ b/docs/admin/deploy/kubernetes/index.mdx
@@ -942,6 +942,8 @@ If you are upgrading to **Sourcegraph 5.1 or later**, we encourage you to perfor
 - Check the `Site Admin > Updates` page to determine [upgrade readiness](/admin/updates/#upgrade-readiness).
 
 **Step 2:**
+> **⚠️ Attention:** If your database is still running Postgres 12, upgrade your database to Postgres 16 in this step. For our built-in databases offerings, this can be accomplished by starting the databases using our `postgresql-16` images packaged in the deploy repos starting in version `5.10.0`. Learn more [here](/admin/postgres).
+
 Scale down `deployments` and `statefulSets` that access the database, _this step prevents services from accessing the database while schema migrations are in process._
 The following services must have their replicas scaled to 0:
  - Deployments (e.g., `kubectl scale deployment <name> --replicas=0`)

--- a/docs/admin/deploy/kubernetes/upgrade.mdx
+++ b/docs/admin/deploy/kubernetes/upgrade.mdx
@@ -133,6 +133,7 @@ To perform a **manual** multi-version upgrade on a Sourcegraph instance running 
    - Check the `Site Admin > Updates` page to determine [upgrade readiness](/admin/updates/#upgrade-readiness).
 
 2. **Disable Connections to the Database**:
+  > **⚠️ Attention:** If your database is still running Postgres 12, upgrade your database to Postgres 16 in this step. For our built-in databases offerings, this can be accomplished by starting the databases using our `postgresql-16` images packaged in the deploy repos starting in version `5.10.0`. Learn more [here](/admin/postgres).
    - The following services must have their replicas scaled to 0:
      - Deployments (e.g., `kubectl scale deployment <name> --replicas=0`)
        - precise-code-intel-worker

--- a/docs/admin/deploy/kubernetes/upgrade.mdx
+++ b/docs/admin/deploy/kubernetes/upgrade.mdx
@@ -134,6 +134,30 @@ To perform a **manual** multi-version upgrade on a Sourcegraph instance running 
 
 2. **Disable Connections to the Database**:
   > **⚠️ Attention:** If your database is still running Postgres 12, upgrade your database to Postgres 16 in this step. For our built-in databases offerings, this can be accomplished by starting the databases using our `postgresql-16` images packaged in the deploy repos starting in version `5.10.0`. Learn more [here](/admin/postgres).
+  - If you're using our built in Postgres containers, versions from 5.10 onwards contain update in place scripts than run if necessary. You will first have to update the `image` field in your `pgsql`, `codeintel-db` and `codeinsights-db` StatefulSets to `sourcegraph/postgresql-16:6.0.0`  and `sourcegraph/codeinsights-db:6.0.0` respectively.
+  - **Example:**
+  ```yaml
+  # deploy-sourcegraph-k8s/base/sourcegraph/codeinsights-db/codeinsights-db.StatefulSet.yaml 
+      containers:
+        - name: codeinsights
+          image: index.docker.io/sourcegraph/postgresql-16-codeinsights:6.0.0
+  # deploy-sourcegraph-k8s/base/sourcegraph/codeintel-db/codeintel-db.StatefulSet.yaml 
+      containers:
+        - name: pgsql
+          image: index.docker.io/sourcegraph/postgresql-16:6.0.0
+  # deploy-sourcegraph-k8s/base/sourcegraph/pgsql/pgsql.StatefulSet.yaml 
+      containers:
+        - name: pgsql
+          image: index.docker.io/sourcegraph/postgresql-16:6.0.0
+  ```
+
+  - Apply specifically these changes to your cluster:
+  ```sh
+  $ kubectl apply -f deploy-sourcegraph-k8s/base/sourcegraph/pgsql/pgsql.StatefulSet.yaml deploy-sourcegraph-k8s/base/sourcegraph/codeintel-db/codeintel-db.StatefulSet.yaml deploy-sourcegraph-k8s/base/sourcegraph/codeinsights-db/codeinsights-db.StatefulSet.yaml
+  ```
+
+  - Wait until the containers come up, and complete their migration to Postgresql 16
+
    - The following services must have their replicas scaled to 0:
      - Deployments (e.g., `kubectl scale deployment <name> --replicas=0`)
        - precise-code-intel-worker

--- a/docs/admin/how-to/upgrade-postgres-12-16-builtin-dbs.mdx
+++ b/docs/admin/how-to/upgrade-postgres-12-16-builtin-dbs.mdx
@@ -1,0 +1,37 @@
+# Upgrading Built-in PostgreSQL
+
+The following doc contains detailed instructions for upgrading the built-in PostgreSQL databases. Via our `postgresql-16` and `postgresql-16-codeinsights` image entrypoint script. This doc assumes an admin is attempting to upgrade to Sourcegraph `6.0.0` from an older version (usually pre `5.10.0`) using one of our "deploy" repos. For more general info see [Upgrading PostgreSQL](/admin/postgres#upgrading-postgresql).
+
+> WARNING: Upgrading the PostgreSQL database requires stopping your Sourcegraph deployment which will result in **downtime**.
+>
+> Additionally, once the upgrade process is started via the database container, interrupting the container before the upgrade is complete could result in corrupting the underlying Postgres database. **We strongly advise taking a backup before the upgrade.**
+
+## Docker Compose
+
+1. Bring down your deployments
+```bash
+docker-compose down --remove-orphans
+```
+2. Change the `image:` in your `docker-compose.yaml` to the release of `pgsql`, `codeinsights-db`, and `codeintel-db`. Or [merge in changes](/admin/deploy/docker-compose/upgrade#standard-upgrades) from the tagged sourcegraph release you're planning to upgrade to. **Example:**
+```yaml
+pgsql:
+    container_name: pgsql
+    image: 'index.docker.io/sourcegraph/postgresql-16:6.0.0'
+...
+codeintel-db:
+    container_name: codeintel-db
+    image: 'index.docker.io/sourcegraph/postgresql-16:6.0.0'
+...
+codeinsights-db:
+    container_name: codeintel-db
+    image: 'index.docker.io/sourcegraph/postgresql-16-codeinsights:6.0.0'
+```
+3. Bring up your deployments
+```bash
+docker-compose up -d pgsql codeintel-db codeinsights-db
+```
+At this point simply wait for the database containers to come up healthy. If for some reason the database containers fail to come up healthy, please check their logs and reach out to us for support at support@sourcegraph.com.
+
+## Kubernetes Kustomize
+
+## Helm

--- a/docs/admin/postgres.mdx
+++ b/docs/admin/postgres.mdx
@@ -6,11 +6,20 @@ Sourcegraph uses several PostgreSQL databases to support various functionality. 
 - `codeintel-db`: provides support for lsif data and part of the code-intelligence
 - `codeinsights-db`: provides support for code insights data
 
-## Version requirements
+## Requirements
+
+### Version requirements
 
 We support Postgres 16 and above. Older versions of Sourcegraph supported 12 see our [Postgres 12 deprecation notice](/admin/postgres12_end_of_life_notice) for more details.
 
-## Role requirements
+Sourcegraph services attempting to connect to a database running Postgres 12 or less will display the following error message:
+```
+"new db handle: Sourcegraph requires PostgreSQL 16+. For more information about PostgreSQL requirements and upgrade guides, visit https://sourcegraph.com/docs/admin/postgres"
+```
+
+See [below](#upgrading-postgresql) for more details about how to upgrade your PostgreSQL database.
+
+### Role requirements
 
 The user provided to Sourcegraph must have full access to the `sg` database and be able to create the following
 extensions:
@@ -25,22 +34,38 @@ pgcrypto
 vector
 ```
 
-## [Configuring PostgreSQL](/admin/config/postgres-conf)
+## Configuring PostgreSQL
+
+Sourcegraph databases come preconfigured, however admins may make custom configurations as needed. For more information see our [configuration docs](/admin/config/postgres-conf).
+
+## Upgrading PostgreSQL
 
 ### Upgrading Built-in PostgreSQL
 
-Sourcegraph deployments come packaged with containers using the `postgresql-16` image for `pgsql` and `codeintel-db` deployments and `postgresql-16-codeinsights` for `codeinsights`. These images contain an entryscript which will detect and upgrade Postgres instances at version 12 (our previous images Postgres version). See the (Postgres 12 end of life notice)[/admin/prostgres12_end_of_life_notice#] for more details. 
+In Sourcegraph 5.10.0, we've upgraded our builtin database images to PostgreSQL 16.
+
+Database Image Updates:
+- `postgres-12` is now `postgresql-16`
+- `codeintel-db` is now `postgresql-16`
+- `codeinsights-db` is now `postgresql-16-codeinsights`
+
+These images contain an entryscript which will detect and upgrade Postgres instances at version 12 (our previous images Postgres version) to Postgres 16.
 
 > WARNING: Upgrading the PostgreSQL database requires stopping your Sourcegraph deployment which will result in **downtime**.
 >
-> Additionally, once the upgrade process is started via the database container, interrupting the container before the upgrade is complete could result in corrupting the underlying Postgres database. We strongly advise taking a backup before the upgrade. 
+> Additionally, once the upgrade process is started via the database container, interrupting the container before the upgrade is complete could result in corrupting the underlying Postgres database. **We strongly advise taking a backup before the upgrade.**
 
-The `PG_UPGRADE_EXTRA_ARGS` env var can be set in the built-in `postgresql-16` and `postgresql-16-codeinsights` deployments to provide extra arguments to the `pg_upgrade` command. 
+**For instance specfic instructions on how to upgrade a builtin Postgres database via the image entrypoint script, see [our instance specific operational instructions](/admin/how-to/upgrade-postgres-12-16-builtin-dbs).**
 
-Setting the env var `PG_UPGRADE_EXTRA_ARGS=--link` provides the `--link` option to the underlying `pg_update`; creating a hard links between the old and new data directories instead of copying data. This option is faster and requires less disk space, however if the database containers are interrupted during the upgrade process there is a strong possibility of data corruption. This can still be a viable choice for users who are confident in their container scheduling and backups and would like to avoid longer downtimes.
+### Upgrade entrypoint script options
 
-If not using the `--link` option, you will need enough disk space available for Postgres to make a copy of the existing data. For example, if your database is currently using 100GiB of storage, you will need an additional 100GiB free space in order for the upgrade process to succeed.
+The `PG_UPGRADE_EXTRA_ARGS` environment variable allows you to customize the `pg_upgrade` command in `postgresql-16` and `postgresql-16-codeinsights` deployments.
 
+- **Quick upgrade option:**
+Setting `PG_UPGRADE_EXTRA_ARGS=--link` creates hard links between old and new data directories instead of copying data. While faster and space-efficient, this method risks data corruption if containers are interrupted during upgrade. Best used when you have reliable container scheduling and solid backups.
+
+- **Storage requirements:**
+Without `--link`, you'll need double the current database size in free disk space. For example, a 100GiB database requires an additional 100GiB free space for the upgrade.
 
 ### Upgrading external PostgreSQL instances
 


### PR DESCRIPTION
This PR updates the upgrade docs embellishing instructions for the different deployment methods to include better coverage and handling of the Postgres 16 database upgrade when crossing over Sourcegraph 5.10.0 using migrator 6.0.0 or greater.

The notable change here is the inclusion of deployment specific builtin Postgres upgrade instructions, as well as changes to the MVU upgrade docs suggesting that users bring down all services and merge upstream changes from their target version into their release branch **before** performing their migrator upgrade. Due to migrators `depends_on` clause this will ensure that Postgres upgrades occur **before** migrator attempts connection to a PG12 database. This gets around the connect bouncer added in 6.0.0 which blocks services connection to our dbs

## Testing
- [ ] docker-compose
  - [ ] autoupgrade
  - [ ] MVU
- [ ] kustomize
  - [ ] autoupgrade
  - [ ] MVU
- [ ] Helm
  - [ ] autoupgrade
  - [ ] MVU
