### PR TITLE
chore(changelog): remove leftover OPTIONAL; placeholders from changelog

### DIFF
--- a/docs/technical-changelog.mdx
+++ b/docs/technical-changelog.mdx
@@ -1,6 +1,6 @@
 # Technical Changelog
 
-This page documents all notable changes to Sourcegraph. For more detailed changelog posts, please [read here](https://sourcegraph.com/changelog/). 
+This page documents all notable changes to Sourcegraph. For more detailed changelog posts, please [read here](https://sourcegraph.com/changelog/).
 
 {/* CHANGELOG_START */}
 
@@ -195,7 +195,7 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 - propagate bestScoringLine and use that to center chunks in the search UI `(PR #2683)`
   - For broad matches, we now center the best-scoring line in search results
 - add tools support to LLM API (aka. function calling) `(PR #2537)`
-  - The `/.api/llm/chat/completions` endpoint now support function calling via the `tools` property. This feature works when using the LLM providers: OpenAI, Anthropic, Fireworks, AWS Bedrock, and Gemini.OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
+  - The `/.api/llm/chat/completions` endpoint now support function calling via the `tools` property. This feature works when using the LLM providers: OpenAI, Anthropic, Fireworks, AWS Bedrock, and Gemini.
 - add ability to boost user-relevant repos for `patterntype:nls` `(PR #2489)`
 
 ### Fix
@@ -289,7 +289,6 @@ To preserve the previous behavior where sessions would be invalidated after they
 - fix post workspace delete redirection `(PR #2698)`
 - fix user management reduce seats case `(PR #2647)`
 - fixes update seats modal max count validation `(PR #2616)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - fixes general setting page re-submitting problem `(PR #2548)`
 
 #### Multitenant
@@ -326,7 +325,6 @@ To preserve the previous behavior where sessions would be invalidated after they
 - accept escaped characters in `content` filters `(PR #2807)`
 - fix repo-rev (button-group) ui `(PR #2806)`
 - add response telemetry for streaming search `(PR #2784)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - VSCode Search extension - auth panel not loading when filesystem is case sensitive `(PR #2713)`
   - fixes `404 errors when trying to load "authSidebar.js"` when the Code Search VS Code extension is used with the VSCode Remote SSH extension
 - remove alert suggesting structural search `(PR #2615)`
@@ -527,7 +525,6 @@ To preserve the previous behavior where sessions would be invalidated after they
 
 - Fix url/text for user menu workspace link `(PR #2843)`
 - Style fixes on Workspace Settings, General Settings and User settings `(PR #2798)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - refactor name-checking to helper `(PR #2726)`
 - add some improved API docstrings `(PR #2708)`
 - enable MSP rollouts `(PR #2619)`
@@ -539,7 +536,6 @@ To preserve the previous behavior where sessions would be invalidated after they
 
 - Layout finetuning of Creating Workspaces and Tenant Onboarding (#3065) `(PR #3139)`
 - Polish buy seats modal `(PR #2917)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - Remove intent heuristic `(PR #2791)`
 - Delete unused DeleteOrg code `(PR #2585)`
 - Replace NewBuffer([]byte("str")) -> NewBufferString("str") `(PR #2466)`
@@ -568,11 +564,9 @@ To preserve the previous behavior where sessions would be invalidated after they
 #### Others
 
 - [Backport 6.0.x] Update Cody Web v0.29.0 `(PR #3162)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)Backport 07c56ed from #3160
 - [backport] feat/web: Update cloning status to new designs (#2760) `(PR #3158)`
 - [Backport 6.0.x] onboarding: add input field to selected repo List `(PR #3154)`
 - Backport 3148 to 6.0.x `(PR #3151)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - [Backport 6.0.x] repoupdater: Don't grow backoff bigger than int32 `(PR #3135)`
 - [Backport 6.0.x] workspace settings: mention query in info message `(PR #3112)`
 -  [Backport 6.0.x] fix(agents): use plural naming convention for API endpoints `(PR #3080)`
@@ -581,11 +575,8 @@ To preserve the previous behavior where sessions would be invalidated after they
 - [Backport 6.0.x] Changes naming "Open" to "Unused" seats `(PR #3029)`
 - Omnibox: route likely code generation commands to Chat `(PR #2969)`
 - Update Cody Web v0.27.0 `(PR #2968)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - Update Cody Web v0.26.0 `(PR #2966)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - Update Cody Web v0.25.0 `(PR #2959)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - auth: Fixup check for canSignOut `(PR #2958)`
 - omnibox: hard boost current repo and relevant repos `(PR #2943)`
 - allowlist `language` on `cody-autoedit` `(PR #2941)`
@@ -598,7 +589,6 @@ To preserve the previous behavior where sessions would be invalidated after they
 - Update Cody Web to 0.24.0 `(PR #2920)`
   - Update Cody to 0.24.0
 - bug: Adds a link to stripe portal on the Last Payment Failed warning  `(PR #2919)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - sg: make `.tool-versions` parsing better and silence mise `(PR #2918)`
 - tenant: Set cody gateway rate limits `(PR #2915)`
 - Adds style to pending invited users `(PR #2898)`
@@ -637,7 +627,6 @@ To preserve the previous behavior where sessions would be invalidated after they
 - web: More alignment of nav dropdown with designs `(PR #2691)`
 - tenant: Small improvements to MT app `(PR #2680)`
 - Update Cody Web v0.22.0 `(PR #2678)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - NLS: support quoted phrases `(PR #2677)`
 - workspaces: Consolidate web config and add web URL `(PR #2670)`
 - auth: Fixup some auth redirections `(PR #2668)`
@@ -949,7 +938,6 @@ The following PRs were merged onto the previous release branch but could not be 
 #### Cody-Gateway
 
 - add Gemini 2.0 Flash experimental model [#2309](https://github.com/sourcegraph/sourcegraph/pull/2309)
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 
 #### Codygateway
 
@@ -1085,7 +1073,6 @@ The following PRs were merged onto the previous release branch but could not be 
 
 - update cody web to 0.19.0 [#2376](https://github.com/sourcegraph/sourcegraph/pull/2376)
 - add cody.notices to json schema [#2373](https://github.com/sourcegraph/sourcegraph/pull/2373)
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - fix prompt library UI layouts [#2288](https://github.com/sourcegraph/sourcegraph/pull/2288)
 - fix prompt avatar for generated initials avatar [#2239](https://github.com/sourcegraph/sourcegraph/pull/2239)
 - switch to Snowball stopwords [#2223](https://github.com/sourcegraph/sourcegraph/pull/2223)
@@ -1134,9 +1121,7 @@ The following PRs were merged onto the previous release branch but could not be 
 - add rote test for workspaceGitHubAppAccountResolver [#2257](https://github.com/sourcegraph/sourcegraph/pull/2257)
   - N/A
 - add test suite for (s *serviceImpl) listRepositoriesSearch [#2255](https://github.com/sourcegraph/sourcegraph/pull/2255)
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - add test suite for (r *workspaceGitHubAppResolver) ListUserGitHubRepositories [#2199](https://github.com/sourcegraph/sourcegraph/pull/2199)
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 
 #### Multitenant
 
@@ -1368,7 +1353,6 @@ The following PRs were merged onto the previous release branch but could not be 
 - Hitesh/change direct route method [#2351](https://github.com/sourcegraph/sourcegraph/pull/2351)
 - change deepseek model for autoedits [#2350](https://github.com/sourcegraph/sourcegraph/pull/2350)
 - Reapply "feat(cody-gateway): add Gemini 2.0 Flash experimental model" [#2348](https://github.com/sourcegraph/sourcegraph/pull/2348)
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)Cody Gateway: add support to Google's Gemini 2.0 Flash Experimental model.
 - auth: Simplify middlewares [#2336](https://github.com/sourcegraph/sourcegraph/pull/2336)
 - http: Refactor HTTP_TRACE to use Sourcegraph logger [#2335](https://github.com/sourcegraph/sourcegraph/pull/2335)
 - http: Drop Blackhole middleware [#2334](https://github.com/sourcegraph/sourcegraph/pull/2334)
@@ -1488,7 +1472,6 @@ The following PRs were merged onto the previous release branch but could not be 
 #### Security
 
 - introduce UntrustedExternalClient [#2433](https://github.com/sourcegraph/sourcegraph/pull/2433)
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
   Backport 3f079a57978179aa2ad3f310195346a8c574f9ce from #2349
 
 ### Fix
@@ -1849,7 +1832,6 @@ The following PRs were merged onto the previous release branch but could not be 
 
 - use models from model config for PLG chat `(PR #1870)`
 - sync allowed models in dotcom user rate limits with models.json `(PR #1864)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - filter allowed models based on subscription tier `(PR #1636)`
 
 #### Database
@@ -2060,7 +2042,6 @@ The following PRs were merged onto the previous release branch but could not be 
 #### Release
 
 - remove check against latest full version in `--post-release-version` code path `(PR #1585)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 
 #### Search
 
@@ -2150,18 +2131,15 @@ The following PRs were merged onto the previous release branch but could not be 
 - add timeout to gateway calls `(PR #1879)`
 - workspaces: Align styling for join page `(PR #1860)`
 - workspaces: Add tables for listing workspaces `(PR #1857)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - workspaces: Slightly tweak style `(PR #1851)`
 - workspaces: Directly link to installation target `(PR #1848)`
 - tenant: Suppress some irrelevant missing_context pprof traces `(PR #1847)`
 - Workspaces: Fix workspace picker rendering in React `(PR #1841)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - fix permissions connection resolver ordering `(PR #1839)`
 - workspaces: Add seat selector on plan page `(PR #1835)`
 - workspaces/billing: create RPC for purchasing seats `(PR #1831)`
 - workspaces/billing: extract subscription attribute computation into a `Plan` helper `(PR #1830)`
 - workspaces: Add updated workspace pickers for tenant `(PR #1829)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - workspaces: Add field to pre-purchase extra seats `(PR #1826)`
 - workspaces/billing: implement periodic workers for subscription renewal `(PR #1823)`
 - auth: Fix background contexts in validate authz provider `(PR #1802)`
@@ -2195,20 +2173,17 @@ The following PRs were merged onto the previous release branch but could not be 
 - autoedit: add speculative decoding `(PR #1673)`
   - autoedit: Add speculative decoding support from fireworks
 - fix `marketingTracking` sending null `(PR #1669)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - Prompts: fix prompt name validation and prompts migration  `(PR #1664)`
 - Add GraphQL resolvers to read and set a list of repositories for a GH App installation ID `(PR #1657)`
 - fixup: remove Git conflict marks in `sg.config.yaml` `(PR #1649)`
 - Require prompt field before successful submission `(PR #1639)`
 - Add builtin prompts field to prompts `(PR #1633)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - Zoekt: refactor memory dashboards `(PR #1618)`
 - workspaces: add billing prototype for subscription creation `(PR #1611)`
 - admin: Update report an issue link `(PR #1608)`
 - change default autoedit model `(PR #1589)`
 - feat(cloud) sg cloud eph deploy: support ms env `(PR #1581)`
 - add Cody.promptLibrary telemetry `(PR #1568)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - worker: Group tasks by purpose `(PR #1566)`
 - Improve policy iterator tests to not rely on SQL for insertion `(PR #1560)`
 - repoupdater: Fix slow scheduling of cloned->uncloned repos `(PR #1552)`
@@ -2222,7 +2197,6 @@ The following PRs were merged onto the previous release branch but could not be 
 - sg: Fix local dev pguser setup `(PR #1506)`
 - Context: ensure we propagate timeouts and missing repos `(PR #1505)`
 - Make Visual Studio Experimental `(PR #1503)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - Context: always use more items for reranker `(PR #1476)`
 - Remove insert prompt mode `(PR #1475)`
 - Add missing Cody Web Alert CSS variable override `(PR #1474)`
@@ -2246,7 +2220,6 @@ The following PRs were merged onto the previous release branch but could not be 
 - Update Marketing URLs in the site footer links `(PR #1390)`
 - Soft delete prompts `(PR #1386)`
 - Widen blocked phrases, but only confine blocked phrases to expensive (aka flagged) models `(PR #1344)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
 - repoupdater: Drop support for gitUpdateInterval `(PR #1339)`
   - The site config setting `gitUpdateInterval` has been deprecated and removed. We are removing it in favor of smarter heuristics like webhooks, user traffic, and repo staleness.
 - repoupdater: Remove total from schedule and update queue state `(PR #1338)`
@@ -2302,7 +2275,6 @@ The following PRs were merged onto the previous release branch but could not be 
 #### Release
 
 - remove extra v identifier for version in artifact exporter `(PR #1594)`
-  - OPTIONAL; info at [https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c)
   Backport c4b838103ce2f71e7591ade720e8bdf17f9a5b39 from #1490
 
 ### Reverts
@@ -4273,7 +4245,7 @@ The following PRs were merged onto the previous release branch but could not be 
 - search: remove smart search logic [#64215](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/64215)Smart search is no longer supported in the Sourcegraph backend. Old searches that specify 'smart search' mode will be run in the default 'precise' mode. If your query now doesn't behave as expected, you can update it to use the new `patterntype:keyword`.
 - search: update Zoekt [#64238](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/64238)
   - added support for all Apex language extensions
-  - shard merging for Zoekt is now enabled by default. This reduces MEM requirements for Zoekt webserver and improves performance for some queries. See our [documentation](https://sourcegraph.com/docs/admin/search#shard-merging) for more information.  
+  - shard merging for Zoekt is now enabled by default. This reduces MEM requirements for Zoekt webserver and improves performance for some queries. See our [documentation](https://sourcegraph.com/docs/admin/search#shard-merging) for more information.
 - search: Add support to all Apex language extensions [#64194](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/64194)
 - search: Enable improved symbol parsing for large repos (when using Rockskip) [#63988](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/63988)
 


### PR DESCRIPTION
Some changelog entries have `OPTIONAL; info at ...` which should actually be removed by an engineer when it gets merged but it is left over.