### PR TITLE
Add a note explaining that no sub-repo perms = sub-repo perms disabled

### DIFF
--- a/docs/admin/permissions/api.mdx
+++ b/docs/admin/permissions/api.mdx
@@ -99,7 +99,7 @@ You can call `setRepositoryPermissionsForUsers` repeatedly to set permissions fo
 
 ## Setting sub-repository permissions for users
 
-> NOTE: If no sub-repository permissions have been set for a repository, that repository is treated as not having sub-repo permissions enabled.
+> NOTE: If a user has no sub-repo permissions set for a specific repository (assuming that they have general access to the repository), they will have access to the entire repository contents.
 
 Sourcegraph supports permissions on a per-file/directory basis. 
 

--- a/docs/admin/permissions/api.mdx
+++ b/docs/admin/permissions/api.mdx
@@ -99,6 +99,8 @@ You can call `setRepositoryPermissionsForUsers` repeatedly to set permissions fo
 
 ## Setting sub-repository permissions for users
 
+> NOTE: If no sub-repository permissions have been set for a repository, that repository is treated as not having sub-repo permissions enabled.
+
 Sourcegraph supports permissions on a per-file/directory basis. 
 
 To enable the sub-repo permissions API, add the following to the [site configuration](/admin/config/site_config):


### PR DESCRIPTION
Just a small note clarifying that if no sub-repo permissions have been set for a repository, that repository is treated as not having sub-repo permissions enabled.

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
