### PR TITLE
docs: Add documentation for the `src prompts` command

### DIFF
--- a/docs/cli/references/index.mdx
+++ b/docs/cli/references/index.mdx
@@ -15,6 +15,7 @@ Most commands require that the user first [authenticate](quickstart#connect-to-s
 * [`login`](references/login)
 * [`lsif`](references/lsif)
 * [`orgs`](references/orgs)
+* [`prompts`](references/prompts)
 * [`repos`](references/repos)
 * [`scout`](references/scout)
 * [`search`](references/search)

--- a/docs/cli/references/prompts.mdx
+++ b/docs/cli/references/prompts.mdx
@@ -1,0 +1,37 @@
+# src prompts
+
+<p className="subtitle">`src prompts` is a tool that manages prompt library prompts and tags in a Sourcegraph instance.</p>
+
+## Usage
+
+```
+'src prompts' is a tool that manages prompt library prompts and tags in a Sourcegraph instance.
+
+Usage:
+
+	src prompts command [command options]
+
+The commands are:
+
+	list        lists prompts
+	get         get a prompt by ID
+	create      create a prompt
+	update      update a prompt
+	delete      delete a prompt
+	export      export prompts to a JSON file
+	import      import prompts from a JSON file
+	tags        manage prompt tags (use "src prompts tags [command] -h" for more info)
+
+Use "src prompts [command] -h" for more information about a command.
+```
+
+## Sub-commands
+
+* [list](prompts/list)
+* [get](prompts/get)
+* [create](prompts/create)
+* [update](prompts/update)
+* [delete](prompts/delete)
+* [export](prompts/export)
+* [import](prompts/import)
+* [tags](prompts/tags)

--- a/docs/cli/references/prompts/create.mdx
+++ b/docs/cli/references/prompts/create.mdx
@@ -1,0 +1,81 @@
+# src prompts create
+
+Create a new prompt in your Sourcegraph instance.
+
+## Usage
+
+```bash
+src prompts create [flags]
+```
+
+## Examples
+
+```bash
+# Create a basic prompt (uses current user as owner)
+src prompts create \
+  -name="go-error-handling" \
+  -description="Best practices for Go error handling" \
+  -content="Write a Go function that properly handles errors..."
+
+# Create a prompt with tags
+src prompts create \
+  -name="python-optimization" \
+  -description="Python performance optimization tips" \
+  -content="Optimize this Python code for better performance..." \
+  -tags="UHJvbXB0VGFnOjE=,UHJvbXB0VGFnOjI="
+
+# Create a draft prompt
+src prompts create \
+  -name="draft-prompt" \
+  -description="Work in progress prompt" \
+  -content="This prompt is still being developed..." \
+  -draft
+
+# Create a recommended prompt with auto-submit
+src prompts create \
+  -name="recommended-prompt" \
+  -description="A recommended prompt for common use" \
+  -content="This is a recommended prompt..." \
+  -recommended \
+  -auto-submit
+
+# Create a secret prompt for INSERT mode
+src prompts create \
+  -name="secret-insert-prompt" \
+  -description="Secret prompt for code insertion" \
+  -content="Insert code here..." \
+  -visibility="SECRET" \
+  -mode="INSERT"
+
+# Create a prompt with explicit owner (optional)
+src prompts create \
+  -name="team-shared-prompt" \
+  -description="A prompt shared with a specific owner" \
+  -content="This prompt has an explicit owner..." \
+  -owner="VXNlcjox"
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-name` | The prompt name (required) |
+| `-description` | Description of the prompt (required) |
+| `-content` | The prompt template text content (required) |
+| `-owner` | The ID of the owner (user or organization) (optional, defaults to current user) |
+| `-tags` | Comma-separated list of tag IDs |
+| `-draft` | Whether the prompt is a draft (default: false) |
+| `-visibility` | Visibility of the prompt: PUBLIC or SECRET (default: "PUBLIC") |
+| `-auto-submit` | Whether the prompt should be automatically executed in one click (default: false) |
+| `-mode` | Mode to execute prompt: CHAT, EDIT, or INSERT (default: "CHAT") |
+| `-recommended` | Whether the prompt is recommended (default: false) |
+
+### API flags
+
+| Flag | Description |
+|------|-------------|
+| `-dump-requests` | Log GraphQL requests and responses to stdout |
+| `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) |
+| `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains |
+| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing |
+| `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/delete.mdx
+++ b/docs/cli/references/prompts/delete.mdx
@@ -1,0 +1,32 @@
+# src prompts delete
+
+Delete a prompt from your Sourcegraph instance.
+
+## Usage
+
+```bash
+src prompts delete <prompt-id>
+```
+
+## Examples
+
+```bash
+# Delete a prompt by ID
+src prompts delete UHJvbXB0OjE=
+
+# The command will confirm successful deletion
+src prompts delete UHJvbXB0OjE=
+# Output: Prompt deleted successfully.
+```
+
+## Flags
+
+### API flags
+
+| Flag | Description |
+|------|-------------|
+| `-dump-requests` | Log GraphQL requests and responses to stdout |
+| `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) |
+| `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains |
+| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing |
+| `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/export.mdx
+++ b/docs/cli/references/prompts/export.mdx
@@ -1,0 +1,46 @@
+# src prompts export
+
+Export prompts to a JSON file.
+
+## Usage
+
+```bash
+src prompts export [flags]
+```
+
+## Examples
+
+```bash
+# Export all prompts to stdout
+src prompts export
+
+# Export all prompts to a file
+src prompts export -o prompts-backup.json
+
+# Export with pretty formatting
+src prompts export -o prompts-backup.json -format=pretty
+
+# Export prompts with specific tags
+src prompts export -o go-prompts.json -tags="go,golang"
+
+# Export prompts with multiple tag filters
+src prompts export -o filtered-prompts.json -tags="python,data-science,ml"
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-o` | Output file path (defaults to stdout if not specified) |
+| `-tags` | Comma-separated list of tag names to filter by |
+| `-format` | JSON format: 'pretty' or 'compact' (default: 'compact') |
+
+### API flags
+
+| Flag | Description |
+|------|-------------|
+| `-dump-requests` | Log GraphQL requests and responses to stdout |
+| `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) |
+| `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains |
+| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing |
+| `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/get.mdx
+++ b/docs/cli/references/prompts/get.mdx
@@ -1,0 +1,28 @@
+# src prompts get
+
+Get details about a specific prompt by ID.
+
+## Usage
+
+```bash
+src prompts get <prompt-id>
+```
+
+## Examples
+
+```bash
+# Get prompt by ID
+src prompts get UHJvbXB0OjE=
+```
+
+## Flags
+
+### API flags
+
+| Flag | Description |
+|------|-------------|
+| `-dump-requests` | Log GraphQL requests and responses to stdout |
+| `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) |
+| `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains |
+| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing |
+| `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/import.mdx
+++ b/docs/cli/references/prompts/import.mdx
@@ -1,0 +1,47 @@
+# src prompts import
+
+Import prompts from a JSON file.
+
+## Usage
+
+```bash
+src prompts import [flags]
+```
+
+## Examples
+
+```bash
+# Import prompts from a file (uses current user as owner)
+src prompts import -i prompts.json
+
+# Import prompts with a specific owner
+src prompts import -i prompts.json -owner="VXNlcjox"
+
+# Perform a dry run without creating any prompts
+src prompts import -i prompts.json -dry-run
+
+# Skip existing prompts with the same name
+src prompts import -i prompts.json -skip-existing
+
+# Combine flags for validation and skipping
+src prompts import -i prompts.json -dry-run -skip-existing
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-i` | Input file path (required) |
+| `-owner` | The ID of the owner for all imported prompts (defaults to current user) |
+| `-dry-run` | Validate without importing |
+| `-skip-existing` | Skip prompts that already exist (based on name) |
+
+### API flags
+
+| Flag | Description |
+|------|-------------|
+| `-dump-requests` | Log GraphQL requests and responses to stdout |
+| `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) |
+| `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains |
+| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing |
+| `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/list.mdx
+++ b/docs/cli/references/prompts/list.mdx
@@ -1,0 +1,79 @@
+# src prompts list
+
+List all prompts in your Sourcegraph instance.
+
+## Usage
+
+```bash
+src prompts list [flags]
+```
+
+## Examples
+
+```bash
+# List all prompts
+src prompts list
+
+# Search prompts by name, description, or content
+src prompts list -query="error handling"
+
+# Filter prompts by tag IDs
+src prompts list -tags="UHJvbXB0VGFnOjE=,UHJvbXB0VGFnOjI="
+
+# List prompts for a specific owner
+src prompts list -owner="VXNlcjox"
+
+# List only recommended prompts
+src prompts list -recommended-only
+
+# List built-in prompts only
+src prompts list -builtin-only
+
+# Include built-in prompts with user prompts
+src prompts list -include-builtin
+
+# Exclude draft prompts
+src prompts list -include-drafts=false
+
+# List prompts owned by viewer or their organizations
+src prompts list -affiliated
+
+# Paginate through results
+src prompts list -limit=10 -after="cursor"
+
+# Select specific columns to display
+src prompts list -c id,name,description,visibility
+
+# Output results as JSON
+src prompts list -json
+
+# Complex filtering example
+src prompts list -query="Go" -recommended-only -include-drafts=false -json
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-query` | Search prompts by name, description, or content |
+| `-owner` | Filter by prompt owner (a namespace, either a user or organization) |
+| `-tags` | Comma-separated list of tag IDs to filter by |
+| `-affiliated` | Filter to only prompts owned by the viewer or viewer's organizations |
+| `-recommended-only` | Whether to include only recommended prompts |
+| `-builtin-only` | Whether to include only builtin prompts |
+| `-include-builtin` | Whether to include builtin prompts |
+| `-include-drafts` | Whether to include draft prompts (default: true) |
+| `-limit` | Maximum number of prompts to list (default: 100) |
+| `-after` | Cursor for pagination (from previous page's endCursor) |
+| `-c` | Comma-separated list of columns to display. Available: id,name,description,draft,visibility,mode,tags (default: "id,name,visibility,tags") |
+| `-json` | Output results as JSON for programmatic access |
+
+### API flags
+
+| Flag | Description |
+|------|-------------|
+| `-dump-requests` | Log GraphQL requests and responses to stdout |
+| `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) |
+| `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains |
+| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing |
+| `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/tags.mdx
+++ b/docs/cli/references/prompts/tags.mdx
@@ -1,0 +1,31 @@
+# src prompts tags
+
+`src prompts tags` is a tool that manages prompt tags in a Sourcegraph instance.
+
+## Usage
+
+```
+'src prompts tags' is a tool that manages prompt tags in a Sourcegraph instance.
+
+Usage:
+
+	src prompts tags command [command options]
+
+The commands are:
+
+	list		lists prompt tags
+	get		get a prompt tag by name
+	create		create a prompt tag
+	update		update a prompt tag
+	delete		delete a prompt tag
+
+Use "src prompts tags [command] -h" for more information about a command.
+```
+
+## Available Commands
+
+- [`src prompts tags list`](./tags/list) - lists prompt tags
+- [`src prompts tags get`](./tags/get) - get a prompt tag by name
+- [`src prompts tags create`](./tags/create) - create a prompt tag
+- [`src prompts tags update`](./tags/update) - update a prompt tag
+- [`src prompts tags delete`](./tags/delete) - delete a prompt tag

