### PR TITLE
Remove References To Legacy Kustomize In Procedural Docs

### DIFF
--- a/docs/admin/deploy/kubernetes/operations.mdx
+++ b/docs/admin/deploy/kubernetes/operations.mdx
@@ -288,9 +288,9 @@ The following instructions apply only if you are restoring your databases into a
 
 If you are restoring a previously running environment, see the instructions for [restoring a previously running deployment](#restoring-sourcegraph-databases-into-an-existing-environment)
 
-A. Copy the database dump files (eg. `sourcegraph_db.out`, `codeintel_db.out` and `codeinsights_db.out`) into the root of the `deploy-sourcegraph` directory
+A. Copy the database dump files (eg. `sourcegraph_db.out`, `codeintel_db.out` and `codeinsights_db.out`) into your deployment directory
 
-B. Start the database services by running the following command from the root of the [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) directory
+B. Start the database services by running the following command from your deployment directory:
 
 ```bash
 $ kubectl rollout restart deployment pgsql
@@ -298,7 +298,7 @@ $ kubectl rollout restart deployment codeintel-db
 $ kubectl rollout restart deployment codeinsights-db
 ```
 
-C. Copy the database files into the pods by running the following command from the root of the [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) directory
+C. Copy the database files into the pods by running the following commands:
 
 ```bash
 $ kubectl cp sourcegraph_db.out $NAMESPACE/$pgsql_POD_NAME:/tmp/sourcegraph_db.out
@@ -355,7 +355,7 @@ $ kubectl delete pv $codeintel-db_PV_NAME --force
 $ kubectl delete pv $codeinsights-db_PV_NAME --force
 ```
 
-C. Copy the database dump files (eg. `sourcegraph_db.out`, `codeintel_db.out` and `codeinsights_db.out`) into the root of the `deploy-sourcegraph` directory
+C. Copy the database dump files (eg. `sourcegraph_db.out`, `codeintel_db.out` and `codeinsights_db.out`) into your deployment directory
 
 D. Start the database services only
 
@@ -365,7 +365,7 @@ $ kubectl rollout restart deployment codeintel-db
 $ kubectl rollout restart deployment codeinsights-db
 ```
 
-E. Copy the database files into the pods by running the following command from the root of the [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) directory
+E. Copy the database files into the pods by running the following commands:
 
 ```bash
 $ kubectl cp sourcegraph_db.out $NAMESPACE/$pgsql_POD_NAME:/tmp/sourcegraph_db.out

--- a/docs/admin/deploy/kubernetes/troubleshoot.mdx
+++ b/docs/admin/deploy/kubernetes/troubleshoot.mdx
@@ -40,7 +40,7 @@ Run `kubectl get ingresses -A` to check if there is more than one ingress for `s
 
 #### Error: error when creating "base/cadvisor/cadvisor.ClusterRoleBinding.yaml": subjects[0].namespace: Required value
 
-Add `namespace: default` to the [base/cadvisor/cadvisor.ClusterRoleBinding.yaml](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/base/cadvisor/cadvisor.ClusterRoleBinding.yaml) file under `subjects`.
+This error occurs when using legacy deployment manifests. For modern deployments using deploy-sourcegraph-k8s, cadvisor is configured as a DaemonSet with a ServiceAccount and doesn't require a ClusterRoleBinding. If you encounter this error, ensure you're using the latest [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) repository.
 
 
 #### Multiple pods are stuck in Pending.

--- a/docs/admin/deploy/kubernetes/upgrade.mdx
+++ b/docs/admin/deploy/kubernetes/upgrade.mdx
@@ -76,47 +76,7 @@ Apply the new manifests from the ouput file `cluster.yaml` to your cluster:
 
 ---
 
-### Upgrade with Legacy Kubernetes
 
-The following procedure is for performing a **standard upgrade** with Sourcegraph instances in versions **prior to `v4.5.0`**, or which **have not** [**migrated**](/admin/deploy/kubernetes/kustomize/migrate) and still use [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph).
-
-**Step 1**: Merge the new version of Sourcegraph into your release branch.
-
-  ```sh
-  cd $DEPLOY_SOURCEGRAPH_FORK
-  # get updates
-  git fetch upstream
-  # to merge the upstream release tag into your release branch.
-  git checkout release
-  # Choose which version you want to deploy from https://github.com/sourcegraph/deploy-sourcegraph/tags
-  git merge $NEW_VERSION
-  ```
-
----
-
-**Step 2**: Update your install script `kubectl-apply-all.sh`
-
-By default, the install script `kubectl-apply-all.sh` applies our base manifests using [`kubectl apply` command](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#apply) with a variety of arguments specific to the layout of the [deploy-sourcegraph reference repository](https://github.com/sourcegraph/deploy-sourcegraph).
-
-If you have specific commands that should be run whenever you apply your manifests, you should modify this script accordingly.
-
-For example, if you use [overlays to make changes to the manifests](https://github.com/sourcegraph/deploy-sourcegraph/tree/master/overlays), you should modify this script to apply the manifests from the `generated cluster` directory instead.
-
----
-
-**Step 3**: Apply the updates to your cluster.
-
-  ```sh
-  $ ./kubectl-apply-all.sh
-  ```
-
-**Step 4**: Monitor the status of the deployment to determine its success.
-
-  ```sh
-  $ kubectl get pods -o wide --watch
-  ```
-
----
 
 ## Multi-version upgrades
 
@@ -129,7 +89,7 @@ To perform a multi-version upgrade via migrators [upgrade](/admin/updates/migrat
    - Check the `Site Admin > Updates` page to determine [upgrade readiness](/admin/updates/#upgrade-readiness).
 
 2. **Pull and merge upstream changes**:
-     - Follow the [standard legacy upgrade procedure](#upgrade-with-legacy-kubernetes) to pull and merge upstream changes from the version you are upgrading to to your `release` branch.
+     - Follow the [standard upgrade procedure](#upgrade-with-kubernetes-kustomize) to pull and merge upstream changes from the version you are upgrading to to your `release` branch.
 
 3. **Update cluster.yaml and scale down non-database deployments and replicas**:
    - In your cluster kustomization file (`instances/my-sourcegraph/kustomize.yaml`), uncomment the [multi-version-upgrade util](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/instances/template/kustomization.template.yaml#L155). This will scale down all non-database deployments and statefulSets replicas to 0.
@@ -236,10 +196,6 @@ If you are rolling back more than a single version, then you must also [rollback
 
 ### Rollback with Kustomize
 
-**For Sourcegraph version 4.5.0 and above, which have [migrated](/admin/deploy/kubernetes/kustomize/migrate) to [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s).**
-
-For instances deployed using the [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) repository:
-
   ```sh
   # Re-generate manifests
   kubectl kustomize instances/$YOUR_INSTANCE -o cluster-rollback.yaml
@@ -247,16 +203,6 @@ For instances deployed using the [deploy-sourcegraph-k8s](https://github.com/sou
   less cluster-rollback.yaml
   # Re-deploy
   kubectl apply --prune -l deploy=sourcegraph -f cluster-rollback.yaml
-  ```
-
-### Rollback without Kustomize
-
-**For Sourcegraph version prior to 4.5.0 using our legacy [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) manifests.**
-
-For instances deployed using the old [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) repository:
-
-  ```sh
-  $ ./kubectl-apply-all.sh
   ```
 
 ### Rollback with `migrator downgrade`

--- a/docs/admin/faq.mdx
+++ b/docs/admin/faq.mdx
@@ -42,11 +42,9 @@ Docker image, you can deploy a reverse proxy such as [Caddy](https://caddyserver
 
 If you are running Sourcegraph as a Kubernetes cluster, you have two additional options:
 
-1. If you are using [NGINX
-   ingress](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/configure#ingress-controller)
-   (`kubectl get ingress | grep sourcegraph-frontend`), modify
-   [`sourcegraph-frontend.Ingress.yaml`](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/base/frontend/sourcegraph-frontend.Ingress.yaml)
-   by [adding a rewrite rule](https://kubernetes.github.io/ingress-nginx/examples/rewrite/).
+1. If you are using NGINX ingress (`kubectl get ingress | grep sourcegraph-frontend`), modify
+   [`sourcegraph-frontend.Ingress.yaml`](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/base/sourcegraph/frontend/sourcegraph-frontend.Ingress.yaml)
+   by [adding a rewrite rule](https://kubernetes.github.io/ingress-nginx/examples/rewrite/). You can also refer to the [ingress configuration examples](https://github.com/sourcegraph/deploy-sourcegraph-k8s/tree/main/examples/ingress-controller).
 
 ## What external HTTP checks are configured?
 

--- a/docs/admin/how-to/precise-code-intel-worker-crashloopbackoff.mdx
+++ b/docs/admin/how-to/precise-code-intel-worker-crashloopbackoff.mdx
@@ -22,11 +22,9 @@ precise-code-intel-worker-9b69b5b59-z7xx4   0/1     CrashLoopBackOff   415      
 
 	`kubectl get pods -o wide`
 
-3. If MinIO is not deployed, create a fork of the [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) repository and make sure you deploy MinIO (or blobstore in 3.4.2+).
-
-
+3. If blobstore is not deployed, make sure you include the blobstore components in your Sourcegraph deployment. For modern Sourcegraph versions (3.4.2+), blobstore replaces MinIO.
 
 ## Further resources
 
 * [Sourcegraph - Kubernetes Configuration](/admin/deploy/kubernetes/configure)
-* [Deploy Sourcegraph - blobstore](https://github.com/sourcegraph/deploy-sourcegraph/tree/master/base/blobstore)
+* [Deploy Sourcegraph K8s - blobstore](https://github.com/sourcegraph/deploy-sourcegraph-k8s/tree/main/base/sourcegraph/blobstore)

--- a/docs/admin/how-to/setup-https.mdx
+++ b/docs/admin/how-to/setup-https.mdx
@@ -1,106 +1,226 @@
-# How to setup HTTPS connection with Ingress controller on your Kubernetes instance
+# How to setup HTTPS/TLS for your Kubernetes Sourcegraph instance
 
-This document will take you through how to setup HTTPS connection using the preinstalled [Ingress controller](/admin/deploy/kubernetes/configure#ingress-controller), which allows external users to access your main web server over the network. It installs rules for the default ingress, see comments to restrict it to a specific host. This is our recommended method to configure network access for production environments.
+This document explains how to configure HTTPS/TLS for your Sourcegraph instance deployed with [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) using Kustomize.
 
 ## Prerequisites
 
-- This document assumes that your Sourcegraph instance is deployed into a Kubernetes cluster and that ingress has already been installed for [sourcegraph-frontend](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/base/frontend/sourcegraph-frontend.Ingress.yaml) (by default).
+- Sourcegraph deployed using [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s)
+- An ingress controller installed in your cluster
+- A domain name pointing to your ingress controller's external IP
 
-## Steps for GCE-GKE user
+## Option 1: TLS with existing certificates
 
-> WARNING: Please visit our [Kubernetes Configuration Docs](/admin/deploy/kubernetes/configure#ingress-controller) for more detail on Network-related topics
->
+If you already have TLS certificates, you can use the built-in TLS component.
 
-### 1. Install the NGINX ingress controller (ingress-nginx)
-Install the NGINX ingress controller by following the instructions at [https://kubernetes.github.io/ingress-nginx/deploy/](https://kubernetes.github.io/ingress-nginx/deploy/)
+### Step 1: Create a TLS secret
 
-For example, GCE-GKE user would simply run [this command](https://kubernetes.github.io/ingress-nginx/deploy/#gce-gke) `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.47.0/deploy/static/provider/cloud/deploy.yaml` to install the NGINX ingress controller
-
-### 2. Update the create-new-cluster.sh file
-Add the [configure/ingress-nginx/install.sh](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/configure/ingress-nginx/install.sh) command to the [create-new-cluster.sh](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/create-new-cluster.sh) file at root, and commit the change.
-Your file should look similar to this:
-```sh
-echo ./configure/ingress-nginx/install.sh >> create-new-cluster.sh
-./kubectl-apply-all.sh $@
-```
-
-### 3. Once the ingress has acquired an external address
-You should be able to access Sourcegraph using the external address returns from the following `kubectl -n ingress-nginx get svc`.
+Create a Kubernetes secret containing your TLS certificate and private key:
 
 ```bash
-$kubectl -n ingress-nginx get svc
-NAME                                 TYPE           CLUSTER-IP    EXTERNAL-IP     PORT(S)                      AGE
-ingress-nginx-controller             LoadBalancer   10.XX.8.XXX   XX.XXX.XXX.XX   80:32695/TCP,443:31722/TCP   5d13h
-ingress-nginx-controller-admission   ClusterIP      10.XX.8.X     <none>          443/TCP                      5d13h
+kubectl create secret tls sourcegraph-frontend-tls \
+  --cert=path/to/your/certificate.crt \
+  --key=path/to/your/private.key \
+  --namespace=YOUR_NAMESPACE
 ```
 
-## Configure TLS/SSL
+### Step 2: Configure your Kustomization
 
-After your Sourcegraph instance is exposed via an ingress controller, you should consider using TLS so that all traffic will be served over HTTPS.
-
-### 1. Create TLS certificate and private key
-
-Place the newly created certificate and private key in a secured place. We will be using `.envrc/private.key` and `.envrc/public.pem` in this example.
-
-### 2. Create a TLS secret for your Cluster
-
-Create a TLS secret that contains your TLS certificate and private key by running the following command:
-
-```bash
-kubectl create secret tls sourcegraph-tls --key .envrc/private.key --cert .envrc/public.pem
-```
-
-> NOTE: You can delete it by running `kubectl delete secret sourcegraph-tls`
-
-### 3. Update the create-new-cluster.sh file
-
-Add the previous command to the [create-new-cluster.sh](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/create-new-cluster.sh) file at root, and commit the change. Your file should look similar to this:
-
-```bash
-echo ./configure/ingress-nginx/install.sh >> create-new-cluster.sh
-echo kubectl create secret tls sourcegraph-tls --key .envrc/private.key --cert .envrc/public.pem  >> create-new-cluster.sh
-./kubectl-apply-all.sh $@
-```
-
-### 4. Update the ingress sourcegraph-frontend.Ingress.yaml file
-
-Add the tls configuration to [base/frontend/sourcegraph-frontend.Ingress.yaml](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/base/frontend/sourcegraph-frontend.Ingress.yaml) file by commenting out the `tls` section, and replace `sourcegraph.example.com` with your domain.
-
-> NOTE: It must be a DNS name, not an IP address
+In your `instances/YOUR_INSTANCE/kustomization.yaml` file, uncomment the TLS component:
 
 ```yaml
-   # base/frontend/sourcegraph-frontend.Ingress.yaml
-   tls:
-     - hosts:
-         #  Replace 'sourcegraph.example.com' with the real domain that you want to use for your Sourcegraph instance.
-         - sourcegraph.example.com
-       secretName: sourcegraph-tls
-   rules:
-     - http:
-         paths:
-         - path: /
-           backend:
-             serviceName: sourcegraph-frontend
-             servicePort: 30080
-       # Replace 'sourcegraph.example.com' with the real domain that you want to use for your Sourcegraph instance.
-       host: sourcegraph.example.com
-
+components:
+  # Enable TLS with existing certificates
+  - ../../components/network/tls
 ```
 
-### 5. Update Site Configuration
+### Step 3: Set environment variables
 
-Update your externalURL in the [site configuration](/admin/config/site_config) to e.g. https://sourcegraph.example.com:
+Add the required configuration to your `instances/YOUR_INSTANCE/.env` file:
+
+```bash
+TLS_HOST=sourcegraph.example.com
+TLS_INGRESS_CLASS_NAME=nginx
+TLS_CLUSTER_ISSUER=your-cluster-issuer  # if using cert-manager
+```
+
+### Step 4: Apply the configuration
+
+```bash
+# Generate updated manifests
+kubectl kustomize instances/YOUR_INSTANCE -o cluster.yaml
+
+# Apply the changes
+kubectl apply --prune -l deploy=sourcegraph -f cluster.yaml
+```
+
+## Option 2: Cloud provider managed certificates
+
+### AWS with Application Load Balancer (ALB)
+
+For AWS deployments, you can use AWS Certificate Manager (ACM) certificates:
+
+```yaml
+components:
+  # Use AWS managed certificates
+  - ../../components/clusters/aws/managed-cert
+  - ../../components/ingress/alb
+```
+
+Set the required environment variables:
+
+```bash
+AWS_CERTIFICATE_ARN=arn:aws:acm:region:account:certificate/certificate-id
+HOST_DOMAIN=sourcegraph.example.com
+```
+
+### Google Kubernetes Engine (GKE)
+
+For GKE deployments, you can use Google-managed SSL certificates:
+
+```yaml
+components:
+  # Use GKE managed certificates
+  - ../../components/clusters/gke/managed-cert
+  - ../../components/ingress/gke
+```
+
+Set the required environment variables:
+
+```bash
+HOST_DOMAIN=sourcegraph.example.com
+```
+
+## Option 3: cert-manager integration
+
+If you have [cert-manager](https://cert-manager.io/) installed in your cluster, you can automatically provision certificates:
+
+### Step 1: Install cert-manager (if not already installed)
+
+```bash
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.0/cert-manager.yaml
+```
+
+### Step 2: Create a ClusterIssuer
+
+Create a ClusterIssuer for Let's Encrypt:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: your-email@example.com
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
+```
+
+### Step 3: Configure Sourcegraph with cert-manager
+
+In your `instances/YOUR_INSTANCE/kustomization.yaml`:
+
+```yaml
+components:
+  - ../../components/network/tls
+```
+
+Set the environment variables:
+
+```bash
+TLS_HOST=sourcegraph.example.com
+TLS_INGRESS_CLASS_NAME=nginx
+TLS_CLUSTER_ISSUER=letsencrypt-prod
+```
+
+## Step 4: Update Site Configuration
+
+After configuring TLS, update your Sourcegraph site configuration to use HTTPS:
+
+1. Navigate to **Site admin > Configuration**
+2. Update the `externalURL` setting:
 
 ```json
 {
-"externalURL": "https://sourcegraph.example.com"
+  "externalURL": "https://sourcegraph.example.com"
 }
 ```
 
-### 6. Update the ingress controller
+## Verification
 
-Update the ingress controller with the previous changes with the following command:
+### Check ingress configuration
 
 ```bash
-kubectl apply -f base/frontend/sourcegraph-frontend.Ingress.yaml
+kubectl get ingress sourcegraph-frontend -o yaml
 ```
+
+You should see TLS configuration in the output:
+
+```yaml
+spec:
+  tls:
+  - hosts:
+    - sourcegraph.example.com
+    secretName: sourcegraph-frontend-tls
+```
+
+### Test the HTTPS connection
+
+```bash
+curl -I https://sourcegraph.example.com
+```
+
+You should receive a response with `HTTP/2 200` or `HTTP/1.1 200` status.
+
+### Check certificate details
+
+```bash
+echo | openssl s_client -servername sourcegraph.example.com -connect sourcegraph.example.com:443 2>/dev/null | openssl x509 -noout -dates
+```
+
+## Troubleshooting
+
+### Certificate not loading
+
+1. Verify the TLS secret exists and contains valid certificate data:
+   ```bash
+   kubectl get secret sourcegraph-frontend-tls -o yaml
+   ```
+
+2. Check ingress controller logs:
+   ```bash
+   kubectl logs -n ingress-nginx deployment/ingress-nginx-controller
+   ```
+
+### cert-manager certificate issues
+
+1. Check certificate status:
+   ```bash
+   kubectl get certificate
+   kubectl describe certificate sourcegraph-frontend-tls
+   ```
+
+2. Check cert-manager logs:
+   ```bash
+   kubectl logs -n cert-manager deployment/cert-manager
+   ```
+
+### DNS issues
+
+Ensure your domain name points to your ingress controller's external IP:
+
+```bash
+kubectl get service -n ingress-nginx ingress-nginx-controller
+nslookup sourcegraph.example.com
+```
+
+## Additional Resources
+
+- [Kubernetes Ingress TLS documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls)
+- [cert-manager documentation](https://cert-manager.io/docs/)
+- [deploy-sourcegraph-k8s TLS component](https://github.com/sourcegraph/deploy-sourcegraph-k8s/tree/main/components/network/tls)

--- a/docs/admin/observability/troubleshooting.mdx
+++ b/docs/admin/observability/troubleshooting.mdx
@@ -164,7 +164,7 @@ If Sourcegraph feels sluggish overall, the likely culprit is resource allocation
 
 If you are seeing cAdvisor metrics from a namespace outside of the one Sourcegraph is currently deployed into.
 
-1. Uncomment our namespaced Prometheus [cAdvisor configuration](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/deploy-sourcegraph%24+cAdvisor-specific+customization+&patternType=literal)
+1. Update your cAdvisor configuration to use namespaced monitoring. See the [cAdvisor monitoring example](https://github.com/sourcegraph/deploy-sourcegraph-k8s/tree/main/examples/monitoring/cadvisor) and [cAdvisor README](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/base/monitoring/cadvisor/README.md) for namespace configuration
 2. Apply this configuration and restart Prometheus
 
 _Note:_ This is unneeded if you are using the 'namespaced' overlay

--- a/docs/admin/troubleshooting.mdx
+++ b/docs/admin/troubleshooting.mdx
@@ -92,35 +92,6 @@ scp -r username@hostname:/tmp/sourcegraph-metrics-dump.tgz .
 
 Please then upload the `sourcegraph-metrics-dump.tgz` for Sourcegraph support to access it. If desired, we can send you a shared private Google Drive folder for the upload as it can sometimes be a few gigabytes.
 
-### Kubernetes deployments
-
-If you're using the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph),
-you can create a metrics dump as follows:
-
-* Open a shell to the running container
-    1. Run `kubectl get pods` to get the name of the Prometheus pod.
-    1. Run `kubectl exec -it <pod-name> -- /bin/bash`.
-
-* Inside the container bash shell trigger the creation of a Prometheus snapshot:
-
-```sh
-wget --post-data "" http://localhost:9090/api/v1/admin/tsdb/snapshot
-```
-
-* Tar up the created snapshot
-
-```sh
-cd /prometheus/snapshots && tar -czvf /tmp/sourcegraph-metrics-dump.tgz <snapshot-name>
-```
-
-* Switch back to local shell and copy the metrics dump file over:
-
-```sh
-kubectl cp <podname>:/tmp/sourcegraph-metrics-dump.tgz /tmp/sourcegraph-metrics-dump.tgz
-```
-
-Again please then upload the `sourcegraph-metrics-dump.tgz` for Sourcegraph support to access it.
-
 ### Generating pprof profiles
 
 Please follow [these instructions](/admin/pprof) to generate pprof profiles.

--- a/docs/admin/updates/grpc/index.mdx
+++ b/docs/admin/updates/grpc/index.mdx
@@ -47,13 +47,11 @@ However, if you’ve applied security measures or have firewall restrictions on 
 - **Protocol Description**: gRPC runs on-top of [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2) (which, in turn, runs on top of [TCP](https://en.wikipedia.org/wiki/Transmission_Control_Protocol). It transfers (binary-encoded, not human-readable plain-text) [Protocol Buffer](https://protobuf.dev/) payloads. Our current gRPC implementation does not use any encryption.
 
 - **List of services**: The following services will now _speak mainly gRPC in addition_ to their previous traffic:
-  - [frontend](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/base/frontend/sourcegraph-frontend.Service.yaml)
-  - [gitserver](https://github.com/sourcegraph/deploy-sourcegraph-cloud/blob/release/base/gitserver/gitserver.Service.yaml)
-  - [searcher](https://github.com/sourcegraph/deploy-sourcegraph-cloud/blob/release/base/searcher/searcher.Service.yaml)
-  - [zoekt-webserver](https://github.com/sourcegraph/deploy-sourcegraph-cloud/blob/release/base/indexed-search/indexed-search.StatefulSet.yaml)
-  - [zoekt-indexserver](https://github.com/sourcegraph/deploy-sourcegraph-cloud/blob/release/base/indexed-search/indexed-search.StatefulSet.yaml)
-  - [symbols](https://github.com/sourcegraph/deploy-sourcegraph-cloud/blob/release/base/symbols/symbols.Deployment.yaml)
-  - [repo-updater](https://github.com/sourcegraph/deploy-sourcegraph-cloud/blob/release/base/repo-updater/repo-updater.Deployment.yaml)
+  - [frontend](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/base/sourcegraph/frontend/sourcegraph-frontend.Service.yaml)
+  - [gitserver](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/base/sourcegraph/gitserver/gitserver.Service.yaml)
+  - [searcher](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/base/sourcegraph/searcher/searcher.StatefulSet.yaml)
+  - [zoekt-webserver](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/base/sourcegraph/indexed-search/indexed-search.StatefulSet.yaml)
+  - [zoekt-indexserver](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/base/sourcegraph/indexed-search/indexed-search.StatefulSet.yaml)
 
 - The following aspects about Sourcegraph’s networking configuration **aren’t changing**:
   - **Ports**: all Sourcegraph services will use the same ports as they were in the **5.1.X** release.
@@ -89,7 +87,7 @@ Set the environment variable `SG_FEATURE_FLAG_GRPC="false"` for every service.
 
 #### `zoekt-indexserver` service: disable via environment variable
 
-Set the environment variable `GRPC_ENABLED="false"` on the `zoekt-indexserver` container. (See [https://github.com/sourcegraph/deploy-sourcegraph-cloud/blob/18e5f9e450878705b7a99ee7c3bcf74c3fb68514/base/indexed-search/indexed-search.StatefulSet.yaml#L105-L106](https://github.com/sourcegraph/deploy-sourcegraph-cloud/blob/18e5f9e450878705b7a99ee7c3bcf74c3fb68514/base/indexed-search/indexed-search.StatefulSet.yaml#L105-L106) for an example:
+Set the environment variable `GRPC_ENABLED="false"` on the `zoekt-indexserver` container. (See [indexed-search.StatefulSet.yaml](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/base/sourcegraph/indexed-search/indexed-search.StatefulSet.yaml) for the configuration):
 
 ```yaml
 - name: zoekt-indexserver

--- a/docs/admin/updates/migrator/downgrading.mdx
+++ b/docs/admin/updates/migrator/downgrading.mdx
@@ -61,8 +61,6 @@ You can rollback by resetting your `release` branch to the old state before rede
 
 ### Rollback with Kustomize
 
-**For Sourcegraph versions `v4.5.0` and above, which have [migrated](/admin/deploy/kubernetes/kustomize/migrate) to [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s):**
-
   ```bash
   # Re-generate manifests
   $ kubectl kustomize instances/$YOUR_INSTANCE -o cluster-rollback.yaml
@@ -70,12 +68,4 @@ You can rollback by resetting your `release` branch to the old state before rede
   $ less cluster-rollback.yaml
   # Re-deploy
   $ kubectl apply --prune -l deploy=sourcegraph -f cluster-rollback.yaml
-  ```
-
-### Rollback without Kustomize
-
-**For Sourcegraph versions prior to `v4.5.0`, or which have not migrated away from [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph):**
-
-  ```bash
-  $ /admin/updates/migrator/kubectl-apply-all.sh
   ```

--- a/docs/admin/updates/migrator/migrator-operations.mdx
+++ b/docs/admin/updates/migrator/migrator-operations.mdx
@@ -34,10 +34,9 @@ Some notes on `migrator`:
 
 Migrator uses environemt variables to target the correct database instances. By default these values are configured to target Sourcegraphs locally deployed databases. These values may be adjusted to connect migrator to externally managed databases.
 
-Manifest loactions:
+Manifest locations:
 - [Docker-compose](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml#L20C4-L43)
 - [Kustomize](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/components/utils/migrator/resources/sourcegraph-frontend.ConfigMap.yaml#L10-L28)
-- [Legacy](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/configure/migrator/migrator.Job.yaml#L23C13-L59)
 - [Helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph-migrator/values.yaml#L39-L79)
 
 Example default environment variables:
@@ -282,10 +281,9 @@ Generally in production environments `migrator` is run by updating the startup *
 
 ### Kubernetes Kustomize
 
-In kubernetes `migrator` is initialized as a [kubernetes job](https://kubernetes.io/docs/concepts/workloads/controllers/job/). The `job` is initialized with arguments passed to the `args:` key. Below are links to the job manifests in our kustomize and legacy deployments:
-- [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/components/utils/migrator/resources/migrator.Job.yaml)
-  - [*configMap*](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/components/utils/migrator/resources/sourcegraph-frontend.ConfigMap.yaml)
-- [legacy](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/configure/migrator/migrator.Job.yaml#LL21C1-L23C1)
+In kubernetes `migrator` is initialized as a [kubernetes job](https://kubernetes.io/docs/concepts/workloads/controllers/job/). The `job` is initialized with arguments passed to the `args:` key. Below are links to the job manifests:
+- [migrator.Job.yaml](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/components/utils/migrator/resources/migrator.Job.yaml)
+- [configMap](https://github.com/sourcegraph/deploy-sourcegraph-k8s/blob/main/components/utils/migrator/resources/sourcegraph-frontend.ConfigMap.yaml)
 
 To run `migrator` with a specific *command*:
 


### PR DESCRIPTION
This PR removes references to the outdated and archived `deploy-sourcegraph` repo kustomize procedures: https://github.com/sourcegraph/deploy-sourcegraph

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
