### PR TITLE
docs: remove manual repo data purge section

### DIFF
--- a/docs/admin/how-to/remove-repo.mdx
+++ b/docs/admin/how-to/remove-repo.mdx
@@ -30,20 +30,3 @@ Alternately, if a repository is synced from multiple code host connections you m
 Open the repository's `Settings` page on Sourcegraph and from the `Mirroring` tab click `Reclone`.
 
 ![Reclone repository](https://storage.googleapis.com/sourcegraph-assets/docs/images/admin/how-to/reclone-repo.png)
-
-## Manually purge deleted repository data from disk
-
-After a repository is deleted from Sourcegraph in the database, its data still remains on disk on gitserver so that in the event the repository is added again it doesn't need to be recloned. These repos are automatically removed when disk space is low on gitserver. However, it is possible to manually trigger removal of deleted repos in the following way:
-
-**NOTE:** This is not available on Docker Compose deployments.
-
-1. Browse to Site Admin -> Instrumentation -> Repo Updater -> Manual Repo Purge
-2. You'll be at a url similar to `https://sourcegraph-instance/-/debug/proxies/repo-updater/manual-purge`
-3. You need to specify a limit parameter which specifies the upper limit to the number of repos that will be removed, for example: `https://sourcegraph-instance/-/debug/proxies/repo-updater/manual-purge?limit=1000`
-4. This will trigger a background process to delete up to `limit` repos, rate limited at 1 per second.
-
-It's possible to see the number of repos that can be cleaned up on disk in Grafana using this query:
-
-```
-max(src_repoupdater_purgeable_repos)
-```


### PR DESCRIPTION
We now automatically reclaim disk space for deleted repos, and this debug endpoint no longer exists.

Fixes SRC-1263