### PR TITLE
Add 6.4 upgrade instruction for symbols

### DIFF
--- a/docs/admin/updates/kubernetes.mdx
+++ b/docs/admin/updates/kubernetes.mdx
@@ -15,6 +15,7 @@ For upgrade procedures or general info about sourcegraph versioning see the link
 ## v6.4.0
 
 - The repo-updater service is no longer needed and will be removed from deployment methods going forward.
+- The symbols service and searcher service have been merged and symbols will be removed from deployment methods going forward. Consider moving env vars set on symbols to the searcher deployment before upgrading and reallocating resources from symbols to searcher.
 
 ## v6.0.0
 


### PR DESCRIPTION
The symbols service will no longer be needed in 6.4. We still publish it at the moment, but it won't do anything. All functionality is now handled by searcher and frontend. Existing set env vars should be moved to the searcher service, and resources may be reallocated to there as well.

Test plan: We'll test this on dotcom and S2 for the next few weeks.
