### PR TITLE
Add hover links to heading levels 4 and 5

### DIFF
--- a/src/components/MdxComponents.tsx
+++ b/src/components/MdxComponents.tsx
@@ -53,6 +53,12 @@ const MdxComponents = (version?: string) => {
     h3: (props: any) => {
       return <Heading level="3" id={props.id} props={props} />;
     },
+    h4: (props: any) => {
+      return <Heading level="4" id={props.id} props={props} />;
+    },
+    h5: (props: any) => {
+      return <Heading level="5" id={props.id} props={props} />;
+    },
     img: (props: any) => {
       return <img className="rounded-xl" {...props} />;
     },


### PR DESCRIPTION
Add to heading levels 4 and 5 the same hover-over links and clickable-ness that heading levels 1-3 enjoy. This does not add them to the in-page table of contents, but simply lets users easily copy deep links straight to the sections.

Why only levels 4 and 5? Because we don't have any level six headings in our docs. Yet.

https://github.com/user-attachments/assets/e03428c9-aba4-439d-904b-acce74225da0
