### PR TITLE
Sourcegraph AMIs: remove references to AMI T-shirt sizes

### DIFF
--- a/docs/admin/deploy/machine-images/aws-ami.mdx
+++ b/docs/admin/deploy/machine-images/aws-ami.mdx
@@ -16,34 +16,22 @@ All Sourcegraph AMIs are published from one of the following AWS accounts:
 - Account ID: `870751268155`
 
 
-### Instance size chart
+### Instance sizing
 
-Select an AMI according and instance type to the number of users and repositories you have using this table. If you fall between two sizes, choose the larger of the two.
-
-For example, if you have 8,000 users with 80,000 repositories, your instance size would be **L**. If you have 1,000 users with 80,000 repositories, you should still go with size **M**.
-
-|                      | **XS**                                                                                                              | **S**                                                                                                             | **M**                                                                                                             | **L**                                                                                                             | **XL**                                                                                                              |
-|----------------------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-| **Users**            | greater than or equal to 500                                                                                        | greater than or equal to 1,000                                                                                    | greater than or equal to 5,000                                                                                    | greater than or equal to 10,000                                                                                   | greater than or equal to 20,000                                                                                     |
-| **Repositories**     | greater than or equal to 5,000                                                                                      | greater than or equal to 10,000                                                                                   | greater than or equal to 50,000                                                                                   | greater than or equal to 100,000                                                                                  | greater than or equal to 250,000                                                                                    |
-| **Recommended Type** | m6a.2xlarge                                                                                                         | m6a.4xlarge                                                                                                       | m6a.8xlarge                                                                                                       | m6a.12xlarge                                                                                                      | m6a.24xlarge                                                                                                        |
-| **Minimum Type**     | m6a.2xlarge                                                                                                         | m6a.2xlarge                                                                                                       | m6a.4xlarge                                                                                                       | m6a.8xlarge                                                                                                       | m6a.12xlarge                                                                                                        |
-| **AMIs List**        | [size-XS AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-XS) | [size-S AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-S) | [size-M AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-M) | [size-L AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-L) | [size-XL AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-XL) |
+Refer to our [AWS Instance Sizing](/how-to/aws-instance-sizing) guide to determine the appropriate EC2 instance type for your Sourcegraph deployment based on the number of users and repositories.
 
 Click [here](https://github.com/sourcegraph/deploy#amazon-ec2-amis) to see the completed list of AMI IDs published in each region.
 
 **The default AMI username is `ec2-user`.**
 
-<Callout type="note">While we recommend certain image types in our sizing chart, AMIs will dynamically use the resources available on the EC2 instance type they are deployed to, provided the minimum amount of resources needed is available. If you would like to resize your EC2 instance, follow the [upgrade steps](#upgrade) to switch to the correct AMI image that is optimized for your EC2 instance type.</Callout>
-
 ---
 
 ## Deploy Sourcegraph
 
-1. In the [instance size chart](#instance-size-chart), click the link for the AMI that matches your deployment size.
+1. Search for Sourcegraph in the AWS Marketplace or AMI catalog (see screenshot in the introduction).
 2. Choose **Launch instance from AMI**.
 3. Name your instance.
-4. Select an **instance type** according to [the sizing chart](#instance-size-chart) or your needs.
+4. Select an **instance type** according to [our sizing guide](/how-to/aws-instance-sizing) or your specific requirements.
 5. **Key pair (login)**: Select or create a new Key Pair for connecting to your instance securely (this may be required in the event you need support).
 6. **Network settings**:
    - Under "Auto-assign public IP" select "Enable".

--- a/docs/how-to/aws-instance-sizing.mdx
+++ b/docs/how-to/aws-instance-sizing.mdx
@@ -1,0 +1,16 @@
+# AWS Instance Sizing for Sourcegraph
+
+## Instance size chart
+
+Select an instance type according to the number of users and repositories you have using this table. If you fall between two sizes, choose the larger of the two.
+
+For example, if you have 8,000 users with 80,000 repositories, your instance size would be **L**. If you have 1,000 users with 80,000 repositories, you should still go with size **M**.
+
+|                      | **XS**                | **S**                 | **M**                 | **L**                 | **XL**                 |
+|----------------------|-----------------------|-----------------------|-----------------------|-----------------------|------------------------|
+| **Users**            | ≥ 500                 | ≥ 1,000               | ≥ 5,000               | ≥ 10,000              | ≥ 20,000               |
+| **Repositories**     | ≥ 5,000               | ≥ 10,000              | ≥ 50,000              | ≥ 100,000             | ≥ 250,000              |
+| **Recommended Type** | m6a.2xlarge           | m6a.4xlarge           | m6a.8xlarge           | m6a.12xlarge          | m6a.24xlarge           |
+| **Minimum Type**     | m6a.2xlarge           | m6a.2xlarge           | m6a.4xlarge           | m6a.8xlarge           | m6a.12xlarge           |
+
+<Callout type="note">While we recommend certain instance types in our sizing chart, the Sourcegraph AMI will dynamically use the resources available on the EC2 instance type it is deployed to, provided the minimum amount of resources needed is available. If you would like to resize your EC2 instance, follow the [upgrade steps](/admin/deploy/machine-images/aws-ami#upgrade) to switch to a more appropriate instance type.</Callout>


### PR DESCRIPTION
We no longer publish images per instance T-shirt size. This PR removes those references from the deployment docs and moves them to a "how-to" so that they can still be referenced as needed.

Tested deployment via EC2 account
