### PR TITLE
Create guidance on contextFilters error

### DIFF
--- a/docs/cody/troubleshooting.mdx
+++ b/docs/cody/troubleshooting.mdx
@@ -105,6 +105,20 @@ It indicates that our web application firewall provider, Cloudflare, has flagged
 
 Consider disabling anonymizers, VPNs, or open proxies. If using a VPN is essential, you can try [1.1.1.1](https://one.one.one.one), which is recognized to be compatible with our services.
 
+### Error with Cody `contextFilters` during chat or editing code
+
+The `contextFilters` setting in Cody is used to control which files are included or excluded when Cody searches for relevant context while answering questions or providing code assistance. Sometimes, you can see the following error:
+
+```
+Edit failed to run: file is ignored (due to cody.contextFilters Enterprise configuration setting)
+```
+
+This error occurs when you're trying to work with a file that's been excluded by Cody's enterprise-level `contextFilters` configuration. At times, this can happen to files that also haven't been excluded. First, check with your organization's admin to understand which files are excluded.
+
+If the error occurs with a file that's not been excluded, the workaround is to uninstall the Cody plugin, restart your IDE and then reinstall the latest version of the extension.
+
+This should clear the error.
+
 ### VS Code Pro License Issues
 
 If VS Code prompts you to upgrade to Pro despite already having a Pro license, this usually happens because you're logged into a free Cody/Sourcegraph account rather than your Pro account. To fix this:


### PR DESCRIPTION
<!-- Explain the changes introduced in your PR -->

## Pull Request approval
This PR introduces a change faced by a couple of customers regarding contextFilters on inline edits. The change introduces a quick workaround to unblock them.
You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
