### PR TITLE
fix: add redirect for admin deploy executors

### DIFF
--- a/src/data/redirects.ts
+++ b/src/data/redirects.ts
@@ -1,5 +1,9 @@
 const redirectsData = [
-
+  {
+    source: "/docs/admin/deploy_executors",
+    destination: "https://sourcegraph.com/docs/admin/executors/deploy_executors",
+    permanent: true
+  },
   {
     source: "/dev/roadmap",
     destination: "https://sourcegraph.com/direction",


### PR DESCRIPTION
Moshin discovered a broken link: https://sourcegraph.slack.com/archives/C01DXLN3D0T/p1743515921995509

This PR adds a redirect to the right content.