### PR TITLE
Update Bitbucket Server OAuth docs inconsistency

### DIFF
--- a/docs/admin/config/authorization_and_authentication.mdx
+++ b/docs/admin/config/authorization_and_authentication.mdx
@@ -112,13 +112,7 @@ And configure the identity provider to pass the email address as the `nameID`.
 
 ### Bitbucket Server / Bitbucket Data Center authorization
 
-We do not currently support OAuth for Bitbucket Server or Bitbucket Data Center. You will need to combine permissions syncing from Bitbucket Server / Bitbucket Data Center with another authentication mechanism (SAML, built-in auth, HTTP authentication proxies). Bitbucket Server and Bitbucket Data Center only pass usernames to Sourcegraph, so you’ll need to make sure that those usernames are matched by whatever mechanism you choose to use for access.
-
-Follow the steps to [sync Bitbucket Server / Bitbucket Data Center permissions](/admin/code_hosts/bitbucket_server#repository-permissions). Then, do one of the following:
-
-1. Create the user accounts in Sourcegraph with matching usernames. (Access using `builtin` auth.)
-2. [Configure SAML authentication](/admin/auth/saml/). If you are using Bitbucket Server / Bitbucket Data Center, the `login` attribute is _not_ optional. You need to pass the Bitbucket Server username as the `login` attribute.
-3. [Configure an HTTP authentication proxy](/admin/auth/#http-authentication-proxies), passing the Bitbucket Server username value as the `usernameHeader`.
+We support authentication through OAuth for Bitbucket Server / Bitbucket Data Center. See the [Bitbucket Server auth provider docs](/admin/auth/#bitbucket-server).
 
 ### Azure DevOps Services
 


### PR DESCRIPTION
Updates a section in the docs we missed when we added OAuth for Bitbucket Server.

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
