### PR TITLE
Add upgrade info for 6.4 repo updater removal

### DIFF
--- a/docs/admin/updates/kubernetes.mdx
+++ b/docs/admin/updates/kubernetes.mdx
@@ -8,14 +8,18 @@ For upgrade procedures or general info about sourcegraph versioning see the link
 - [General Upgrade Info](/admin/updates)
 - [Technical changelog](/technical-changelog)
 
-> ***Attention:** These notes may contain relevant information about the infrastructure update such as resource requirement changes or versions of depencies (Docker, kubernetes, externalized databases).*
+> ***Attention:** These notes may contain relevant information about the infrastructure update such as resource requirement changes or versions of dependencies (Docker, kubernetes, externalized databases).*
 >
 > ***If the notes indicate a patch release exists, target the highest one.***
+
+## v6.4.0
+
+- The repo-updater service is no longer needed and will be removed from deployment methods going forward.
 
 ## v6.0.0
 
 - Sourcegraph 6.0.0 no longer supports PostgreSQL 12, admins must upgrade to PostgreSQL 16. See our [postgres 12 end of life](/admin/postgres12_end_of_life_notice) notice! As well as [supporting documentation](/admin/postgres) and advisements on how to upgrade.
-- <Callout type="warning">The Kuberentes Helm deployment type does not support MVU from Sourcegraph `v5.9.45` versions and earlier to Sourcegraph `v6.0.0`. Admins seeking to upgrade to Sourcegraph `v6.0.0` should upgrade to `v5.11.6271` then use the standard upgrade procedure to get to `v6.0.0`. This is because migrator v6.0.0 will no longer connect to Postgres 12 databases. For more info see our [PostgreSQL upgrade docs](/admin/postgres#requirements).</Callout>
+- <Callout type="warning">The Kubernetes Helm deployment type does not support MVU from Sourcegraph `v5.9.45` versions and earlier to Sourcegraph `v6.0.0`. Admins seeking to upgrade to Sourcegraph `v6.0.0` should upgrade to `v5.11.6271` then use the standard upgrade procedure to get to `v6.0.0`. This is because migrator v6.0.0 will no longer connect to Postgres 12 databases. For more info see our [PostgreSQL upgrade docs](/admin/postgres#requirements).</Callout>
 
 ## v5.9.0 ➔ v5.10.1164
 


### PR DESCRIPTION
The service is no longer needed. Corresponding helm chart update: https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/671

Test plan: n/a

