### PR TITLE
De-purplize code blocks

### DIFF
--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -22,20 +22,20 @@ export function CopyButton({ text, lang }: { text: string, lang: string }) {
   }
 
   return (
-    <div className="absolute inline-flex items-center top-0 pt-1 right-0 left-0 w-full border-b-0.1 border-gray-500 rounded-t-lg shadow">
+    <div className="absolute inline-flex items-center top-0 pt-0.5 pb-0.5 right-0 left-0 w-full border-b-0.1 border-gray-500 rounded-t-lg shadow">
       <div className="relative flex justify-between items-center w-full">
-        <div className="text-white text-sm pl-2">{lang.toUpperCase()}</div>
+        <div className="text-xs pl-3 pt-0.5 text-dark-text-muted">{lang.toUpperCase()}</div>
         <div className="relative">
           <button
             onClick={handleCopy}
             onMouseEnter={() => setShowTooltip(true)}
             onMouseLeave={() => setShowTooltip(false)}
-            className="relative flex items-center justify-center p-2 text-white-500 rounded transition duration-300 ease-in-out hover:scale-125 focus:outline-none"
+            className="relative flex items-center justify-center mr-1 p-2 rounded transition text-gray-300 hover:text-white focus:outline-none"
           >
             {copied ? (
-              <CheckIcon className="h-5 w-5 text-green-400" aria-hidden="true" />
+              <CheckIcon className="h-4 w-4 text-green-400" aria-hidden="true" />
             ) : (
-              <DocumentDuplicateIcon className="h-5 w-5" aria-hidden="true" />
+              <DocumentDuplicateIcon className="h-4 w-4" aria-hidden="true" title="Copy to clipboard" />
             )}
           </button>
           {showTooltip && copied && (

--- a/src/components/Prose.tsx
+++ b/src/components/Prose.tsx
@@ -25,7 +25,7 @@ export function Prose<T extends React.ElementType = 'div'>({
 				// link underline
 				'prose-a:underline prose-a:decoration-link-light hover:prose-a:text-link-light hover:prose-a:underline dark:prose-a:no-underline dark:hover:prose-a:underline',
 				// pre
-				'prose-pre:rounded-xl prose-pre:bg-slate-900 prose-pre:shadow-lg dark:prose-pre:bg-slate-800/60 dark:prose-pre:shadow-none dark:prose-pre:ring-1 dark:prose-pre:ring-slate-300/10',
+				'prose-pre:rounded-xl prose-pre:bg-slate-900 prose-pre:shadow-lg dark:prose-pre:bg-slate-900 dark:prose-pre:shadow-none prose-pre:border prose-pre:border-slate-300 dark:prose-pre:border-slate-700',
 				// hr
 				'dark:prose-hr:border-slate-800',
 				//table head alignment

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -10,9 +10,6 @@
 	[inert] ::-webkit-scrollbar {
 		display: none;
 	}
-	pre {
-		@apply !bg-sop-700;
-	}
 	/* h1, h2, h3, h4, h5, h6 {
 		@apply font-sans font-bulky;
 	}


### PR DESCRIPTION
Before:

<img width="647" alt="Screenshot 2025-02-20 at 3 59 02 pm" src="https://github.com/user-attachments/assets/722cd5a0-8c0c-4a49-845b-1c5d5e6068ca" />

After:

<img width="632" alt="Screenshot 2025-02-20 at 4 01 13 pm" src="https://github.com/user-attachments/assets/26e9b892-2ea0-4f0e-b9ac-bb670988620b" />

Also cleaned up some of the type and positioning of the prose header block while I was there too.