### PR TITLE
search: document INDEXED_SEARCH_INDEXERS

### DIFF
--- a/docs/admin/deploy/docker-compose/configuration.mdx
+++ b/docs/admin/deploy/docker-compose/configuration.mdx
@@ -125,7 +125,7 @@ If you must use a `.netrc` file to store these credentials instead, follow the p
 
 ## Add replicas
 
-When adding replicas for `gitserver`, `indexed-search`, `searcher`, or `symbols`, you must update the corresponding environment variable on each of the frontend services in your docker-compose.override.yaml file, `SRC_GIT_SERVERS`, `INDEXED_SEARCH_SERVERS`, `SEARCHER_URL`, and `SYMBOLS_URL` to the number of replicas for each respective service. Sourcegraph will then automatically infer the endpoints for each replica.
+When adding replicas for `gitserver`, `searcher`, `symbols`, `zoekt-indexserver`, or `zoekt-webserver`, you must update the corresponding environment variable on each of the frontend services in your docker-compose.override.yaml file to the number of replicas for the respective service. Sourcegraph will then automatically infer the containers' endpoints for each replica.
 
 ```yaml
 # docker-compose.override.yaml
@@ -133,24 +133,24 @@ services:
 
   sourcegraph-frontend-0:
     environment:
-      - 'SRC_GIT_SERVERS=2'
-      - 'INDEXED_SEARCH_SERVERS=2'
-      - 'INDEXED_SEARCH_INDEXERS=2'
+      - 'INDEXED_SEARCH_INDEXERS=1'
+      - 'INDEXED_SEARCH_SERVERS=1'
       - 'SEARCHER_URL=1'
+      - 'SRC_GIT_SERVERS=1'
       - 'SYMBOLS_URL=1'
 
   sourcegraph-frontend-internal:
     environment:
-      - 'SRC_GIT_SERVERS=2'
-      - 'INDEXED_SEARCH_SERVERS=2'
-      - 'INDEXED_SEARCH_INDEXERS=2'
+      - 'INDEXED_SEARCH_INDEXERS=1'
+      - 'INDEXED_SEARCH_SERVERS=1'
       - 'SEARCHER_URL=1'
+      - 'SRC_GIT_SERVERS=1'
       - 'SYMBOLS_URL=1'
 ```
 
 ## Shard gitserver
 
-If you find that your gitserver container is performing poorly, you can shard it into multiple containers. This is especially helpful when your Docker Compose host can mount multiple storage volumes, and each gitserver shared can use its own storage IOPS limit.
+If you find that your gitserver container is performing poorly, you can shard it into multiple containers. This is especially helpful when your Docker Compose host can mount multiple storage volumes, and each gitserver shard can use its own storage IOPS limit.
 
 To split gitserver across multiple shards:
 

--- a/docs/admin/deploy/docker-compose/configuration.mdx
+++ b/docs/admin/deploy/docker-compose/configuration.mdx
@@ -135,6 +135,7 @@ services:
     environment:
       - 'SRC_GIT_SERVERS=2'
       - 'INDEXED_SEARCH_SERVERS=2'
+      - 'INDEXED_SEARCH_INDEXERS=2'
       - 'SEARCHER_URL=1'
       - 'SYMBOLS_URL=1'
 
@@ -142,6 +143,7 @@ services:
     environment:
       - 'SRC_GIT_SERVERS=2'
       - 'INDEXED_SEARCH_SERVERS=2'
