### PR TITLE
Add info box recommending indexing locally first

### DIFF
--- a/docs/code-search/code-navigation/precise_code_navigation.mdx
+++ b/docs/code-search/code-navigation/precise_code_navigation.mdx
@@ -22,7 +22,7 @@ Precise code navigation relies on the open source [SCIP Code Intelligence Protoc
 
 ## Setting up code navigation for your codebase
 
-There are several options for setting up precise code navigation:
+<Callout type="info">There are several options for setting up precise code navigation listed below. However, we always recommend you start by manually indexing your repo locally using the [approriate indexer](/code-navigation/writing_an_indexer#quick-reference) for your language. Code and build systems can vary by project and ensuring you can first succesfully run the indexer locally leads to a smoother experience since it is vastly easier to debug and iterate on any issues locally before trying to do so in CI/CD or in Auto-Indexing.</Callout>
 
 1. **Manual indexing**. Index a repository and upload it to your Sourcegraph instance:
 


### PR DESCRIPTION
Adding an info box to encourage users to first index their repos locally to ensure they work.

![image](https://github.com/user-attachments/assets/402fdcab-0fc2-4090-b3f6-cd3b2b11c3a2)

 