### PR TITLE
monitors: Remove mention of removed experimental feature flag

### DIFF
--- a/docs/code_monitoring/how-tos/webhook.mdx
+++ b/docs/code_monitoring/how-tos/webhook.mdx
@@ -6,7 +6,6 @@ by Sourcegraph, and contains all the information available about the cause of th
 
 ## Prerequisites
 
-- You must not have have the setting `experimentalFeatures.codeMonitoringWebHooks` disabled in your user, org, or global settings.
 - You must have a service running that can accept the POST request triggered by the webhook notification
 
 ## Creating a webhook receiver


### PR DESCRIPTION
No longer a requirement.
