### PR TITLE
Update Code Insights docs with new sub-repo perms setting

### DIFF
--- a/docs/code_insights/explanations/current_limitations_of_code_insights.mdx
+++ b/docs/code_insights/explanations/current_limitations_of_code_insights.mdx
@@ -79,9 +79,24 @@ Code Insights does not yet support running over specific revisions.
 
 ## VCS limitations
 
-Code Insights only supports git based repositories and does not support perforce repositories that have sub-repo permissions enabled.
+Code Insights by default can **not** query repositories that have [sub-repo permissions](/admin/permissions/api#Setting-sub-repository-permissions-for-users) configured. Note that some repositories can sync sub-repo permissions from the code host - Perforce depots currently (6.3).
 
-<Callout type="note"> Perforce depots converted to git are also currently not supported for Code Insights.</Callout>
+The reason for that restriction is security concerns around exposing the code in those repositories to users who should not be able to access it.
+
+Code Insights exposes only aggregated analytics and counts of patterns, though, not the raw code, so the security concerns could be less for Code Insights.
+
+If desired, a Sourcegraph admin can enable Code Insights access to repositories that use sub-repo permissions in site config:
+
+```json
+"experimentalFeatures": {
+    "subRepoPermissions": {
+      "enabled": true,
+      "allowCodeInsights": true
+    }
+}
+```
+
+`allowCodeInsights` is `false` by default, preserving historical behavior. 
 
 ## Feature parity limitations
 

--- a/docs/code_insights/explanations/current_limitations_of_code_insights.mdx
+++ b/docs/code_insights/explanations/current_limitations_of_code_insights.mdx
@@ -79,7 +79,7 @@ Code Insights does not yet support running over specific revisions.
 
 ## VCS limitations
 
-Code Insights by default can **not** query repositories that have [sub-repo permissions](/admin/permissions/api#Setting-sub-repository-permissions-for-users) configured. Note that some repositories can sync sub-repo permissions from the code host - Perforce depots currently (6.3).
+Code Insights by default can **not** query repositories that have [sub-repo permissions](/admin/permissions/api#Setting-sub-repository-permissions-for-users) configured. Note that some repositories can sync sub-repo permissions from the code host - Perforce depots currently (6.4).
 
 The reason for that restriction is security concerns around exposing the code in those repositories to users who should not be able to access it.
 

--- a/docs/code_insights/references/requirements.mdx
+++ b/docs/code_insights/references/requirements.mdx
@@ -15,6 +15,6 @@ You can only use Code Insights on a [Docker Compose](/admin/deploy/docker-compos
 
 ## Code hosts
 
-Sourcegraph Code Insights is compatible with any [Sourcegraph-compatible code host](/admin/repo/), except:
+Sourcegraph Code Insights is compatible with any [Sourcegraph-compatible code host](/admin/repo/).
 
-* Perforce repositories making use of sub-repo permissions are not supported
+If the repo has [sub-repo permissions](/admin/permissions/api#Setting-sub-repository-permissions-for-users) configured, an admin will need to set `experimentalSettings.subRepoPermissions.allowCodeInsights` to `true` in site config to allow Code Insights to query that repo.  


### PR DESCRIPTION
Update Code Insights documentation for the changes introduced in [PR 5187](https://github.com/sourcegraph/sourcegraph/pull/5187), which will be in the May 28th (6.4) release.