--- a/docs/cli/references/prompts/tags/create.mdx
+++ b/docs/cli/references/prompts/tags/create.mdx
@@ -1,0 +1,38 @@
+# src prompts tags create
+
+Create a new tag for prompts.
+
+## Usage
+
+```bash
+src prompts tags create <tag-name>
+```
+
+## Examples
+
+```bash
+# Create a new tag
+src prompts tags create go
+
+# Create a tag with hyphen
+src prompts tags create machine-learning
+
+# Create a tag for Python
+src prompts tags create python
+```
+
+## Flags
+
+### API flags
+
+| Flag | Description |
+|------|-------------|
+| `-dump-requests` | Log GraphQL requests and responses to stdout |
+| `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) |
+| `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains |
+| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing |
+| `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |
+
+## Notes
+
+If a tag with this name already exists, the command will return the existing tag's ID.

--- a/docs/cli/references/prompts/tags/delete.mdx
+++ b/docs/cli/references/prompts/tags/delete.mdx
@@ -1,0 +1,32 @@
+# src prompts tags delete
+
+Delete a tag from your Sourcegraph instance.
+
+## Usage
+
+```bash
+src prompts tags delete <tag-id>
+```
+
+## Examples
+
+```bash
+# Delete a tag by ID
+src prompts tags delete UHJvbXB0VGFnOjE=
+
+# The command will confirm successful deletion
+src prompts tags delete UHJvbXB0VGFnOjE=
+# Output: Prompt tag deleted successfully.
+```
+
+## Flags
+
+### API flags
+
+| Flag | Description |
+|------|-------------|
+| `-dump-requests` | Log GraphQL requests and responses to stdout |
+| `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) |
+| `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains |
+| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing |
+| `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/tags/get.mdx
+++ b/docs/cli/references/prompts/tags/get.mdx
@@ -1,0 +1,31 @@
+# src prompts tags get
+
+Get details about a specific tag by name.
+
+## Usage
+
+```bash
+src prompts tags get <tag-name>
+```
+
+## Examples
+
+```bash
+# Get tag by name
+src prompts tags get go
+
+# Get tag details for machine learning
+src prompts tags get machine-learning
+```
+
+## Flags
+
+### API flags
+
+| Flag | Description |
+|------|-------------|
+| `-dump-requests` | Log GraphQL requests and responses to stdout |
+| `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) |
+| `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains |
+| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing |
+| `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/tags/list.mdx
+++ b/docs/cli/references/prompts/tags/list.mdx
@@ -1,0 +1,51 @@
+# src prompts tags list
+
+List all tags in your Sourcegraph instance.
+
+## Usage
+
+```bash
+src prompts tags list [flags]
+```
+
+## Examples
+
+```bash
+# List all tags
+src prompts tags list
+
+# Search for tags by name
+src prompts tags list -query="go"
+
+# Paginate through results
+src prompts tags list -limit=10 -after="cursor"
+
+# Select specific columns to display
+src prompts tags list -c id,name
+
+# Output results as JSON
+src prompts tags list -json
+
+# Combine search and pagination
+src prompts tags list -query="python" -limit=5
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-query` | Search prompt tags by name |
+| `-limit` | Maximum number of tags to list (default: 100) |
+| `-after` | Cursor for pagination (from previous page's endCursor) |
+| `-c` | Comma-separated list of columns to display. Available: id,name (default: "id,name") |
+| `-json` | Output results as JSON for programmatic access |
+
+### API flags
+
+| Flag | Description |
+|------|-------------|
+| `-dump-requests` | Log GraphQL requests and responses to stdout |
+| `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) |
+| `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains |
+| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing |
+| `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/tags/update.mdx
+++ b/docs/cli/references/prompts/tags/update.mdx
@@ -1,0 +1,35 @@
+# src prompts tags update
+
+Update an existing tag in your Sourcegraph instance.
+
+## Usage
+
+```bash
+src prompts tags update [flags] <tag-id>
+```
+
+## Examples
+
+```bash
+# Update a tag's name
+src prompts tags update -name="updated-tag-name" UHJvbXB0VGFnOjE=
+
+# Update to a different name
+src prompts tags update -name="golang-updated" UHJvbXB0VGFnOjE=
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-name` | The new name for the tag |
+
+### API flags
+
+| Flag | Description |
+|------|-------------|
+| `-dump-requests` | Log GraphQL requests and responses to stdout |
+| `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) |
+| `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains |
+| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing |
+| `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/update.mdx
+++ b/docs/cli/references/prompts/update.mdx
@@ -1,0 +1,69 @@
+# src prompts update
+
+Update an existing prompt in your Sourcegraph instance.
+
+## Usage
+
+```bash
+src prompts update [flags] <prompt-id>
+```
+
+## Examples
+
+```bash
+# Update a prompt's basic information
+src prompts update \
+  -name="updated-prompt-name" \
+  -description="Updated description" \
+  -content="Updated prompt content" \
+  UHJvbXB0OjE=
+
+# Update a prompt with new tags
+src prompts update \
+  -name="prompt-with-new-tags" \
+  -description="Updated description" \
+  -content="Updated content" \
+  -tags="UHJvbXB0VGFnOjE=,UHJvbXB0VGFnOjI=" \
+  UHJvbXB0OjE=
+
+# Update prompt to draft status
+src prompts update \
+  -name="draft-prompt" \
+  -description="Now a draft" \
+  -content="Work in progress content" \
+  -draft \
+  UHJvbXB0OjE=
+
+# Update prompt settings
+src prompts update \
+  -name="auto-submit-prompt" \
+  -description="Auto-submit enabled" \
+  -content="This prompt auto-submits" \
+  -auto-submit \
+  -recommended \
+  -mode="EDIT" \
+  UHJvbXB0OjE=
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-name` | The updated prompt name |
+| `-description` | Updated description of the prompt |
+| `-content` | The updated prompt template text content |
+| `-tags` | Comma-separated list of tag IDs (replaces existing tags) |
+| `-draft` | Whether the prompt is a draft |
+| `-auto-submit` | Whether the prompt should be automatically executed in one click |
+| `-mode` | Mode to execute prompt: CHAT, EDIT, or INSERT (default: "CHAT") |
+| `-recommended` | Whether the prompt is recommended |
+
+### API flags
+
+| Flag | Description |
+|------|-------------|
+| `-dump-requests` | Log GraphQL requests and responses to stdout |
+| `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) |
+| `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains |
+| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing |
+| `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |


### PR DESCRIPTION
Add documentation for the `src prompts` command and its subcommands.

Added documentation for the new src prompts commands

https://github.com/sourcegraph/src-cli/pull/1168

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
