### PR TITLE
Claude 3.7 Non Thinking and Thinking Changes/Claude 3.7 on GCP

### DIFF
--- a/docs/admin/deploy/kubernetes/index.mdx
+++ b/docs/admin/deploy/kubernetes/index.mdx
@@ -938,7 +938,7 @@ When all pods have restarted and show as Running, you can browse to your Sourceg
 - Check the `Site Admin > Updates` page to determine [upgrade readiness](/admin/updates/#upgrade-readiness).
 
 **Step 2:**
-> <Callout type="warning">The Kubernetes Helm deployment type does not support MVU from Sourcegraph `v5.9.45` versions and earlier to Sourcegraph `v6.0.0`. Admins seeking to upgrade to Sourcegraph `v6.0.0` should upgrade to `v5.10.3940` or `v5.11.6271` and then use the standard upgrade procedure to get to `v6.0.0`. This is because migrator v6.0.0 will no longer connect to Postgres 12 databases. For more info see our [PostgreSQL upgrade docs](/admin/postgres#requirements).</Callout>
+> <Callout type="warning">The Kubernetes Helm deployment type does not support MVU from Sourcegraph `v5.9.45` versions and earlier to ANY version `v6.0.x` or later. Admins seeking to upgrade to any Sourcegraph version `v6.0.x` or later (including `v6.1.x`, `v6.2.x`, etc.) must first upgrade to `v5.10.3940` or `v5.11.6271` and then use the standard upgrade procedure to get to their target version. This is because migrator in all versions from `v6.0.0` onwards will no longer connect to Postgres 12 databases. For more info see our [PostgreSQL upgrade docs](/admin/postgres#requirements).</Callout>
 
 Scale down `deployments` and `statefulSets` that access the database, _this step prevents services from accessing the database while schema migrations are in process._
 The following services must have their replicas scaled to 0:

--- a/docs/admin/how-to/upgrade-postgres-12-16-builtin-dbs.mdx
+++ b/docs/admin/how-to/upgrade-postgres-12-16-builtin-dbs.mdx
@@ -82,6 +82,28 @@ $ kubectl apply -f deploy-sourcegraph-k8s/base/sourcegraph/pgsql/pgsql.StatefulS
 
 ## Helm
 
-To upgrade builtin containers in Helm admins must update their instance to v5.11.6271 via the [helm multi-version upgrade procedure](/admin/deploy/kubernetes#multi-version-upgrade-procedure) or standard upgrade procedure. This is because `helm upgrade` doesn't support just the DBs in a chart.
+When using the in-cluster PostgreSQL databases included in the Sourcegraph Helm chart, database upgrades are integrated with the overall application upgrade process and there is no mechanism to upgrade only the PostgreSQL containers independently. Therefore, the PostgreSQL upgrade must be performed as part of a full Sourcegraph version upgrade.
 
-<Callout type="warning"> In Sourcegraph version 6.0.0 Sourcegraph services will no longer be able to connect to a Postgres 12 database. This means at and after Sourcegraph 6.0.0, migrator will not be connect to older versions to execute the `upgrade` command. </Callout>
+For production deployments, we recommend using external PostgreSQL databases, which allows for more flexible database management outside the Helm deployment lifecycle.
+
+### Required Upgrade Path
+
+<Callout type="warning">Sourcegraph versions `v6.0.x` and later require PostgreSQL 16 and will not connect to PostgreSQL 12 databases. This means any direct upgrade from versions earlier than `v5.10.3940` to any version `v6.0.x` or later will fail because the migrator in `v6.0.x` and later cannot connect to PostgreSQL 12 to perform the upgrade.</Callout>
+
+To safely upgrade PostgreSQL in Helm deployments:
+
+1. **First upgrade to an intermediate version**:
+   - Upgrade to either Sourcegraph `v5.10.3940` or `v5.11.6271` using the [helm multi-version upgrade procedure](/admin/deploy/kubernetes#multi-version-upgrade-procedure) or [standard upgrade procedure](/admin/deploy/kubernetes#standard-upgrades)
+   - These specific versions include the necessary PostgreSQL upgrade scripts to safely migrate from PG12 to PG16
+
+2. **Verify the PostgreSQL upgrade** (optional):
+   - You can verify the PostgreSQL version has been successfully upgraded by connecting to the database:
+     ```bash
+     kubectl exec -it pgsql -- psql -U sg -c "SELECT version();"
+     ```
+   - The output should show PostgreSQL 16.x
+
+3. **Proceed to target version**:
+   - Once PostgreSQL has been upgraded to version 16, you can safely upgrade to your target version (`v6.0.x` or later) using the standard upgrade procedure
+
+For any issues during the PostgreSQL upgrade process, please contact support@sourcegraph.com.

--- a/docs/cody/capabilities/auto-edit.mdx
+++ b/docs/cody/capabilities/auto-edit.mdx
@@ -2,7 +2,7 @@
 
 <p className="subtitle">Auto-edit suggests code changes by analyzing cursor movements and typing. After you've made at least one character edit in your codebase, it begins proposing contextual modifications based on your cursor position and recent changes.</p>
 
-<Callout type="info">Auto-edits is currently in experimental rollout within the VS Code extension. Access is limited to selected Enterprise Starter (Cody Pro) and Enterprise users on Cody Gateway. We will expand availability as we validate the feature's performance.</Callout>
+<Callout type="info">Auto-edit is currently supported in the VS Code extension with Sourcegraph v6.0+. It's available in Beta for Pro, Enterprise Starter and Enterprise users on Cody Gateway. Auto-edit requires Fireworks to be enabled as a provider. Enterprise customers without Fireworks enabled can [disable the feature flag](#auto-edit-access-for-enterprise-customers)</Callout>
 
 ## Capabilities of auto-edit
 
@@ -14,25 +14,20 @@
 
 ## Enabling auto-edit
 
-Eligible Cody Pro users will gradually be given access to the auto-edit feature. Once you have it, you will receive an in-editor notification.
+Auto-edit is enabled by default for Cody Pro Enterprise Starter, and Enterprise users. You can opt out and switch back to **autocomplete** by selecting it from the suggestion mode in the Cody VS Code extension settings.
 
-<video width="100%" loop playsInline controls style={{ width: '100%', height: 'auto' }}>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/auto-edit-in-action-2025.mp4" type="video/mp4" />
-</video>
+Site admins can opt their organization out of the auto-edit feature by disabling it from their config settings.
 
 ### Auto-edit access for Enterprise customers
 
 Auto-edit is available for Enterprise customers with [Sourcegraph Cody Gateway](/cody/core-concepts/cody-gateway#sourcegraph-cody-gateway) access. Enabling the feature requires two steps:
 
 1. Site administrators must:
-   - Enable the feature flag `cody-autoedit-experiment-enabled-flag`
+   - Ensure the feature flag `cody-autoedit-experiment-enabled-flag` is enabled (enabled by default)
    - Add `fireworks::*` as an [allowed provider](https://sourcegraph.com/docs/cody/enterprise/model-configuration#model-filters) (see below)
-2. Once enabled, developers will receive a notification in their editor to turn it on
-3. If you skip the notification or don't see it, you can manually enable/disable it from the Cody extension settings.
-
-![enable-from-cody-settings](https://storage.googleapis.com/sourcegraph-assets/Docs/enable-auto-edit-from-settings.jpg)
-
-There is a drop-down menu for Cody's suggestions mode. You can choose between the default autocomplete and the auto-edit mode, or you can turn off the suggestions completely.
+2. Once enabled, auto-edit will become the default suggestion mode for all users
+3. Users can optionally switch back to autocomplete from the Cody extension settings
+4. Site admins can opt out of auto-edits using the `cody-autoedit-experiment-enabled-flag` feature flag
 
 The following example demonstrates how to add Fireworks as an allowed LLM provider:
 
@@ -85,4 +80,4 @@ The auto-edit feature can help you with various repetitive tasks in your code:
 - **Call site updates**: When you change a function's signature, auto-edit detects all locations where the function is called and suggests necessary modifications to match the new signature. This includes updating parameter orders, adding error handling, and adjusting return value usage.
 - **Test file maintenance**: Helps with repetitive updates in test files, such as modifying test assertions, updating mock objects, or changing test data structures. Auto-edit recognizes patterns from your recent changes and suggests similar modifications across related tests.
 - **Parameter refactoring**: Assists in adding, removing, or reorganizing function parameters. When you unpack a function to handle more cases, auto-edit helps restructure the parameter list and suggests corresponding changes at call sites.
-- **Type system modifications**: When updating type definitions or interfaces, auto-edit identifies and suggests consistent changes across your codebase. This includes updating variable declarations, function parameters, and return types to maintain type consistency.
+- **Type system modifications**: Auto-edit identifies and suggests consistent changes across your codebase when updating type definitions or interfaces. This includes updating variable declarations, function parameters, and return types to maintain type consistency.

--- a/docs/cody/capabilities/supported-models.mdx
+++ b/docs/cody/capabilities/supported-models.mdx
@@ -23,9 +23,15 @@ Cody supports a variety of cutting-edge large language models for use in chat an
 
 <Callout type="note">To use Claude 3 Sonnet models with Cody Enterprise, make sure you've upgraded your Sourcegraph instance to the latest version. </Callout>
 
+### CLaude 3.7 Sonnet
+
 Claude 3.7 has two variants — **thinking** and **non-thinking** — to support deep reasoning and fast, responsive edit workflows. This means you can use Claude 3.7 in different contexts depending on whether long-form reasoning is required or for tasks where speed and performance are a priority.
 
 Claude 3.7 non-thinking version will be the default chat model for Cloud customers. Self-hosted customers are encouraged to follow this recommendation, as Claude 3.7 outperforms 3.5 in most scenarios.
+
+#### Claude 3.7 for GCP
+
+In addition, Sourcegraph Enterprise customers using GCP vertex (Google Cloud Platform) for Claude models can use the **extended thinking** variant of Claude 3.7 to optimize extended reasoning and deeper understanding.
 
 <Callout type="info">Claude 3.7 Sonnet with thinking is not supported for BYOK deployments.</Callout>
 

--- a/docs/cody/capabilities/supported-models.mdx
+++ b/docs/cody/capabilities/supported-models.mdx
@@ -25,13 +25,13 @@ Cody supports a variety of cutting-edge large language models for use in chat an
 
 ### CLaude 3.7 Sonnet
 
-Claude 3.7 has two variants — **thinking** and **non-thinking** — to support deep reasoning and fast, responsive edit workflows. This means you can use Claude 3.7 in different contexts depending on whether long-form reasoning is required or for tasks where speed and performance are a priority.
+Claude 3.7 has two variants — Claude 3.7 Sonnet and Claude 3.7 Extended Thinking — to support deep reasoning and fast, responsive edit workflows. This means you can use Claude 3.7 in different contexts depending on whether long-form reasoning is required or for tasks where speed and performance are a priority.
 
-Claude 3.7 non-thinking version will be the default chat model for Cloud customers. Self-hosted customers are encouraged to follow this recommendation, as Claude 3.7 outperforms 3.5 in most scenarios.
+Claude 3.7 Extended Thinking version will be the recommended default chat model for Cloud customers. Self-hosted customers are encouraged to follow this recommendation, as Claude 3.7 outperforms 3.5 in most scenarios.
 
 #### Claude 3.7 for GCP
 
-In addition, Sourcegraph Enterprise customers using GCP vertex (Google Cloud Platform) for Claude models can use the **extended thinking** variant of Claude 3.7 to optimize extended reasoning and deeper understanding.
+In addition, Sourcegraph Enterprise customers using GCP vertex (Google Cloud Platform) for Claude models can use both these variants of Claude 3.7 to optimize extended reasoning and deeper understanding. Customers using AWS Bedrock doesn't have Claude 3.7 Extended Thinking variant.
 
 <Callout type="info">Claude 3.7 Sonnet with thinking is not supported for BYOK deployments.</Callout>
 

--- a/docs/cody/capabilities/supported-models.mdx
+++ b/docs/cody/capabilities/supported-models.mdx
@@ -21,7 +21,13 @@ Cody supports a variety of cutting-edge large language models for use in chat an
 | Google | [Gemini 2.0 Flash](https://deepmind.google/technologies/gemini/flash/)                                                                               | ✅            | ✅            | ✅       |     |     |     |     |
 | Google | [Gemini 2.0 Flash-Lite Preview](https://deepmind.google/technologies/gemini/flash/) (experimental)                                                                               | ✅            | ✅            | ✅       |     |     |     |     |
 
-<Callout type="note">To use Claude 3 Sonnet models with Cody Enterprise, make sure you've upgraded your Sourcegraph instance to the latest version. Claude 3.7 Sonnet with thinking is not supported for BYOK deployments.</Callout>
+<Callout type="note">To use Claude 3 Sonnet models with Cody Enterprise, make sure you've upgraded your Sourcegraph instance to the latest version. </Callout>
+
+Claude 3.7 has two variants — **thinking** and **non-thinking** — to support deep reasoning and fast, responsive edit workflows. This means you can use Claude 3.7 in different contexts depending on whether long-form reasoning is required or for tasks where speed and performance are a priority.
+
+Claude 3.7 non-thinking version will be the default chat model for Cloud customers. Self-hosted customers are encouraged to follow this recommendation, as Claude 3.7 outperforms 3.5 in most scenarios.
+
+<Callout type="info">Claude 3.7 Sonnet with thinking is not supported for BYOK deployments.</Callout>
 
 ## Autocomplete
 

--- a/docs/pricing/plan-comparison.mdx
+++ b/docs/pricing/plan-comparison.mdx
@@ -11,7 +11,7 @@
 | Integrated search results        | -                                                     | ✓                                                     | ✓                                                     |
 | Prompt Library                   | ✓                                                     | ✓                                                     | ✓                                                     |
 | Bring your own LLM Key           | -                                                     | -                                                     | Self-Hosted only                                      |
-| Auto-edit                        | -                                                     | Experimental                                          | Experimental                                          |
+| Auto-edit                        | -                                                     | Beta                                          | Beta                                          |
 | Aentic chat experience           | -                                                     | Experimental                                          | Experimental                                          |
 | **Code Search**                  |                                                       |                                                       |                                                       |
 | Code Search                      | -                                                     | ✓                                                     | ✓                                                     |


### PR DESCRIPTION
This PR tackles two docs of the 6.2 release:

- Claude 3.7 thinking and non-thinking changes ([Linear](https://linear.app/sourcegraph/issue/TM-59/docs-april-2025-claude-37-non-thinking-and-thinking-changes))
- Claude 3.7 on GCP ([Linear](https://linear.app/sourcegraph/issue/TM-60/docs-april-2025-claude-37-on-gcp))
