### PR TITLE
Update docs for Entra ID  to reference Azure Active Directory

### DIFF
--- a/docs/admin/auth/saml/azure_ad.mdx
+++ b/docs/admin/auth/saml/azure_ad.mdx
@@ -1,4 +1,5 @@
-# Configuring SAML with Microsoft Entra ID
+# Configuring SAML with Microsoft Entra ID 
+<Callout type="note">Formerly known as Azure Active Directory, or Azure AD.</Callout>
 
 ## 1. Add an unlisted (non-gallery) application to your Microsoft Entra ID organization
 


### PR DESCRIPTION
Make it really clear that Azure AD is the same thing as Entra