### PR TITLE
Remove self-hosted analytics language

### DIFF
--- a/docs/analytics/index.mdx
+++ b/docs/analytics/index.mdx
@@ -1,6 +1,9 @@
 # Sourcegraph Analytics
 
-Enterprise customers can use Sourcegraph Analytics to get a clear view of usage, engagement, performance, and impact. This solution is available to: 
+Enterprise customers can use Sourcegraph Analytics to get a clear view of usage, engagement, performance, and impact. 
+
+## Sourcegraph Cloud Analytics
+This solution is available to: 
 - [Sourcegraph Cloud](/cloud) customers
 - Self-hosted customers that have fully enabled usage telemetry, and that are running a supported version of Sourcegraph (5.9+) 
 

--- a/docs/analytics/index.mdx
+++ b/docs/analytics/index.mdx
@@ -1,22 +1,16 @@
 # Sourcegraph Analytics
 
-Enterprise customers can use Sourcegraph Analytics to get a clear view of usage, engagement, performance, and impact.
+Enterprise customers can use Sourcegraph Analytics to get a clear view of usage, engagement, performance, and impact. This solution is available to: 
+- [Sourcegraph Cloud](/cloud) customers
+- Self-hosted customers that have fully enabled usage telemetry, and that are running a supported version of Sourcegraph (5.9+) 
 
-## Sourcegraph Cloud Analytics
-
-[Sourcegraph Cloud](/cloud) customers can use our managed [cloud analytics service](https://cody-analytics.sourcegraph.com) for Cody and Code Search usage data.
-Self-hosted customers can also use this service, but they must
-
-Upgrade to a supported version of Sourcegraph (5.9+)
-Have fully enabled usage telemetry.
-
--   [Enablement instructions](/analytics/cloud#enablement)
+For more details on setting up Sourcegraph Analytics, see our [enablement instructions](/analytics/cloud#enablement)
 
 ![Sourcegraph-cloud-analytics](https://storage.googleapis.com/sourcegraph-assets/Docs/Sourcegraph-Analytics-2025-01-28.png)
 
-## Self-Hosted Analytics
+## Air-gapped Analytics
 
-Self-hosted customers will soon be able to use our self-hosted and locally deployed analytics service, built on Grafana, to see Sourcegraph usage data.
+Air-gapped customers will soon be able to use our self-hosted and locally deployed analytics service, built on Grafana, to see Sourcegraph usage data.
 
 This product is in development now. If you would like to learn more, please contact your Sourcegraph representative.
 


### PR DESCRIPTION
Removing language around self-hosted vs cloud analytics to align with product roadmap
