### PR TITLE
Update SLAs to add Amp Support

### DIFF
--- a/docs/sla/index.mdx
+++ b/docs/sla/index.mdx
@@ -10,7 +10,7 @@ While we always strive to respond to your issues as quickly as possible, our SLA
 
 The following policy applies to both our cloud-based (managed instance) and on-premise/self-hosted Sourcegraph customers:
 
-## For enterprise plans
+## For Sourcegraph Enterprise & Amp Enterprise Premium plans
 
 | Severity level |                                                                     Description                                                                      |                    Response time                     | Support availability |
 | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | -------------------- |
@@ -22,7 +22,7 @@ The following policy applies to both our cloud-based (managed instance) and on-p
 >NOTE: Premium support with enhanced SLAs can be added to your Enterprise plans as an add-on. Our business hours, defined as Sunday 2 PM PST to Friday 5 PM PST, align with our 24x5 support coverage.
 
 
-### For Enterprise Starter & Cody Pro plans
+### All other paid plans
 
 | **Severity level** |                                                                     **Description**                                                                      |                    **Response time**                    | **Support availability** |
 | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | -------------------- |


### PR DESCRIPTION
This differentiates between Sourcegraph Code Search support plans with everything else.

Basically:

Code Search Enterprise, Cody Enterprise, Amp Enterprise Premium get 24x5

Amp Individual, Teams, Enterprise get 9x5 support