### PR TITLE
chore: remove notebooks from main navigation and outlines

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,31 +1,52 @@
 Sourcegraph is a Code Intelligence platform that deeply understands your code, no matter how large or where it’s hosted, to power modern developer experiences.
 
-- **Cody**: Use Cody our AI code assistant to read, write, and understand your entire codebase faster
-- **Code search:** Search through all of your repositories across all branches and all code hosts
-- **Code intelligence:** Navigate code, find references, see code owners, trace history, and more
-- **Fix & refactor:** Roll out and track large-scale changes and migrations across repos at once
+-   **Cody**: Use Cody our AI code assistant to read, write, and understand your entire codebase faster
+-   **Code search:** Search through all of your repositories across all branches and all code hosts
+-   **Code intelligence:** Navigate code, find references, see code owners, trace history, and more
+-   **Fix & refactor:** Roll out and track large-scale changes and migrations across repos at once
 
 ## Quickstart
 
 <QuickLinks>
-	<QuickLink href="/cody" icon="cody" imgAlt="Cody" title="Cody" description="Write, fix, and maintain code with Sourcegraph’s AI coding assistant, Cody. " />
-	<QuickLink href="/code-search" icon="codesearch" imgAlt="Code Search" title="Code Search" description="Search all of your repositories across all branches and all code hosts." />
-	<QuickLink title="Sourcegraph 101" icon="plugins" href="/getting-started" description="Learn how to use Sourcegraph." />
-	<QuickLink title="Sourcegraph Tour" icon="codegraph" href="/getting-started/tour" description="Take a tour of Sourcegraph’s features using real-world examples and use cases." />
+	<QuickLink
+		href="/cody"
+		icon="cody"
+		imgAlt="Cody"
+		title="Cody"
+		description="Write, fix, and maintain code with Sourcegraph’s AI coding assistant, Cody. "
+	/>
+	<QuickLink
+		href="/code-search"
+		icon="codesearch"
+		imgAlt="Code Search"
+		title="Code Search"
+		description="Search all of your repositories across all branches and all code hosts."
+	/>
+	<QuickLink
+		title="Sourcegraph 101"
+		icon="plugins"
+		href="/getting-started"
+		description="Learn how to use Sourcegraph."
+	/>
+	<QuickLink
+		title="Sourcegraph Tour"
+		icon="codegraph"
+		href="/getting-started/tour"
+		description="Take a tour of Sourcegraph’s features using real-world examples and use cases."
+	/>
 </QuickLinks>
 
 ## Main Features
 
 Some of the main Sourcegraph features include:
 
-| **Feature**                    | **Description**                                                                                                                        |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| **Cody** | Cody is a free AI coding assistant that writes, fixes, and maintains your code |
-| **Code Navigation**            | Jump-to-definition, find references, and other IDE-like code browsing features on any branch, commit, or PR/code review      |
-| **Code Insights**              | Reveal high-level information about your codebase at its current state and over time, to track migrations, version usage, vulnerability remediation, ownership, and more |
-| **Batch Changes**              | Make large-scale code changes across many repositories and codehosts                                                              |
-| **Integrations**               | With code hosts, code review tools, editors, web browsers, etc.                                                                   |
-| **Notebooks**                  | Pair code and markdown to create powerful live and persistent documentation                                                      |
+| **Feature**         | **Description**                                                                                                                                                          |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Cody**            | Cody is a free AI coding assistant that writes, fixes, and maintains your code                                                                                           |
+| **Code Navigation** | Jump-to-definition, find references, and other IDE-like code browsing features on any branch, commit, or PR/code review                                                  |
+| **Code Insights**   | Reveal high-level information about your codebase at its current state and over time, to track migrations, version usage, vulnerability remediation, ownership, and more |
+| **Batch Changes**   | Make large-scale code changes across many repositories and codehosts                                                                                                     |
+| **Integrations**    | With code hosts, code review tools, editors, web browsers, etc.                                                                                                          |
 
 ## What's New
 

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -225,11 +225,6 @@ export const navigation: NavigationItem[] = [
 					{ title: "References", href: "/code_insights/references" },
 				],
 			},
-			{
-				title: "Notebooks",
-				href: "/notebooks",
-				sections: [{ title: "Quickstart", href: "/notebooks/quickstart" }],
-			},
 		],
 	},
 	{


### PR DESCRIPTION
Notebooks have been deprecated and are disabled by default. This removes them from the main navigation and removes a few incoming links to notebooks on index pages. This does not remove the notebooks pages so that customers can still search the docs for notebooks pages, just cannot browse to them.