### PR TITLE
Callout on using the correct image for 5.10 upgrade

### DIFF
--- a/docs/admin/postgres12_end_of_life_notice.mdx
+++ b/docs/admin/postgres12_end_of_life_notice.mdx
@@ -16,6 +16,8 @@ If you are using Sourcegraph's released Postgres images, these images will be up
 
 We strongly recommend that you consider this downtime prior to upgrading to ensure minimal disruption to your users. We also strongly recommend creating a backup of your database before the upgrade process, as an interruption to the upgrade process could lead to database corruption.
 
+<Callout type="info">When upgrading, it's important to note that even if there's a newer version of the migrator image you should only use the 5.10 image to get the databases to v5.10 first. After that you can use newer migrator images to target versions beyond 5.10.</Callout>
+
 ### External Databases
 If you are using externally managed databases for your Sourcegraph instance, you will need to manually upgrade the version of Postgres you are using to Postgres 16. For the Sourcegraph version that will be released on January 15, 2025 and subsequent versions, Sourcegraph will no longer run on any version of Postgres lower than Postgres 16, and you will not be able to upgrade your instance to any of those Sourcegraph versions unless that minimum required version of Postgres is met.
 


### PR DESCRIPTION
<!-- Explain the changes introduced in your PR -->
This change introduces a nuanced callout where typically customers can use the most recent version of migrator when performing an MVU but to upgrade to 5.10 they explicitly need to use the 5.10 migrator image, otherwise the database upgrade will fail.
## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
