### PR TITLE
Add callout for instances where NO_PROXY requires an asterisk

### DIFF
--- a/docs/admin/config/private-network.mdx
+++ b/docs/admin/config/private-network.mdx
@@ -44,6 +44,15 @@ executor|frontend|gitserver|migrator|repo-updater|worker:
     value: "blobstore,codeinsights-db,codeintel-db,sourcegraph-frontend-internal,sourcegraph-frontend,github-proxy,gitserver,grafana,indexed-search-indexer,indexed-search,jaeger-query,pgsql,precise-code-intel-worker,prometheus,redis-cache,redis-store,repo-updater,searcher,symbols,syntect-server,worker-executors,worker,cloud-sql-proxy,localhost,127.0.0.1,.svc,.svc.cluster.local,kubernetes.default.svc"
 ```
 
+<Callout type="info">
+After setting up your proxy in the override file, you may notice some pods like the frontend, gitserver and repo-updater failing health checks. In such a case, you'll need to add an '*' to the NO_PROXY environment variable. This should look like:
+</Callout>
+
+```
+- name: NO_PROXY
+    value: "blobstore,codeinsights-db,codeintel-db,sourcegraph-frontend-internal,sourcegraph-frontend,github-proxy,gitserver,grafana,indexed-search-indexer,indexed-search,jaeger-query,pgsql,precise-code-intel-worker,prometheus,redis-cache,redis-store,repo-updater,searcher,symbols,syntect-server,worker-executors,worker,cloud-sql-proxy,localhost,127.0.0.1,.svc,.svc.cluster.local,kubernetes.default.svc, *"
+```
+
 ### Docker Compose
 
 Add the proxy environment variables your docker compose override file.


### PR DESCRIPTION
<!-- Explain the changes introduced in your PR -->
This change adds a nuanced item where some customers may need to add an asterisk when using proxies in their override file.

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
