### PR TITLE
AWS Bedrock Claude 3.7 and 4 Sonnet 'thinking' support

### DIFF
--- a/docs/cody/capabilities/supported-models.mdx
+++ b/docs/cody/capabilities/supported-models.mdx
@@ -41,6 +41,10 @@ In addition, Sourcegraph Enterprise customers using GCP Vertex (Google Cloud Pla
 
 <Callout type="info">Claude 3.7 Sonnet with thinking is not supported for BYOK deployments.</Callout>
 
+#### Claude 3.7 Sonnet and Claude 4 Sonnet for AWS Bedrock
+
+Cody's BYOK AWS Bedrock support can use Claude 3.7 Sonnet's **thinking mode**. Once enabled, Cody routes your prompts through Claude 3.7 Sonnet, using its expanded context window and advanced reasoning abilities to return noticeably smarter, more context-aware responses.
+
 ## Autocomplete
 
 Cody uses a set of models for autocomplete which are suited for the low latency use case.

--- a/docs/cody/enterprise/model-configuration.mdx
+++ b/docs/cody/enterprise/model-configuration.mdx
@@ -228,6 +228,9 @@ This field is an array of items, each with the following fields:
 -   `reasoningEffort`: Specifies the effort on reasoning for reasoning models (having `reasoning` capability). Supported values: `high`, `medium`, `low`. How this value is treated depends on the specific provider.
 For example, for Anthropic models supporting thinking, `low` effort means that the minimum [`thinking.budget_tokens`](https://docs.anthropic.com/en/api/messages#body-thinking) value (1024) will be used. For other `reasoningEffort` values, the `contextWindow.maxOutputTokens / 2` value will be used.
 For OpenAI reasoning models, the `reasoningEffort` field value corresponds to the [`reasoning_effort`](https://platform.openai.com/docs/api-reference/chat/create#chat-create-reasoning_effort) request body value.
+
+<Callout type="note">If you are a Claude 3.0 user, you'll need to enable both the `reasoning` and `reasoningEffort` fields in order to get **thinking** support.</Callout>
+
 -   `serverSideConfig`: Additional configuration for the model. It can be one of the following:
 
     -   `awsBedrockProvisionedThroughput`: Specifies provisioned throughput settings for AWS Bedrock models with the following fields:


### PR DESCRIPTION
Cody updates

- [AWS Bedrock Claude 3.7 and 4 Sonnet 'thinking' support](https://linear.app/sourcegraph/issue/CORE-1021/enablement-ga-self-hosted-models-aws-bedrock-claude-37-and-4-sonnet)