+      - 'INDEXED_SEARCH_INDEXERS=2'
       - 'SEARCHER_URL=1'
       - 'SYMBOLS_URL=1'
 ```

--- a/docs/admin/deploy/kubernetes/configure.mdx
+++ b/docs/admin/deploy/kubernetes/configure.mdx
@@ -82,7 +82,7 @@ RBAC must be enabled in your cluster for the frontend to communicate with other 
 
 This will allow the frontend service to discover endpoints for each service replica and communicate with them through the Kubernetes API. Note that this component should only be added if RBAC is enabled in your cluster.
 
-If you are not using Kubernetes service discovery (for example, if you are running without RBAC or outside Kubernetes), you must manually configure service endpoints for the frontend.** See [Running Sourcegraph Without Kubernetes Service Discovery](/admin/deploy/without_service_discovery) for instructions.
+If you are not using Kubernetes service discovery (for example, if you are running without RBAC or outside Kubernetes), you must manually configure service endpoints for the frontend. See [Running Sourcegraph Without Kubernetes Service Discovery](/admin/deploy/without_service_discovery) for instructions.
 
 ---
 

--- a/docs/admin/deploy/kubernetes/configure.mdx
+++ b/docs/admin/deploy/kubernetes/configure.mdx
@@ -82,7 +82,7 @@ RBAC must be enabled in your cluster for the frontend to communicate with other 
 
 This will allow the frontend service to discover endpoints for each service replica and communicate with them through the Kubernetes API. Note that this component should only be added if RBAC is enabled in your cluster.
 
-> **If you are not using Kubernetes service discovery (for example, if you are running without RBAC or outside Kubernetes), you must manually configure service endpoints for the frontend.** See [Running Sourcegraph Without Kubernetes Service Discovery](/admin/deploy/without_service_discovery) for instructions.
+If you are not using Kubernetes service discovery (for example, if you are running without RBAC or outside Kubernetes), you must manually configure service endpoints for the frontend.** See [Running Sourcegraph Without Kubernetes Service Discovery](/admin/deploy/without_service_discovery) for instructions.
 
 ---
 

--- a/docs/admin/deploy/kubernetes/configure.mdx
+++ b/docs/admin/deploy/kubernetes/configure.mdx
@@ -82,6 +82,8 @@ RBAC must be enabled in your cluster for the frontend to communicate with other 
 
 This will allow the frontend service to discover endpoints for each service replica and communicate with them through the Kubernetes API. Note that this component should only be added if RBAC is enabled in your cluster.
 
+> **If you are not using Kubernetes service discovery (for example, if you are running without RBAC or outside Kubernetes), you must manually configure service endpoints for the frontend.** See [Running Sourcegraph Without Kubernetes Service Discovery](/admin/deploy/without_service_discovery) for instructions.
+
 ---
 
 ## Monitoring stack

--- a/docs/admin/deploy/without_service_discovery.mdx
+++ b/docs/admin/deploy/without_service_discovery.mdx
@@ -1,0 +1,15 @@
+# Running Sourcegraph Without Kubernetes Service Discovery
+
+<Callout type="warning">Not settting these environment variables might prevent pods from starting when running without service discovery.</Callout>
+
+If you are deploying Sourcegraph in an environment **without Kubernetes service discovery** (for example, using Docker Compose or single-container Docker), you must manually configure the frontend service to know about the other service replicas. This is typically required when you are not using RBAC or the `service-discovery` component in Kubernetes, or when running outside Kubernetes entirely.
+
+## Required Environment Variables
+
+- INDEXED_SEARCH_INDEXER
+- INDEXED_SEARCH_SERVERS
+- SEARCHER_URL
+- SRC_GIT_SERVERS
+- SYMBOLS_URL
+
+For detailed instructions on how to set these environment variables in a Docker Compose deployment, see the [Docker Compose configuration guide](/admin/deploy/docker-compose/configuration#set-environment-variables).

--- a/docs/admin/deploy/without_service_discovery.mdx
+++ b/docs/admin/deploy/without_service_discovery.mdx
@@ -2,7 +2,7 @@
 
 <Callout type="warning">Not settting these environment variables might prevent pods from starting when running without service discovery.</Callout>
 
-If you are deploying Sourcegraph in an environment **without Kubernetes service discovery** (for example, using Docker Compose or single-container Docker), you must manually configure the frontend service to know about the other service replicas. This is typically required when you are not using RBAC or the `service-discovery` component in Kubernetes, or when running outside Kubernetes entirely.
+If you are deploying Sourcegraph in an environment **without Kubernetes service discovery** (for example, using Docker Compose or single-container Docker), you must manually configure the frontend service to know about the other service replicas. This is typically required when you are not using RBAC, or when running outside Kubernetes entirely.
 
 ## Required Environment Variables
 


### PR DESCRIPTION
INDEXED_SEARCH_INDEXERS was added in a previous release but I missed to document it properly which caused unexpected log spam for customers using docker and failed pods for customers on K8S without service discovery.
