### PR TITLE
Clarify accepted values for projectQuery

### DIFF
--- a/docs/admin/code_hosts/gitlab.mdx
+++ b/docs/admin/code_hosts/gitlab.mdx
@@ -44,7 +44,10 @@ Example config:
 There are three fields for configuring which projects are mirrored/synchronized:
 
 - [`projects`](/admin/code_hosts/gitlab#configuration): A list of projects in `{"name": "group/name"}` or `{"id": id}` format. The order determines the order in which we sync project metadata and is safe to change.
-- [`projectQuery`](/admin/code_hosts/gitlab#configuration): A list of strings with one pre-defined option (`none`), and/or an URL path and query that targets the [GitLab Projects API endpoint](https://docs.gitlab.com/ee/api/projects.html), returning a list of projects.
+- [`projectQuery`](/admin/code_hosts/gitlab#configuration): A list of strings. Accepted values include:
+  - The special value `none`, which will sync no repositories.
+  - Query parameters for the [GitLab Projects API endpoint](https://docs.gitlab.com/ee/api/projects.html). For example, `?archived=false`.
+  - A path and set of query parameters for any GitLab API endpoint that returns a list of repos. For example, `groups/mygroup/projects?visibility=public`.
 - [`exclude`](/admin/code_hosts/gitlab#configuration): A list of projects to exclude which takes precedence over the `projects`, and `projectQuery` fields. It has the same format as `projects`.
 
 ### Troubleshooting


### PR DESCRIPTION
It's not clear from reading that this config supports endpoints other than the `/projects` endpoint. This attempts to clarify.

[Related thread](https://sourcegraph.slack.com/archives/C05EMJM2SLR/p1738623269376519)

# Test plan

Rendered: 
![CleanShot 2025-02-03 at 17 31 39@2x](https://github.com/user-attachments/assets/2cc337a4-3186-429d-827d-45bed2191a8e)
