### PR TITLE
license: Remove very old notice

### DIFF
--- a/docs/admin/licensing/index.mdx
+++ b/docs/admin/licensing/index.mdx
@@ -15,13 +15,7 @@ License keys should not be shared across instances of Sourcegraph. If an additio
 
 ### What happens if our Sourcegraph license expires?
 
-#### After Sourcegraph 5.3
-
 Sourcegraph will continue to function as normal, but all users will be signed out of Sourcegraph. Only site administrators will be able to sign into Sourcegraph so that they can enter a new license key.
-
-#### Before Sourcegraph 5.3
-
-Sourcegraph will revert to a free license, and any features that require an enterprise license will stop functioning. This could lead to data loss if some of these features were in use, so be sure to renew your license in advance!
 
 ### How can we update our license key?
 
@@ -32,7 +26,8 @@ These settings live in the JSON object, and you will need to navigate to the _li
 Update the value of this with your new license key and click Save to apply your changes.
 
 Example:
-```
+
+```bash
   "licenseKey": "<your_key_here>",
 ```
 


### PR DESCRIPTION
This is just confusing in versioned docs IMO and adding cognitive complexity, so dropping the version split here.