### PR TITLE
Add schema sync markers for automated release updates

### DIFF
--- a/docs/admin/code_hosts/aws_codecommit.mdx
+++ b/docs/admin/code_hosts/aws_codecommit.mdx
@@ -32,6 +32,9 @@ AWS CodeCommit connections support the following configuration options, which ar
 
 ### admin/code_hosts/aws_codecommit.schema.json
 
+<!-- SCHEMA_SYNC_START: admin/code_hosts/aws_codecommit.schema.json -->
+<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
+<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
 ```json
 {
 	// The AWS access key ID to use when listing and updating repositories from AWS CodeCommit. Must have the AWSCodeCommitReadOnly IAM policy.
@@ -109,6 +112,7 @@ To add CodeCommit repositories in Docker Container:
   }
 }
 ```
+<!-- SCHEMA_SYNC_END: admin/code_hosts/aws_codecommit.schema.json -->
 
 ### Mounting SSH keys into the container
 

--- a/docs/admin/code_hosts/aws_codecommit.mdx
+++ b/docs/admin/code_hosts/aws_codecommit.mdx
@@ -32,9 +32,9 @@ AWS CodeCommit connections support the following configuration options, which ar
 
 ### admin/code_hosts/aws_codecommit.schema.json
 
-<!-- SCHEMA_SYNC_START: admin/code_hosts/aws_codecommit.schema.json -->
-<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
-<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
+{/* SCHEMA_SYNC_START: admin/code_hosts/aws_codecommit.schema.json */}
+{/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
+{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
 ```json
 {
 	// The AWS access key ID to use when listing and updating repositories from AWS CodeCommit. Must have the AWSCodeCommitReadOnly IAM policy.
@@ -112,7 +112,7 @@ To add CodeCommit repositories in Docker Container:
   }
 }
 ```
-<!-- SCHEMA_SYNC_END: admin/code_hosts/aws_codecommit.schema.json -->
+{/* SCHEMA_SYNC_END: admin/code_hosts/aws_codecommit.schema.json */}
 
 ### Mounting SSH keys into the container
 

--- a/docs/admin/code_hosts/azuredevops.mdx
+++ b/docs/admin/code_hosts/azuredevops.mdx
@@ -65,6 +65,9 @@ Azure DevOps connections support the following configuration options, which are 
 
 ### admin/code_hosts/azuredevops.schema.json
 
+<!-- SCHEMA_SYNC_START: admin/code_hosts/azuredevops.schema.json -->
+<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
+<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
 ```json
 {
 	// A flag to enforce Azure DevOps repository access permissions
@@ -124,6 +127,7 @@ Azure DevOps connections support the following configuration options, which are 
 	"username": null
 }
 ```
+<!-- SCHEMA_SYNC_END: admin/code_hosts/azuredevops.schema.json -->
 
 ## Webhooks
 

--- a/docs/admin/code_hosts/azuredevops.mdx
+++ b/docs/admin/code_hosts/azuredevops.mdx
@@ -65,9 +65,9 @@ Azure DevOps connections support the following configuration options, which are 
 
 ### admin/code_hosts/azuredevops.schema.json
 
-<!-- SCHEMA_SYNC_START: admin/code_hosts/azuredevops.schema.json -->
-<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
-<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
+{/* SCHEMA_SYNC_START: admin/code_hosts/azuredevops.schema.json */}
+{/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
+{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
 ```json
 {
 	// A flag to enforce Azure DevOps repository access permissions
@@ -127,7 +127,7 @@ Azure DevOps connections support the following configuration options, which are 
 	"username": null
 }
 ```
-<!-- SCHEMA_SYNC_END: admin/code_hosts/azuredevops.schema.json -->
+{/* SCHEMA_SYNC_END: admin/code_hosts/azuredevops.schema.json */}
 
 ## Webhooks
 

--- a/docs/admin/code_hosts/bitbucket_cloud.mdx
+++ b/docs/admin/code_hosts/bitbucket_cloud.mdx
@@ -116,6 +116,9 @@ Bitbucket Cloud connections support the following configuration options, which a
 
 ### admin/code_hosts/bitbucket_cloud.schema.json
 
+<!-- SCHEMA_SYNC_START: admin/code_hosts/bitbucket_cloud.schema.json -->
+<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
+<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
 ```json
 {
 	// The workspace access token to use when authenticating with Bitbucket Cloud.
@@ -203,6 +206,7 @@ Bitbucket Cloud connections support the following configuration options, which a
 	"webhookSecret": null
 }
 ```
+<!-- SCHEMA_SYNC_END: admin/code_hosts/bitbucket_cloud.schema.json -->
 
 ## Webhooks
 

--- a/docs/admin/code_hosts/bitbucket_cloud.mdx
+++ b/docs/admin/code_hosts/bitbucket_cloud.mdx
@@ -116,9 +116,9 @@ Bitbucket Cloud connections support the following configuration options, which a
 
 ### admin/code_hosts/bitbucket_cloud.schema.json
 
-<!-- SCHEMA_SYNC_START: admin/code_hosts/bitbucket_cloud.schema.json -->
-<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
-<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
+{/* SCHEMA_SYNC_START: admin/code_hosts/bitbucket_cloud.schema.json */}
+{/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
+{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
 ```json
 {
 	// The workspace access token to use when authenticating with Bitbucket Cloud.
@@ -206,7 +206,7 @@ Bitbucket Cloud connections support the following configuration options, which a
 	"webhookSecret": null
 }
 ```
-<!-- SCHEMA_SYNC_END: admin/code_hosts/bitbucket_cloud.schema.json -->
+{/* SCHEMA_SYNC_END: admin/code_hosts/bitbucket_cloud.schema.json */}
 
 ## Webhooks
 

--- a/docs/admin/code_hosts/bitbucket_server.mdx
+++ b/docs/admin/code_hosts/bitbucket_server.mdx
@@ -207,6 +207,9 @@ Bitbucket Server / Bitbucket Data Center connections support the following confi
 
 ### admin/code_hosts/bitbucket_server.schema.json
 
+<!-- SCHEMA_SYNC_START: admin/code_hosts/bitbucket_server.schema.json -->
+<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
+<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
 ```json
 {
 	// If non-null, enforces Bitbucket Server / Bitbucket Data Center repository permissions.
@@ -327,3 +330,4 @@ Bitbucket Server / Bitbucket Data Center connections support the following confi
 	"webhooks": null
 }
 ```
+<!-- SCHEMA_SYNC_END: admin/code_hosts/bitbucket_server.schema.json -->

--- a/docs/admin/code_hosts/bitbucket_server.mdx
+++ b/docs/admin/code_hosts/bitbucket_server.mdx
@@ -207,9 +207,9 @@ Bitbucket Server / Bitbucket Data Center connections support the following confi
 
 ### admin/code_hosts/bitbucket_server.schema.json
 
-<!-- SCHEMA_SYNC_START: admin/code_hosts/bitbucket_server.schema.json -->
-<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
-<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
+{/* SCHEMA_SYNC_START: admin/code_hosts/bitbucket_server.schema.json */}
+{/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
+{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
 ```json
 {
 	// If non-null, enforces Bitbucket Server / Bitbucket Data Center repository permissions.
@@ -330,4 +330,4 @@ Bitbucket Server / Bitbucket Data Center connections support the following confi
 	"webhooks": null
 }
 ```
-<!-- SCHEMA_SYNC_END: admin/code_hosts/bitbucket_server.schema.json -->
+{/* SCHEMA_SYNC_END: admin/code_hosts/bitbucket_server.schema.json */}

--- a/docs/admin/code_hosts/gerrit.mdx
+++ b/docs/admin/code_hosts/gerrit.mdx
@@ -108,6 +108,9 @@ Gerrit connections support the following configuration options, which are specif
 
 ### admin/code_hosts/gerrit.schema.json
 
+<!-- SCHEMA_SYNC_START: admin/code_hosts/gerrit.schema.json -->
+<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
+<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
 ```json
 {
 	// If non-null, enforces Gerrit repository permissions. This requires that there is an item in the [site configuration json](https://sourcegraph.com/docs/admin/config/site_config#auth-providers) `auth.providers` field, of type "gerrit" with the same `url` field as specified in this `GerritConnection`.
@@ -150,3 +153,4 @@ Gerrit connections support the following configuration options, which are specif
 	"username": null
 }
 ```
+<!-- SCHEMA_SYNC_END: admin/code_hosts/gerrit.schema.json -->

--- a/docs/admin/code_hosts/gerrit.mdx
+++ b/docs/admin/code_hosts/gerrit.mdx
@@ -108,9 +108,9 @@ Gerrit connections support the following configuration options, which are specif
 
 ### admin/code_hosts/gerrit.schema.json
 
-<!-- SCHEMA_SYNC_START: admin/code_hosts/gerrit.schema.json -->
-<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
-<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
+{/* SCHEMA_SYNC_START: admin/code_hosts/gerrit.schema.json */}
+{/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
+{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
 ```json
 {
 	// If non-null, enforces Gerrit repository permissions. This requires that there is an item in the [site configuration json](https://sourcegraph.com/docs/admin/config/site_config#auth-providers) `auth.providers` field, of type "gerrit" with the same `url` field as specified in this `GerritConnection`.
@@ -153,4 +153,4 @@ Gerrit connections support the following configuration options, which are specif
 	"username": null
 }
 ```
-<!-- SCHEMA_SYNC_END: admin/code_hosts/gerrit.schema.json -->
+{/* SCHEMA_SYNC_END: admin/code_hosts/gerrit.schema.json */}

--- a/docs/admin/code_hosts/github.mdx
+++ b/docs/admin/code_hosts/github.mdx
@@ -401,9 +401,9 @@ GitHub connections support the following configuration options, which are specif
 
 ### admin/code_hosts/github.schema.json
 
-<!-- SCHEMA_SYNC_START: admin/code_hosts/github.schema.json -->
-<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
-<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
+{/* SCHEMA_SYNC_START: admin/code_hosts/github.schema.json */}
+{/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
+{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
 ```json
 {
 	// If non-null, enforces GitHub repository permissions. This requires that there is an item in the [site configuration json](https://sourcegraph.com/docs/admin/config/site_config#auth-providers) `auth.providers` field, of type "github" with the same `url` field as specified in this `GitHubConnection`.
@@ -583,4 +583,4 @@ If you would like to sync all public repositories while omitting archived repos,
     ]
 }
 ```
-<!-- SCHEMA_SYNC_END: admin/code_hosts/github.schema.json -->
+{/* SCHEMA_SYNC_END: admin/code_hosts/github.schema.json */}

--- a/docs/admin/code_hosts/github.mdx
+++ b/docs/admin/code_hosts/github.mdx
@@ -401,6 +401,9 @@ GitHub connections support the following configuration options, which are specif
 
 ### admin/code_hosts/github.schema.json
 
+<!-- SCHEMA_SYNC_START: admin/code_hosts/github.schema.json -->
+<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
+<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
 ```json
 {
 	// If non-null, enforces GitHub repository permissions. This requires that there is an item in the [site configuration json](https://sourcegraph.com/docs/admin/config/site_config#auth-providers) `auth.providers` field, of type "github" with the same `url` field as specified in this `GitHubConnection`.
@@ -580,3 +583,4 @@ If you would like to sync all public repositories while omitting archived repos,
     ]
 }
 ```
+<!-- SCHEMA_SYNC_END: admin/code_hosts/github.schema.json -->

--- a/docs/admin/code_hosts/gitlab.mdx
+++ b/docs/admin/code_hosts/gitlab.mdx
@@ -185,9 +185,9 @@ See [Internal rate limits](/admin/code_hosts/rate_limits#internal-rate-limits).
 
 ### admin/code_hosts/gitlab.schema.json
 
-<!-- SCHEMA_SYNC_START: admin/code_hosts/gitlab.schema.json -->
-<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
-<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
+{/* SCHEMA_SYNC_START: admin/code_hosts/gitlab.schema.json */}
+{/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
+{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
 ```json
 {
 	// If non-null, enforces GitLab repository permissions. This requires that there be an item in the `auth.providers` field of type "gitlab" with the same `url` field as specified in this `GitLabConnection`.
@@ -336,7 +336,7 @@ The Sourcegraph instance's site admin must [update the `corsOrigin` site config 
   // ...
 }
 ```
-<!-- SCHEMA_SYNC_END: admin/code_hosts/gitlab.schema.json -->
+{/* SCHEMA_SYNC_END: admin/code_hosts/gitlab.schema.json */}
 
 ## Access token scopes
 

--- a/docs/admin/code_hosts/gitlab.mdx
+++ b/docs/admin/code_hosts/gitlab.mdx
@@ -185,6 +185,9 @@ See [Internal rate limits](/admin/code_hosts/rate_limits#internal-rate-limits).
 
 ### admin/code_hosts/gitlab.schema.json
 
+<!-- SCHEMA_SYNC_START: admin/code_hosts/gitlab.schema.json -->
+<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
+<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
 ```json
 {
 	// If non-null, enforces GitLab repository permissions. This requires that there be an item in the `auth.providers` field of type "gitlab" with the same `url` field as specified in this `GitLabConnection`.
@@ -333,6 +336,7 @@ The Sourcegraph instance's site admin must [update the `corsOrigin` site config 
   // ...
 }
 ```
+<!-- SCHEMA_SYNC_END: admin/code_hosts/gitlab.schema.json -->
 
 ## Access token scopes
 

--- a/docs/admin/code_hosts/gitolite.mdx
+++ b/docs/admin/code_hosts/gitolite.mdx
@@ -25,9 +25,9 @@ To connect Gitolite to Sourcegraph:
 
 ### admin/code_hosts/gitolite.schema.json
 
-<!-- SCHEMA_SYNC_START: admin/code_hosts/gitolite.schema.json -->
-<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
-<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
+{/* SCHEMA_SYNC_START: admin/code_hosts/gitolite.schema.json */}
+{/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
+{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
 ```json
 {
 	// A list of repositories to never mirror from this Gitolite instance. Supports excluding by exact name ({"name": "foo"}).
@@ -62,4 +62,4 @@ To connect Gitolite to Sourcegraph:
 	// - "gitolite.example.com/"
 }
 ```
-<!-- SCHEMA_SYNC_END: admin/code_hosts/gitolite.schema.json -->
+{/* SCHEMA_SYNC_END: admin/code_hosts/gitolite.schema.json */}

--- a/docs/admin/code_hosts/gitolite.mdx
+++ b/docs/admin/code_hosts/gitolite.mdx
@@ -25,6 +25,9 @@ To connect Gitolite to Sourcegraph:
 
 ### admin/code_hosts/gitolite.schema.json
 
+<!-- SCHEMA_SYNC_START: admin/code_hosts/gitolite.schema.json -->
+<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
+<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
 ```json
 {
 	// A list of repositories to never mirror from this Gitolite instance. Supports excluding by exact name ({"name": "foo"}).
@@ -59,3 +62,4 @@ To connect Gitolite to Sourcegraph:
 	// - "gitolite.example.com/"
 }
 ```
+<!-- SCHEMA_SYNC_END: admin/code_hosts/gitolite.schema.json -->

--- a/docs/admin/code_hosts/other.mdx
+++ b/docs/admin/code_hosts/other.mdx
@@ -68,9 +68,9 @@ Repositories must be listed individually:
 
 ### admin/code_hosts/other_external_service.schema.json
 
-<!-- SCHEMA_SYNC_START: admin/code_hosts/other_external_service.schema.json -->
-<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
-<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
+{/* SCHEMA_SYNC_START: admin/code_hosts/other_external_service.schema.json */}
+{/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
+{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
 ```json
 {
 	// A list of repositories to never mirror by name after applying repositoryPathPattern. Supports excluding by exact name ({"name": "myrepo"}) or regular expression ({"pattern": ".*secret.*"}).
@@ -113,4 +113,4 @@ Repositories must be listed individually:
 	// - "git://host.xz:2333/"
 }
 ```
-<!-- SCHEMA_SYNC_END: admin/code_hosts/other_external_service.schema.json -->
+{/* SCHEMA_SYNC_END: admin/code_hosts/other_external_service.schema.json */}

--- a/docs/admin/code_hosts/other.mdx
+++ b/docs/admin/code_hosts/other.mdx
@@ -68,6 +68,9 @@ Repositories must be listed individually:
 
 ### admin/code_hosts/other_external_service.schema.json
 
+<!-- SCHEMA_SYNC_START: admin/code_hosts/other_external_service.schema.json -->
+<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
+<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
 ```json
 {
 	// A list of repositories to never mirror by name after applying repositoryPathPattern. Supports excluding by exact name ({"name": "myrepo"}) or regular expression ({"pattern": ".*secret.*"}).
@@ -110,3 +113,4 @@ Repositories must be listed individually:
 	// - "git://host.xz:2333/"
 }
 ```
+<!-- SCHEMA_SYNC_END: admin/code_hosts/other_external_service.schema.json -->

--- a/docs/admin/code_hosts/phabricator.mdx
+++ b/docs/admin/code_hosts/phabricator.mdx
@@ -77,7 +77,9 @@ The Sourcegraph instance's site admin must [update the `corsOrigin` site config 
 
 ### admin/code_hosts/phabricator.schema.json
 
-
+<!-- SCHEMA_SYNC_START: admin/code_hosts/phabricator.schema.json -->
+<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
+<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
 ```json
 {
 	// The list of repositories available on Phabricator.
@@ -92,3 +94,4 @@ The Sourcegraph instance's site admin must [update the `corsOrigin` site config 
 	// - "https://phabricator.example.com"
 }
 ```
+<!-- SCHEMA_SYNC_END: admin/code_hosts/phabricator.schema.json -->

--- a/docs/admin/code_hosts/phabricator.mdx
+++ b/docs/admin/code_hosts/phabricator.mdx
@@ -77,9 +77,9 @@ The Sourcegraph instance's site admin must [update the `corsOrigin` site config 
 
 ### admin/code_hosts/phabricator.schema.json
 
-<!-- SCHEMA_SYNC_START: admin/code_hosts/phabricator.schema.json -->
-<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
-<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
+{/* SCHEMA_SYNC_START: admin/code_hosts/phabricator.schema.json */}
+{/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
+{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
 ```json
 {
 	// The list of repositories available on Phabricator.
@@ -94,4 +94,4 @@ The Sourcegraph instance's site admin must [update the `corsOrigin` site config 
 	// - "https://phabricator.example.com"
 }
 ```
-<!-- SCHEMA_SYNC_END: admin/code_hosts/phabricator.schema.json -->
+{/* SCHEMA_SYNC_END: admin/code_hosts/phabricator.schema.json */}

--- a/docs/admin/config/settings.mdx
+++ b/docs/admin/config/settings.mdx
@@ -25,9 +25,9 @@ Settings options and their default values are shown below.
 
 ### admin/config/settings.schema.json
 
-<!-- SCHEMA_SYNC_START: admin/config/settings.schema.json -->
-<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
-<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
+{/* SCHEMA_SYNC_START: admin/config/settings.schema.json */}
+{/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
+{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
 ```json
 {
 	// Disables observability-related site alert banners.
@@ -148,7 +148,7 @@ Settings options and their default values are shown below.
 	"experimentalFeatures": null
 }
 ```
-<!-- SCHEMA_SYNC_END: admin/config/settings.schema.json -->
+{/* SCHEMA_SYNC_END: admin/config/settings.schema.json */}
 
 ## Additional details on settings
 

--- a/docs/admin/config/settings.mdx
+++ b/docs/admin/config/settings.mdx
@@ -25,6 +25,9 @@ Settings options and their default values are shown below.
 
 ### admin/config/settings.schema.json
 
+<!-- SCHEMA_SYNC_START: admin/config/settings.schema.json -->
+<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
+<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
 ```json
 {
 	// Disables observability-related site alert banners.
@@ -145,6 +148,7 @@ Settings options and their default values are shown below.
 	"experimentalFeatures": null
 }
 ```
+<!-- SCHEMA_SYNC_END: admin/config/settings.schema.json -->
 
 ## Additional details on settings
 

--- a/docs/admin/config/site_config.mdx
+++ b/docs/admin/config/site_config.mdx
@@ -19,9 +19,9 @@ All site configuration options and their default values are shown below.
 
 ### admin/config/site.schema.json
 
-<!-- SCHEMA_SYNC_START: admin/config/site.schema.json -->
-<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
-<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
+{/* SCHEMA_SYNC_START: admin/config/site.schema.json */}
+{/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
+{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
 ```json
 {
 	// Prompts user to install new browser for non es5
@@ -935,7 +935,7 @@ You can check the container logs to see if you have made any typos or mistakes i
 	],
 }
 ```
-<!-- SCHEMA_SYNC_END: admin/config/site.schema.json -->
+{/* SCHEMA_SYNC_END: admin/config/site.schema.json */}
 
 ## Accessing global settings
 

--- a/docs/admin/config/site_config.mdx
+++ b/docs/admin/config/site_config.mdx
@@ -19,6 +19,9 @@ All site configuration options and their default values are shown below.
 
 ### admin/config/site.schema.json
 
+<!-- SCHEMA_SYNC_START: admin/config/site.schema.json -->
+<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
+<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
 ```json
 {
 	// Prompts user to install new browser for non es5
@@ -932,6 +935,7 @@ You can check the container logs to see if you have made any typos or mistakes i
 	],
 }
 ```
+<!-- SCHEMA_SYNC_END: admin/config/site.schema.json -->
 
 ## Accessing global settings
 

--- a/docs/admin/repo/perforce.mdx
+++ b/docs/admin/repo/perforce.mdx
@@ -219,9 +219,9 @@ With this setting, Sourcegraph will ignore any rules with a host other than `*`,
 
 ### `admin/code_hosts/perforce.schema.json`
 
-<!-- SCHEMA_SYNC_START: admin/code_hosts/perforce.schema.json -->
-<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
-<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
+{/* SCHEMA_SYNC_START: admin/code_hosts/perforce.schema.json */}
+{/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
+{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
 ```json
 {
 	// If non-null, enforces Perforce depot permissions.
@@ -335,7 +335,7 @@ Add `"batchChanges.enablePerforce": true` to `experimentalFeatures` in the [site
   }
 }
 ```
-<!-- SCHEMA_SYNC_END: admin/code_hosts/perforce.schema.json -->
+{/* SCHEMA_SYNC_END: admin/code_hosts/perforce.schema.json */}
 
 Batch Changes does not support repos that use sub-repo permissions, so in order to use batch changes with Perforce depots, the code host cannot use [file-level permissions](#file-level-permissions).
 

--- a/docs/admin/repo/perforce.mdx
+++ b/docs/admin/repo/perforce.mdx
@@ -219,6 +219,9 @@ With this setting, Sourcegraph will ignore any rules with a host other than `*`,
 
 ### `admin/code_hosts/perforce.schema.json`
 
+<!-- SCHEMA_SYNC_START: admin/code_hosts/perforce.schema.json -->
+<!-- WARNING: This section is auto-generated during releases. Do not edit manually. -->
+<!-- Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases -->
 ```json
 {
 	// If non-null, enforces Perforce depot permissions.
@@ -332,6 +335,7 @@ Add `"batchChanges.enablePerforce": true` to `experimentalFeatures` in the [site
   }
 }
 ```
+<!-- SCHEMA_SYNC_END: admin/code_hosts/perforce.schema.json -->
 
 Batch Changes does not support repos that use sub-repo permissions, so in order to use batch changes with Perforce depots, the code host cannot use [file-level permissions](#file-level-permissions).
 


### PR DESCRIPTION
REL-1076

Adds JSX comment markers around embedded JSON schema sections in documentation files to enable automated schema updates during releases.

These markers identify the start and end boundaries for 13 schema sections across site configuration and code host documentation files. The markers include developer warnings to prevent manual edits and version tracking for audit trails.

This prepares the docs repository for automated schema synchronization from the monorepo during the release process.