### PR TITLE
fix missing links and remove reference to auto-dependency indexing

### DIFF
--- a/docs/code-search/code-navigation/precise_code_navigation.mdx
+++ b/docs/code-search/code-navigation/precise_code_navigation.mdx
@@ -22,7 +22,7 @@ Precise code navigation relies on the open source [SCIP Code Intelligence Protoc
 
 ## Setting up code navigation for your codebase
 
-<Callout type="info">There are several options for setting up precise code navigation listed below. However, we always recommend you start by manually indexing your repo locally using the [approriate indexer](/code-navigation/writing_an_indexer#quick-reference) for your language. Code and build systems can vary by project and ensuring you can first succesfully run the indexer locally leads to a smoother experience since it is vastly easier to debug and iterate on any issues locally before trying to do so in CI/CD or in Auto-Indexing.</Callout>
+<Callout type="info">There are several options for setting up precise code navigation listed below. However, we always recommend you start by manually indexing your repo locally using the [approriate indexer](/code-search/code-navigation/writing_an_indexer#quick-reference) for your language. Code and build systems can vary by project and ensuring you can first succesfully run the indexer locally leads to a smoother experience since it is vastly easier to debug and iterate on any issues locally before trying to do so in CI/CD or in Auto-Indexing.</Callout>
 
 1. **Manual indexing**. Index a repository and upload it to your Sourcegraph instance:
 
@@ -32,12 +32,8 @@ Precise code navigation relies on the open source [SCIP Code Intelligence Protoc
     - [Index a Python repository](https://sourcegraph.com/github.com/sourcegraph/scip-python)
     - [Index a Ruby repository](https://sourcegraph.com/github.com/sourcegraph/scip-ruby)
 
-2. [**Automate indexing via CI**](/code_navigation/how-to/adding_scip_to_workflows): Add indexing and uploading to your CI setup.
+2. [**Automate indexing via CI**](/code-search/code-navigation/how-to/adding_scip_to_workflows): Add indexing and uploading to your CI setup.
 3. [**Auto-indexing**](/code-search/code-navigation/auto_indexing#enable-auto-indexing): Sourcegraph will automatically index your repositories and enable precise code navigation for them.
-4. Set up **auto-dependency indexing** to navigate and search through the dependencies your code uses:
-    - **Go**: Enable [auto-indexing](/code-search/code-navigation/auto_indexing) and Sourcegraph will start indexing your dependencies.
-    - **JavaScript, TypeScript**: Enable [auto-indexing](/code-search/code-navigation/auto_indexing#enable-auto-indexing) and set up an [npm dependencies code host](/integration/npm).
-    - **Java, Scala, Kotlin**: Enable [auto-indexing](/code-search/code-navigation/auto_indexing) and set up a [JVM dependencies code host](/integration/jvm).
 
 ## Supported languages and indexers
 


### PR DESCRIPTION
- fixes a couple of 404 broken links on the precise indexing doc page
- remove reference to auto-dependency indexing which relies on [package code hosts](https://github.com/sourcegraph/docs/pull/724)

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
