### PR TITLE
chore(rel): add missing patch release

### DIFF
--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -13,6 +13,7 @@ Currently supported versions of Sourcegraph:
 | **Release**  | **General Availability Date** | **Supported** | **Release Notes**                                                  | **Install**                                          |
 |--------------|-------------------------------|---------------|--------------------------------------------------------------------|------------------------------------------------------|
 | 6.2 Patch 0  | April 2025                    | ✅             | [Notes](https://sourcegraph.com/docs/technical-changelog#v620)     | [Install](https://sourcegraph.com/docs/admin/deploy) |
+| 6.1 Patch 5  | March 2025                    | ✅             | [Notes](https://sourcegraph.com/docs/technical-changelog#v615633)  | [Install](https://sourcegraph.com/docs/admin/deploy) |
 | 6.1 Patch 4  | March 2025                    | ✅             | [Notes](https://sourcegraph.com/docs/technical-changelog#v614020)  | [Install](https://sourcegraph.com/docs/admin/deploy) |
 | 6.1 Patch 3  | March 2025                    | ✅             | [Notes](https://sourcegraph.com/docs/technical-changelog#v612889)  | [Install](https://sourcegraph.com/docs/admin/deploy) |
 | 6.1 Patch 2  | February 2025                 | ✅             | [Notes](https://sourcegraph.com/docs/technical-changelog#v611295)  | [Install](https://sourcegraph.com/docs/admin/deploy) |
@@ -54,12 +55,12 @@ These versions fall outside the release lifecycle and are not supported anymore:
 
 | **Release** | **General Availability Date** | **Supported** | **Release Notes**                                                                               |
 |-------------|-------------------------------|---------------|-------------------------------------------------------------------------------------------------|
-| 4.5          | February 2023                | ❌             | [Notes](https://sourcegraph.com/docs/technical-changelog#v451)                                  |
-| 4.4          | January 2023                 | ❌             | [Notes](https://sourcegraph.com/docs/technical-changelog#v442)                                  |
-| 4.3          | December 2022                | ❌             | [Notes](https://sourcegraph.com/docs/technical-changelog#v431)                                  |
-| 4.2          | November 2022                | ❌             | [Notes](https://sourcegraph.com/docs/technical-changelog#v421)                                  |
-| 4.1          | October 2022                 | ❌             | [Notes](https://sourcegraph.com/docs/technical-changelog#v413)                                  |
-| 4.0          | September 2022               | ❌             | [Notes](https://sourcegraph.com/docs/technical-changelog#v401)                                  |
+| 4.5         | February 2023                 | ❌             | [Notes](https://sourcegraph.com/docs/technical-changelog#v451)                                  |
+| 4.4         | January 2023                  | ❌             | [Notes](https://sourcegraph.com/docs/technical-changelog#v442)                                  |
+| 4.3         | December 2022                 | ❌             | [Notes](https://sourcegraph.com/docs/technical-changelog#v431)                                  |
+| 4.2         | November 2022                 | ❌             | [Notes](https://sourcegraph.com/docs/technical-changelog#v421)                                  |
+| 4.1         | October 2022                  | ❌             | [Notes](https://sourcegraph.com/docs/technical-changelog#v413)                                  |
+| 4.0         | September 2022                | ❌             | [Notes](https://sourcegraph.com/docs/technical-changelog#v401)                                  |
 | 3.43        | August 2022                   | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG.md#3432) |
 | 3.42        | July 2022                     | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG.md#3422) |
 | 3.41        | June 2022                     | ❌             | [Notes](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG.md#3422) |


### PR DESCRIPTION
# Add Sourcegraph 6.1 Patch 5 to supported versions

This PR adds Sourcegraph 6.1 Patch 5 (March 2025) to the list of currently supported versions in the releases documentation. It also aligns column spacing in the unsupported versions table for better readability.

