### PR TITLE
search: discourage use of structural search

### DIFF
--- a/docs/code-search/types/structural.mdx
+++ b/docs/code-search/types/structural.mdx
@@ -2,7 +2,7 @@
 
 <p className="subtitle">Learn and understand about Sourcegraph's Structural Search and core functionality.</p>
 
-<Callout type="note"> Changed in version 5.3. Structural search is disabled by default. To enable it, ask your site administrator to set `experimentalFeatures.structuralSearch = "enabled" in site configuration. To make sure this functions properly, make sure you have "structuralSearch" : "enabled" nested within "experimentalFeatures".</Callout>
+<Callout type="note"> Changed in version 5.3. Structural search is disabled by default. To enable it, ask your site administrator to set experimentalFeatures.structuralSearch = "enabled" in site configuration. Structural search has performance limitations and is not actively developed. We recommend using regex search or a combination of Search Jobs and custom scripts instead. Please reach out to [support@sourcegraph.com](mailto:support@sourcegraph.com) for guidance on alternative approaches.</Callout>
 
 With structural search, you can match richer syntax patterns specifically in code and structured data formats like JSON. It can be awkward or difficult to match code blocks or nested expressions with regular expressions. To meet this challenge we've introduced a new and easier way to search code that operates more closely on a program's parse tree. We use [Comby syntax](https://comby.dev/docs/syntax-reference) for structural matching. Below you'll find examples and notes for this language-aware search functionality.
 


### PR DESCRIPTION
The feature is off by default and we already discourage users to use regex or a combination of Search Jobs and custom scripts. This change formalizes the current state.
