### PR TITLE
Add a beta mark for Perforce permissions feature

### DIFF
--- a/docs/admin/repo/perforce.mdx
+++ b/docs/admin/repo/perforce.mdx
@@ -75,7 +75,7 @@ Perforce label names are also more flexible than git tag names, so incompatible 
 
 This behaviour can be disabled by setting `noConvertLabels` to `true` in the [fusion client configuration](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@44e848d4ba5a3d47bc6e8651638cfe2279d02102/-/blob/schema/perforce.schema.json?L66-131).
 
-## Repository permissions
+## Repository permissions (Beta)
 
 To enforce file-level permissions for Perforce depots using the [Perforce protects file](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html), include [the `authorization` field](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2a716bd70c294acf1b3679b790834c4dea9ea956/-/blob/schema/perforce.schema.json?L67-78) in the configuration of the Perforce code host connection you created [above](#add-a-perforce-code-host):
 


### PR DESCRIPTION
Labels perfore permissions as a beta feature. 

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
