### PR TITLE
Configuring UID & GUID for native k8s executors

### DIFF
--- a/docs/admin/executors/deploy_executors_kubernetes.mdx
+++ b/docs/admin/executors/deploy_executors_kubernetes.mdx
@@ -27,6 +27,7 @@ Native Kubernetes Executors can be deployed via either the `sourcegraph-executor
     2. `EXECUTOR_FRONTEND_PASSWORD` should match the `executors.accessToken` key in the Sourcegraph instance's site configuration
     3. Either `EXECUTOR_QUEUE_NAMES` or `EXECUTOR_QUEUE_NAME` should be set depending on whether the Executor will process batch change or precise auto indexing jobs
     4. `EXECUTOR_KUBERNETES_NAMESPACE` should be set to the Kubernetes namespace where you intend to run the worker pods. This should generally match the namesapce where you deploy the Executor resources in the next step.
+    5. `KUBERNETES_RUN_AS_USER` and `KUBERNETES_RUN_AS_GROUP` should be set to the user and group IDs that the worker pods should run as.
 
     <Callout type="note">Additional environment variables may need to be configured for your Executors deployment. See [here](/admin/executors/executors_config) for a complete list.</Callout>
 


### PR DESCRIPTION
added note to configure `KUBERNETES_RUN_AS_USER` & `KUBERNETES_RUN_AS_GROUP` for native k8s executors as it is now required to explicitly configure these ENVs when deploying native k8s executors

Follow up doc change for https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/618
## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
