### PR TITLE
Update JSON schemas for v6.5.1211

### DIFF
--- a/docs/admin/code_hosts/aws_codecommit.mdx
+++ b/docs/admin/code_hosts/aws_codecommit.mdx
@@ -34,86 +34,171 @@ AWS CodeCommit connections support the following configuration options, which ar
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/aws_codecommit.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T19:22:27Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
-	// The AWS access key ID to use when listing and updating repositories from AWS CodeCommit. Must have the AWSCodeCommitReadOnly IAM policy.
-	"accessKeyID": null,
-
-	// A list of repositories to never mirror from AWS CodeCommit.
-	//
-	// Supports excluding by name ({"name": "git-codecommit.us-west-1.amazonaws.com/repo-name"}) or by ARN ({"id": "arn:aws:codecommit:us-west-1:999999999999:name"}).
-	"exclude": null,
-	// Other example values:
-	// - [
-	//     {
-	//       "name": "go-monorepo"
-	//     },
-	//     {
-	//       "id": "f001337a-3450-46fd-b7d2-650c0EXAMPLE"
-	//     }
-	//   ]
-	// - [
-	//     {
-	//       "name": "go-monorepo"
-	//     },
-	//     {
-	//       "name": "go-client"
-	//     }
-	//   ]
-
-	// The Git credentials used for authentication when cloning an AWS CodeCommit repository over HTTPS.
-	//
-	// See the AWS CodeCommit documentation on Git credentials for CodeCommit: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_ssh-keys.html#git-credentials-code-commit.
-	// For detailed instructions on how to create the credentials in IAM, see this page: https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-gc.html
-	"gitCredentials": null,
-
-	// Deprecated and ignored field which will be removed entirely in the next release. AWS CodeCommit repositories can no longer be enabled or disabled explicitly. Configure which repositories should not be mirrored via "exclude" instead.
-	"initialRepositoryEnablement": false,
-
-	// The AWS region in which to access AWS CodeCommit. See the list of supported regions at https://docs.aws.amazon.com/codecommit/latest/userguide/regions.html#regions-git.
-	"region": "us-east-1",
-
-	// The pattern used to generate a the corresponding Sourcegraph repository name for an AWS CodeCommit repository. In the pattern, the variable "{name}" is replaced with the repository's name.
-	//
-	// For example, if your Sourcegraph instance is at https://src.example.com, then a repositoryPathPattern of "awsrepos/{name}" would mean that a AWS CodeCommit repository named "myrepo" is available on Sourcegraph at https://src.example.com/awsrepos/myrepo.
-	//
-	// It is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.
-	"repositoryPathPattern": "{name}",
-	// Other example values:
-	// - "git-codecommit.us-west-1.amazonaws.com/{name}"
-	// - "git-codecommit.eu-central-1.amazonaws.com/{name}"
-
-	// The AWS secret access key (that corresponds to the AWS access key ID set in `accessKeyID`).
-	"secretAccessKey": null
-}
-```
-
-## Setup steps for SSH connections to AWS CodeCommit repositories
-
-To add CodeCommit repositories in Docker Container:
-
-1. Generate a public/private rsa key pair that does not require passphrase as listed in the [Step 3.1 of the AWS SSH setup guide](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-ssh-unixes.html#setting-up-ssh-unixes-keys). Sourcegraph does not work with the key pair that requires passphrase.
-1. Follow the rest of the steps detailed in the [AWS SSH setup guide](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-ssh-unixes.html) to make sure you can connect to the code host locally.
-1. Confirm you have the connection by running the following ssh command locally: `ssh git-codecommit.us-west-1.amazonaws.com` (Update link with your server region)
-1. Confirm you can clone the repository locally.
-
-### Configuring SSH credentials in the Web UI
-
-```json
-{
-  "gitURLType": "ssh",
-  "gitSSHKeyID": "<SSH key ID>",
-  "gitSSHCredential": {
-    // make sure the key is base64 encoded
-    // $ cat ~/.ssh/id_rsa | base64
-    "privateKey": "<base64 encoded of the SSH private key>",
-    "passphrase": "<passphrase if applicable, omit if none is needed>"
-  }
+	"$id": "aws_codecommit.schema.json#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": false,
+	"allowComments": true,
+	"description": "Configuration for a connection to AWS CodeCommit.",
+	"properties": {
+		"accessKeyID": {
+			"description": "The AWS access key ID to use when listing and updating repositories from AWS CodeCommit. Must have the AWSCodeCommitReadOnly IAM policy.",
+			"type": "string"
+		},
+		"exclude": {
+			"description": "A list of repositories to never mirror from AWS CodeCommit. \n\nSupports excluding by name ({\"name\": \"git-codecommit.us-west-1.amazonaws.com/repo-name\"}) or by ARN ({\"id\": \"arn:aws:codecommit:us-west-1:999999999999:name\"}).",
+			"examples": [
+				[
+					{
+						"name": "go-monorepo"
+					},
+					{
+						"id": "f001337a-3450-46fd-b7d2-650c0EXAMPLE"
+					}
+				],
+				[
+					{
+						"name": "go-monorepo"
+					},
+					{
+						"name": "go-client"
+					}
+				]
+			],
+			"items": {
+				"additionalProperties": false,
+				"anyOf": [
+					{
+						"required": [
+							"name"
+						]
+					},
+					{
+						"required": [
+							"id"
+						]
+					}
+				],
+				"properties": {
+					"id": {
+						"description": "The ID of an AWS Code Commit repository (as returned by the AWS API) to exclude from mirroring. Use this to exclude the repository, even if renamed, or to differentiate between repositories with the same name in multiple regions.",
+						"pattern": "^[\\w-]+$",
+						"type": "string"
+					},
+					"name": {
+						"description": "The name of an AWS CodeCommit repository (\"repo-name\") to exclude from mirroring.",
+						"pattern": "^[\\w.-]+$",
+						"type": "string"
+					}
+				},
+				"title": "ExcludedAWSCodeCommitRepo",
+				"type": "object"
+			},
+			"minItems": 1,
+			"type": "array"
+		},
+		"gitCredentials": {
+			"description": "The Git credentials used for authentication when cloning an AWS CodeCommit repository over HTTPS.\n\nSee the AWS CodeCommit documentation on Git credentials for CodeCommit: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_ssh-keys.html#git-credentials-code-commit.\nFor detailed instructions on how to create the credentials in IAM, see this page: https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-gc.html",
+			"properties": {
+				"password": {
+					"description": "The Git password",
+					"minLength": 1,
+					"type": "string"
+				},
+				"username": {
+					"description": "The Git username",
+					"minLength": 1,
+					"type": "string"
+				}
+			},
+			"required": [
+				"username",
+				"password"
+			],
+			"title": "AWSCodeCommitGitCredentials",
+			"type": "object"
+		},
+		"gitSSHCipher": {
+			"$ref": "git.schema.json#/definitions/gitSSHCipher",
+			"description": "SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`."
+		},
+		"gitSSHCredential": {
+			"$ref": "git.schema.json#/definitions/gitSSHCredential",
+			"description": "SSH keys to use when cloning Git repo."
+		},
+		"gitSSHKeyID": {
+			"description": "The ID of the SSH key created for your IAM users. It is required when using SSH to clone repositories.",
+			"type": "string"
+		},
+		"gitURLType": {
+			"default": "http",
+			"description": "The type of Git URLs to use for cloning and fetching Git repositories.",
+			"enum": [
+				"http",
+				"ssh"
+			],
+			"type": "string"
+		},
+		"initialRepositoryEnablement": {
+			"default": false,
+			"description": "Deprecated and ignored field which will be removed entirely in the next release. AWS CodeCommit repositories can no longer be enabled or disabled explicitly. Configure which repositories should not be mirrored via \"exclude\" instead.",
+			"type": "boolean"
+		},
+		"maxDeletions": {
+			"default": 0,
+			"description": "The maximum number of repos that will be deleted per sync. A value of 0 or less indicates no maximum.",
+			"type": "integer"
+		},
+		"region": {
+			"default": "us-east-1",
+			"description": "The AWS region in which to access AWS CodeCommit. See the list of supported regions at https://docs.aws.amazon.com/codecommit/latest/userguide/regions.html#regions-git.",
+			"enum": [
+				"ap-northeast-1",
+				"ap-northeast-2",
+				"ap-south-1",
+				"ap-southeast-1",
+				"ap-southeast-2",
+				"ca-central-1",
+				"eu-central-1",
+				"eu-west-1",
+				"eu-west-2",
+				"eu-west-3",
+				"sa-east-1",
+				"us-east-1",
+				"us-east-2",
+				"us-west-1",
+				"us-west-2"
+			],
+			"pattern": "^[a-z\\d-]+$",
+			"type": "string"
+		},
+		"repositoryPathPattern": {
+			"default": "{name}",
+			"description": "The pattern used to generate a the corresponding Sourcegraph repository name for an AWS CodeCommit repository. In the pattern, the variable \"{name}\" is replaced with the repository's name.\n\nFor example, if your Sourcegraph instance is at https://src.example.com, then a repositoryPathPattern of \"awsrepos/{name}\" would mean that a AWS CodeCommit repository named \"myrepo\" is available on Sourcegraph at https://src.example.com/awsrepos/myrepo.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.",
+			"examples": [
+				"git-codecommit.us-west-1.amazonaws.com/{name}",
+				"git-codecommit.eu-central-1.amazonaws.com/{name}"
+			],
+			"type": "string"
+		},
+		"secretAccessKey": {
+			"description": "The AWS secret access key (that corresponds to the AWS access key ID set in `accessKeyID`).",
+			"type": "string"
+		}
+	},
+	"required": [
+		"region",
+		"accessKeyID",
+		"secretAccessKey",
+		"gitCredentials"
+	],
+	"title": "AWSCodeCommitConnection",
+	"type": "object"
 }
 ```
 {/* SCHEMA_SYNC_END: admin/code_hosts/aws_codecommit.schema.json */}
-
 ## Configuration Notes
 
 ### Git Credentials Requirement

--- a/docs/admin/code_hosts/azuredevops.mdx
+++ b/docs/admin/code_hosts/azuredevops.mdx
@@ -67,68 +67,226 @@ Azure DevOps connections support the following configuration options, which are 
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/azuredevops.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T19:22:26Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
-	// A flag to enforce Azure DevOps repository access permissions
-	"enforcePermissions": false,
-
-	// A list of repositories to never mirror from Azure DevOps Services.
-	"exclude": null,
-	// Other example values:
-	// - [
-	//     {
-	//       "name": "myorg/myproject/myrepo"
-	//     }
-	//   ]
-	// - [
-	//     {
-	//       "name": "myorg/myproject/myrepo"
-	//     },
-	//     {
-	//       "name": "myorg/myproject/myotherrepo"
-	//     },
-	//     {
-	//       "pattern": "^topsecretproject/.*"
-	//     }
-	//   ]
-
-	// The type of Git URLs to use for cloning and fetching Git repositories.
-	//
-	// If "http", Sourcegraph will access repositories using Git URLs of the form http(s)://dev.azure.com/myrepo.git.
-	//
-	// If "ssh", Sourcegraph will access repositories using Git URLs of the form git@ssh.dev.azure.com:v3/myrepo. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.
-	"gitURLType": "http",
-
-	// An array of organization names identifying Azure DevOps organizations whose repositories should be mirrored on Sourcegraph.
-	"orgs": null,
-	// Other example values:
-	// - ["name"]
-	// - [
-	//     "kubernetes",
-	//     "golang",
-	//     "facebook"
-	//   ]
-
-	// An array of projects "org/project" strings specifying which Azure DevOps projects' repositories should be mirrored on Sourcegraph.
-	"projects": null,
-	// Other example values:
-	// - ["org/project"]
-
-	// The Personal Access Token associated with the Azure DevOps username used for authentication.
-	"token": null,
-
-	// URL for Azure DevOps Services, set to https://dev.azure.com.
-	"url": null,
-	// Other example values:
-	// - "https://dev.azure.com"
-
-	// A username for authentication with the Azure DevOps code host.
-	"username": null
+	"$id": "azuredevops.schema.json#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": false,
+	"allowComments": true,
+	"description": "Configuration for a connection to Azure DevOps.",
+	"oneOf": [
+		{
+			"properties": {
+				"windowsPassword": {
+					"type": "null"
+				}
+			},
+			"required": [
+				"token"
+			]
+		},
+		{
+			"properties": {
+				"token": {
+					"type": "null"
+				}
+			},
+			"required": [
+				"windowsPassword"
+			]
+		}
+	],
+	"properties": {
+		"enforcePermissions": {
+			"default": false,
+			"description": "A flag to enforce Azure DevOps repository access permissions",
+			"type": "boolean"
+		},
+		"exclude": {
+			"description": "A list of repositories to never mirror from Azure DevOps Services.",
+			"examples": [
+				[
+					{
+						"name": "myorg/myproject/myrepo"
+					}
+				],
+				[
+					{
+						"name": "myorg/myproject/myrepo"
+					},
+					{
+						"name": "myorg/myproject/myotherrepo"
+					},
+					{
+						"pattern": "^topsecretproject/.*"
+					}
+				]
+			],
+			"items": {
+				"additionalProperties": false,
+				"anyOf": [
+					{
+						"required": [
+							"name"
+						]
+					},
+					{
+						"required": [
+							"id"
+						]
+					},
+					{
+						"required": [
+							"pattern"
+						]
+					}
+				],
+				"properties": {
+					"name": {
+						"description": "The name of an Azure DevOps Services organization, project, and repository (\"orgName/projectName/repositoryName\") to exclude from mirroring.",
+						"pattern": "^[\\w./ -]*?$",
+						"type": "string"
+					},
+					"pattern": {
+						"description": "Regular expression which matches against the name of an Azure DevOps Services repo.",
+						"format": "regex",
+						"type": "string"
+					}
+				},
+				"title": "ExcludedAzureDevOpsServerRepo",
+				"type": "object"
+			},
+			"minItems": 1,
+			"type": "array"
+		},
+		"gitSSHCipher": {
+			"$ref": "git.schema.json#/definitions/gitSSHCipher",
+			"description": "SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`."
+		},
+		"gitSSHCredential": {
+			"$ref": "git.schema.json#/definitions/gitSSHCredential",
+			"description": "SSH keys to use when cloning Git repo."
+		},
+		"gitURLType": {
+			"default": "http",
+			"description": "The type of Git URLs to use for cloning and fetching Git repositories.\n\nIf \"http\", Sourcegraph will access repositories using Git URLs of the form http(s)://dev.azure.com/myrepo.git.\n\nIf \"ssh\", Sourcegraph will access repositories using Git URLs of the form git@ssh.dev.azure.com:v3/myrepo. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth.",
+			"enum": [
+				"http",
+				"ssh"
+			],
+			"type": "string"
+		},
+		"maxDeletions": {
+			"default": 0,
+			"description": "The maximum number of repos that will be deleted per sync. A value of 0 or less indicates no maximum.",
+			"type": "integer"
+		},
+		"orgs": {
+			"description": "An array of organization names identifying Azure DevOps organizations whose repositories should be mirrored on Sourcegraph.",
+			"examples": [
+				[
+					"name"
+				],
+				[
+					"kubernetes",
+					"golang",
+					"facebook"
+				]
+			],
+			"items": {
+				"pattern": "^[\\w-]+$",
+				"type": "string"
+			},
+			"type": "array"
+		},
+		"projects": {
+			"description": "An array of projects \"org/project\" strings specifying which Azure DevOps projects' repositories should be mirrored on Sourcegraph.",
+			"examples": [
+				[
+					"org/project"
+				]
+			],
+			"items": {
+				"pattern": "^[\\w-]+/[\\w.-]+([ ]*[\\w.-]+)*$",
+				"type": "string"
+			},
+			"type": "array"
+		},
+		"rateLimit": {
+			"default": {
+				"enabled": false,
+				"requestsPerHour": 0
+			},
+			"description": "Rate limit applied when making background API requests.",
+			"properties": {
+				"enabled": {
+					"default": false,
+					"description": "true if rate limiting is enabled.",
+					"type": "boolean"
+				},
+				"requestsPerHour": {
+					"description": "Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.",
+					"minimum": 0,
+					"type": "number"
+				}
+			},
+			"required": [
+				"enabled",
+				"requestsPerHour"
+			],
+			"title": "AzureDevOpsRateLimit",
+			"type": "object"
+		},
+		"repositoryPathPattern": {
+			"default": "{host}/{orgName}/{projectName}/{repositoryName}",
+			"description": "The pattern used to generate the corresponding Sourcegraph repository name for a Azure DevOps repository.\n\n - \"{host}\" is replaced with the Azure DevOps URL's host (such as dev.azure.com)\n - \"{orgName}\" is replaced with the repository's parent projects owning organization (or collection on DevOps server)\n - \"{projectName}\" is replaced with the repository's parent project\n - \"{repositoryName}\" is replaced with the repository's name.\n\nFor example, if your Azure DevOps is https://dev.azure.com and your Sourcegraph is https://src.example.com, then a repositoryPathPattern of \"{host}/{orgName}/{projectName}/{repositoryName}\" would mean that a Azure DevOps repository at https://dev.azure.com/MYORG/MYPROJECT/MYREPO is available on Sourcegraph at https://src.example.com/dev.azure.com/MYORG/MYPROJECT/MYREPO.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.",
+			"examples": [
+				"{projectName}/{repositoryName}"
+			],
+			"type": "string"
+		},
+		"token": {
+			"description": "The Personal Access Token associated with the Azure DevOps username used for authentication.",
+			"minLength": 1,
+			"type": "string"
+		},
+		"url": {
+			"!go": {
+				"typeName": "NormalizedURL"
+			},
+			"description": "URL for Azure DevOps Services, set to https://dev.azure.com.",
+			"examples": [
+				"https://dev.azure.com"
+			],
+			"format": "uri",
+			"not": {
+				"pattern": "example\\.com",
+				"type": "string"
+			},
+			"pattern": "^https?://",
+			"type": "string"
+		},
+		"username": {
+			"description": "A username for authentication with the Azure DevOps code host. Typically an email address when connect to Azure DevOps Services (cloud) and a domain\\username when connecting to Azure DevOp Server (onPrem)",
+			"minLength": 1,
+			"type": "string"
+		},
+		"windowsPassword": {
+			"description": "Windows account password (Azure Devops Server OnPrem Only): This is needed to clone the repo, the Token will be used for REST API calls",
+			"minLength": 1,
+			"type": "string"
+		}
+	},
+	"required": [
+		"url",
+		"username"
+	],
+	"title": "AzureDevOpsConnection",
+	"type": "object"
 }
 ```
 {/* SCHEMA_SYNC_END: admin/code_hosts/azuredevops.schema.json */}
-
 ## Configuration Notes
 
 ### Token Requirements

--- a/docs/admin/code_hosts/bitbucket_cloud.mdx
+++ b/docs/admin/code_hosts/bitbucket_cloud.mdx
@@ -118,96 +118,270 @@ Bitbucket Cloud connections support the following configuration options, which a
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/bitbucket_cloud.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T19:22:25Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
-	// The workspace access token to use when authenticating with Bitbucket Cloud.
-	"accessToken": null,
-
-	// The API URL of Bitbucket Cloud, such as https://api.bitbucket.org. Generally, admin should not modify the value of this option because Bitbucket Cloud is a public hosting platform.
-	"apiURL": null,
-	// Other example values:
-	// - "https://api.bitbucket.org"
-
-	// The app password to use when authenticating to the Bitbucket Cloud. Also set the corresponding "username" field.
-	"appPassword": null,
-
-	// If non-null, enforces Bitbucket Cloud repository permissions. This requires that there is an item in the [site configuration json](https://sourcegraph.com/docs/admin/config/site_config#auth-providers) `auth.providers` field, of type "bitbucketcloud" with the same `url` field as specified in this `BitbucketCloudConnection`.
-	"authorization": null,
-
-	// A list of repositories to never mirror from Bitbucket Cloud. Takes precedence over "teams" configuration.
-	//
-	// Supports excluding by name ({"name": "myorg/myrepo"}) or by UUID ({"uuid": "{fceb73c7-cef6-4abe-956d-e471281126bd}"}).
-	"exclude": null,
-	// Other example values:
-	// - [
-	//     {
-	//       "name": "myorg/myrepo"
-	//     },
-	//     {
-	//       "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bc}"
-	//     }
-	//   ]
-	// - [
-	//     {
-	//       "name": "myorg/myrepo"
-	//     },
-	//     {
-	//       "name": "myorg/myotherrepo"
-	//     },
-	//     {
-	//       "pattern": "^topsecretproject/.*"
-	//     }
-	//   ]
-
-	// The type of Git URLs to use for cloning and fetching Git repositories on this Bitbucket Cloud.
-	//
-	// If "http", Sourcegraph will access Bitbucket Cloud repositories using Git URLs of the form https://bitbucket.org/myteam/myproject.git.
-	//
-	// If "ssh", Sourcegraph will access Bitbucket Cloud repositories using Git URLs of the form git@bitbucket.org:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.
-	"gitURLType": "http",
-	// Other example values:
-	// - "ssh"
-
-	// Rate limit applied when making background API requests to Bitbucket Cloud.
-	"rateLimit": {
-		"enabled": true,
-		"requestsPerHour": 7200
+	"$id": "bitbucket_cloud.schema.json#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": false,
+	"allowComments": true,
+	"description": "Configuration for a connection to Bitbucket Cloud.",
+	"oneOf": [
+		{
+			"allOf": [
+				{
+					"required": [
+						"accessToken"
+					]
+				},
+				{
+					"not": {
+						"required": [
+							"username"
+						]
+					}
+				},
+				{
+					"not": {
+						"required": [
+							"appPassword"
+						]
+					}
+				}
+			]
+		},
+		{
+			"not": {
+				"required": [
+					"accessToken"
+				]
+			},
+			"required": [
+				"username",
+				"appPassword"
+			]
+		}
+	],
+	"properties": {
+		"accessToken": {
+			"description": "The workspace access token to use when authenticating with Bitbucket Cloud.",
+			"type": "string"
+		},
+		"apiURL": {
+			"description": "The API URL of Bitbucket Cloud, such as https://api.bitbucket.org. Generally, admin should not modify the value of this option because Bitbucket Cloud is a public hosting platform.",
+			"examples": [
+				"https://api.bitbucket.org"
+			],
+			"format": "uri",
+			"not": {
+				"pattern": "example\\.com",
+				"type": "string"
+			},
+			"pattern": "^https?://",
+			"type": "string"
+		},
+		"appPassword": {
+			"description": "The app password to use when authenticating to the Bitbucket Cloud. Also set the corresponding \"username\" field.",
+			"type": "string"
+		},
+		"authorization": {
+			"description": "If non-null, enforces Bitbucket Cloud repository permissions. This requires that there is an item in the [site configuration json](https://sourcegraph.com/docs/admin/config/site_config#auth-providers) `auth.providers` field, of type \"bitbucketcloud\" with the same `url` field as specified in this `BitbucketCloudConnection`.",
+			"properties": {
+				"identityProvider": {
+					"description": "The identity provider to use for user information. If not set, the `url` field is used.",
+					"type": "string"
+				}
+			},
+			"title": "BitbucketCloudAuthorization",
+			"type": "object"
+		},
+		"exclude": {
+			"description": "A list of repositories to never mirror from Bitbucket Cloud. Takes precedence over \"teams\" configuration.\n\nSupports excluding by name ({\"name\": \"myorg/myrepo\"}) or by UUID ({\"uuid\": \"{fceb73c7-cef6-4abe-956d-e471281126bd}\"}).",
+			"examples": [
+				[
+					{
+						"name": "myorg/myrepo"
+					},
+					{
+						"uuid": "{fceb73c7-cef6-4abe-956d-e471281126bc}"
+					}
+				],
+				[
+					{
+						"name": "myorg/myrepo"
+					},
+					{
+						"name": "myorg/myotherrepo"
+					},
+					{
+						"pattern": "^topsecretproject/.*"
+					}
+				]
+			],
+			"items": {
+				"additionalProperties": false,
+				"anyOf": [
+					{
+						"required": [
+							"name"
+						]
+					},
+					{
+						"required": [
+							"uuid"
+						]
+					},
+					{
+						"required": [
+							"pattern"
+						]
+					}
+				],
+				"properties": {
+					"name": {
+						"description": "The name of a Bitbucket Cloud repo (\"myorg/myrepo\") to exclude from mirroring.",
+						"pattern": "^[\\w-]+/[\\w.-]+$",
+						"type": "string"
+					},
+					"pattern": {
+						"description": "Regular expression which matches against the name of a Bitbucket Cloud repo.",
+						"format": "regex",
+						"type": "string"
+					},
+					"uuid": {
+						"description": "The UUID of a Bitbucket Cloud repo (as returned by the Bitbucket Cloud's API) to exclude from mirroring.",
+						"pattern": "^\\{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\}$",
+						"type": "string"
+					}
+				},
+				"title": "ExcludedBitbucketCloudRepo",
+				"type": "object"
+			},
+			"type": "array"
+		},
+		"gitSSHCipher": {
+			"$ref": "git.schema.json#/definitions/gitSSHCipher",
+			"description": "SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`."
+		},
+		"gitSSHCredential": {
+			"$ref": "git.schema.json#/definitions/gitSSHCredential",
+			"description": "SSH keys to use when cloning Git repo."
+		},
+		"gitURLType": {
+			"default": "http",
+			"description": "The type of Git URLs to use for cloning and fetching Git repositories on this Bitbucket Cloud.\n\nIf \"http\", Sourcegraph will access Bitbucket Cloud repositories using Git URLs of the form https://bitbucket.org/myteam/myproject.git.\n\nIf \"ssh\", Sourcegraph will access Bitbucket Cloud repositories using Git URLs of the form git@bitbucket.org:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.",
+			"enum": [
+				"http",
+				"ssh"
+			],
+			"examples": [
+				"ssh"
+			],
+			"type": "string"
+		},
+		"maxDeletions": {
+			"default": 0,
+			"description": "The maximum number of repos that will be deleted per sync. A value of 0 or less indicates no maximum.",
+			"type": "integer"
+		},
+		"rateLimit": {
+			"default": {
+				"enabled": true,
+				"requestsPerHour": 7200
+			},
+			"description": "Rate limit applied when making background API requests to Bitbucket Cloud.",
+			"properties": {
+				"enabled": {
+					"default": true,
+					"description": "true if rate limiting is enabled.",
+					"type": "boolean"
+				},
+				"requestsPerHour": {
+					"default": 7200,
+					"description": "Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 500, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 500 requests immediately, provided that the complexity cost of each request is 1.",
+					"minimum": 0,
+					"type": "number"
+				}
+			},
+			"required": [
+				"enabled",
+				"requestsPerHour"
+			],
+			"title": "BitbucketCloudRateLimit",
+			"type": "object"
+		},
+		"repos": {
+			"description": "An array of repository \"projectKey/repositorySlug\" strings specifying repositories to mirror on Sourcegraph.",
+			"examples": [
+				[
+					"myproject/myrepo",
+					"myproject/myotherrepo"
+				]
+			],
+			"items": {
+				"pattern": "^~?[\\w-]+/[\\w.-]+$",
+				"type": "string"
+			},
+			"type": "array"
+		},
+		"repositoryPathPattern": {
+			"default": "{host}/{nameWithOwner}",
+			"description": "The pattern used to generate the corresponding Sourcegraph repository name for a Bitbucket Cloud repository.\n\n - \"{host}\" is replaced with the Bitbucket Cloud URL's host (such as bitbucket.org),  and \"{nameWithOwner}\" is replaced with the Bitbucket Cloud repository's \"owner/path\" (such as \"myorg/myrepo\").\n\nFor example, if your Bitbucket Cloud is https://bitbucket.org and your Sourcegraph is https://src.example.com, then a repositoryPathPattern of \"{host}/{nameWithOwner}\" would mean that a Bitbucket Cloud repository at https://bitbucket.org/alice/my-repo is available on Sourcegraph at https://src.example.com/bitbucket.org/alice/my-repo.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.",
+			"type": "string"
+		},
+		"teams": {
+			"description": "An array of team names identifying Bitbucket Cloud teams whose repositories should be mirrored on Sourcegraph.",
+			"examples": [
+				[
+					"name"
+				],
+				[
+					"kubernetes",
+					"golang",
+					"facebook"
+				]
+			],
+			"items": {
+				"pattern": "^[\\w-]+$",
+				"type": "string"
+			},
+			"type": "array"
+		},
+		"url": {
+			"!go": {
+				"typeName": "NormalizedURL"
+			},
+			"description": "URL of Bitbucket Cloud, such as https://bitbucket.org. Generally, admin should not modify the value of this option because Bitbucket Cloud is a public hosting platform.",
+			"examples": [
+				"https://bitbucket.org"
+			],
+			"format": "uri",
+			"not": {
+				"pattern": "example\\.com",
+				"type": "string"
+			},
+			"pattern": "^https?://",
+			"type": "string"
+		},
+		"username": {
+			"description": "The username to use when authenticating to the Bitbucket Cloud. Also set the corresponding \"appPassword\" field.",
+			"type": "string"
+		},
+		"webhookSecret": {
+			"deprecationMessage": "Deprecated in favour of first class webhooks. See https://sourcegraph.com/docs/admin/config/webhooks/incoming#deprecation-notice",
+			"description": "A shared secret used to authenticate incoming webhooks (minimum 12 characters).",
+			"minLength": 12,
+			"type": "string"
+		}
 	},
-
-	// The pattern used to generate the corresponding Sourcegraph repository name for a Bitbucket Cloud repository.
-	//
-	//  - "{host}" is replaced with the Bitbucket Cloud URL's host (such as bitbucket.org),  and "{nameWithOwner}" is replaced with the Bitbucket Cloud repository's "owner/path" (such as "myorg/myrepo").
-	//
-	// For example, if your Bitbucket Cloud is https://bitbucket.org and your Sourcegraph is https://src.example.com, then a repositoryPathPattern of "{host}/{nameWithOwner}" would mean that a Bitbucket Cloud repository at https://bitbucket.org/alice/my-repo is available on Sourcegraph at https://src.example.com/bitbucket.org/alice/my-repo.
-	//
-	// It is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.
-	"repositoryPathPattern": "{host}/{nameWithOwner}",
-
-	// An array of team names identifying Bitbucket Cloud teams whose repositories should be mirrored on Sourcegraph.
-	"teams": null,
-	// Other example values:
-	// - ["name"]
-	// - [
-	//     "kubernetes",
-	//     "golang",
-	//     "facebook"
-	//   ]
-
-	// URL of Bitbucket Cloud, such as https://bitbucket.org. Generally, admin should not modify the value of this option because Bitbucket Cloud is a public hosting platform.
-	"url": null,
-	// Other example values:
-	// - "https://bitbucket.org"
-
-	// The username to use when authenticating to the Bitbucket Cloud. Also set the corresponding "appPassword" field.
-	"username": null,
-
-	// A shared secret used to authenticate incoming webhooks (minimum 12 characters).
-	"webhookSecret": null
+	"required": [
+		"url"
+	],
+	"title": "BitbucketCloudConnection",
+	"type": "object"
 }
 ```
 {/* SCHEMA_SYNC_END: admin/code_hosts/bitbucket_cloud.schema.json */}
-
 ## Configuration Notes
 
 Bitbucket Cloud connections provide streamlined configuration for cloud-hosted repositories:

--- a/docs/admin/code_hosts/bitbucket_server.mdx
+++ b/docs/admin/code_hosts/bitbucket_server.mdx
@@ -209,129 +209,393 @@ Bitbucket Server / Bitbucket Data Center connections support the following confi
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/bitbucket_server.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T19:22:24Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
-	// If non-null, enforces Bitbucket Server / Bitbucket Data Center repository permissions.
-	"authorization": null,
-
-	// TLS certificate of the Bitbucket Server / Bitbucket Data Center instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
-	"certificate": null,
-	// Other example values:
-	// - "-----BEGIN CERTIFICATE-----\n..."
-
-	// A list of repositories to never mirror from this Bitbucket Server / Bitbucket Data Center instance. Takes precedence over "repos" and "repositoryQuery".
-	//
-	// Supports excluding by name ({"name": "projectKey/repositorySlug"}) or by ID ({"id": 42}).
-	"exclude": null,
-	// Other example values:
-	// - [
-	//     {
-	//       "name": "myproject/myrepo"
-	//     },
-	//     {
-	//       "id": 42
-	//     }
-	//   ]
-	// - [
-	//     {
-	//       "name": "myproject/myrepo"
-	//     },
-	//     {
-	//       "name": "myproject/myotherrepo"
-	//     },
-	//     {
-	//       "name": "~USER/theirrepo"
-	//     },
-	//     {
-	//       "pattern": "^topsecretproject/.*"
-	//     }
-	//   ]
-
-	// Whether or not personal repositories should be excluded or not. When true, Sourcegraph will ignore personal repositories it may have access to. See https://sourcegraph.com/docs/integration/bitbucket_server#excluding-personal-repositories for more information.
-	"excludePersonalRepositories": false,
-
-	// The type of Git URLs to use for cloning and fetching Git repositories on this Bitbucket Server / Bitbucket Data Center instance.
-	//
-	// If "http", Sourcegraph will access Bitbucket Server / Bitbucket Data Center repositories using Git URLs of the form http(s)://bitbucket.example.com/scm/myproject/myrepo.git (using https: if the Bitbucket Server / Bitbucket Data Center instance uses HTTPS).
-	//
-	// If "ssh", Sourcegraph will access Bitbucket Server / Bitbucket Data Center repositories using Git URLs of the form ssh://git@example.bitbucket.org/myproject/myrepo.git. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.
-	"gitURLType": "http",
-	// Other example values:
-	// - "ssh"
-
-	// Deprecated and ignored field which will be removed entirely in the next release. BitBucket repositories can no longer be enabled or disabled explicitly.
-	"initialRepositoryEnablement": false,
-
-	// The password to use when authenticating to the Bitbucket Server / Bitbucket Data Center instance. Also set the corresponding "username" field.
-	//
-	// For Bitbucket Server / Bitbucket Data Center instances that support personal access tokens (Bitbucket Server / Bitbucket Data Center version 5.5 and newer), it is recommended to provide a token instead (in the "token" field).
-	"password": null,
-
-	// Configuration for Bitbucket Server / Bitbucket Data Center Sourcegraph plugin
-	"plugin": null,
-
-	// An array of project key strings that defines a collection of repositories related to their associated project keys
-	"projectKeys": null,
-
-	// Rate limit applied when making background API requests to BitbucketServer.
-	"rateLimit": {
-		"enabled": true,
-		"requestsPerHour": 28800
+	"$id": "bitbucket_server.schema.json#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": false,
+	"allowComments": true,
+	"definitions": {
+		"UsernameIdentity": {
+			"additionalProperties": false,
+			"properties": {
+				"type": {
+					"const": "username",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type"
+			],
+			"title": "BitbucketServerUsernameIdentity",
+			"type": "object"
+		}
 	},
-
-	// An array of repository "projectKey/repositorySlug" strings specifying repositories to mirror on Sourcegraph.
-	"repos": null,
-	// Other example values:
-	// - [
-	//     "myproject/myrepo",
-	//     "myproject/myotherrepo",
-	//     "~USER/theirrepo"
-	//   ]
-
-	// The pattern used to generate the corresponding Sourcegraph repository name for a Bitbucket Server / Bitbucket Data Center repository.
-	//
-	//  - "{host}" is replaced with the Bitbucket Server / Bitbucket Data Center URL's host (such as bitbucket.example.com)
-	//  - "{projectKey}" is replaced with the Bitbucket repository's parent project key (such as "PRJ")
-	//  - "{repositorySlug}" is replaced with the Bitbucket repository's slug key (such as "my-repo").
-	//
-	// For example, if your Bitbucket Server / Bitbucket Data Center is https://bitbucket.example.com and your Sourcegraph is https://src.example.com, then a repositoryPathPattern of "{host}/{projectKey}/{repositorySlug}" would mean that a Bitbucket Server / Bitbucket Data Center repository at https://bitbucket.example.com/projects/PRJ/repos/my-repo is available on Sourcegraph at https://src.example.com/bitbucket.example.com/PRJ/my-repo.
-	//
-	// It is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.
-	"repositoryPathPattern": "{host}/{projectKey}/{repositorySlug}",
-	// Other example values:
-	// - "{projectKey}/{repositorySlug}"
-
-	// An array of strings specifying which repositories to mirror on Sourcegraph. Each string is a URL query string with parameters that filter the list of returned repos. Examples: "?name=my-repo&projectname=PROJECT&visibility=private".
-	//
-	// The special string "none" can be used as the only element to disable this feature. Repositories matched by multiple query strings are only imported once. Here's the official Bitbucket Server / Bitbucket Data Center documentation about which query string parameters are valid: https://docs.atlassian.com/bitbucket-server/rest/6.1.2/bitbucket-rest.html#idp355
-	"repositoryQuery": [
-		"none"
+	"description": "Configuration for a connection to Bitbucket Server / Bitbucket Data Center.",
+	"oneOf": [
+		{
+			"properties": {
+				"password": {
+					"type": "null"
+				}
+			},
+			"required": [
+				"token"
+			]
+		},
+		{
+			"properties": {
+				"token": {
+					"type": "null"
+				}
+			},
+			"required": [
+				"password"
+			]
+		}
 	],
-	// Other example values:
-	// - [
-	//     "?name=my-repo\u0026projectname=PROJECT\u0026visibility=private"
-	//   ]
-
-	// A Bitbucket Server / Bitbucket Data Center personal access token with Read permissions. When using batch changes, the token needs Write permissions. Create one at https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add. Also set the corresponding "username" field.
-	//
-	// For Bitbucket Server / Bitbucket Data Center instances that don't support personal access tokens (Bitbucket Server / Bitbucket Data Center version 5.4 and older), specify user-password credentials in the "username" and "password" fields.
-	"token": null,
-
-	// URL of a Bitbucket Server / Bitbucket Data Center instance, such as https://bitbucket.example.com.
-	"url": null,
-	// Other example values:
-	// - "https://bitbucket.example.com"
-
-	// The username to use when authenticating to the Bitbucket Server / Bitbucket Data Center instance. Also set the corresponding "token" or "password" field.
-	"username": null,
-
-	// DEPRECATED: Switch to "plugin.webhooks"
-	"webhooks": null
+	"properties": {
+		"authorization": {
+			"additionalProperties": false,
+			"description": "If non-null, enforces Bitbucket Server / Bitbucket Data Center repository permissions.",
+			"oneOf": [
+				{
+					"required": [
+						"identityProvider",
+						"oauth"
+					]
+				},
+				{
+					"required": [
+						"oauth2"
+					]
+				}
+			],
+			"properties": {
+				"identityProvider": {
+					"!go": {
+						"taggedUnionType": true
+					},
+					"description": "The source of identity to use when computing permissions. This defines how to compute the Bitbucket Server / Bitbucket Data Center identity to use for a given Sourcegraph user. When 'username' is used, Sourcegraph assumes usernames are identical in Sourcegraph and Bitbucket Server / Bitbucket Data Center accounts and `auth.enableUsernameChanges` must be set to false for security reasons.",
+					"oneOf": [
+						{
+							"$ref": "#/definitions/UsernameIdentity"
+						}
+					],
+					"properties": {
+						"type": {
+							"enum": [
+								"username"
+							],
+							"type": "string"
+						}
+					},
+					"required": [
+						"type"
+					],
+					"title": "BitbucketServerIdentityProvider",
+					"type": "object"
+				},
+				"oauth": {
+					"additionalProperties": false,
+					"description": "OAuth configuration specified when creating the Bitbucket Server / Bitbucket Data Center Application Link with incoming authentication. Two Legged OAuth with 'ExecuteAs=admin' must be enabled as well as user impersonation.",
+					"properties": {
+						"consumerKey": {
+							"description": "The OAuth consumer key specified when creating the Bitbucket Server / Bitbucket Data Center Application Link with incoming authentication.",
+							"minLength": 1,
+							"type": "string"
+						},
+						"signingKey": {
+							"description": "Base64 encoding of the OAuth PEM encoded RSA private key used to generate the public key specified when creating the Bitbucket Server / Bitbucket Data Center Application Link with incoming authentication.",
+							"minLength": 1,
+							"type": "string"
+						}
+					},
+					"required": [
+						"consumerKey",
+						"signingKey"
+					],
+					"title": "BitbucketServerOAuth",
+					"type": "object"
+				},
+				"oauth2": {
+					"type": "boolean"
+				}
+			},
+			"title": "BitbucketServerAuthorization",
+			"type": "object"
+		},
+		"certificate": {
+			"description": "TLS certificate of the Bitbucket Server / Bitbucket Data Center instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run `openssl s_client -connect HOST:443 -showcerts \u003c /dev/null 2\u003e /dev/null | openssl x509 -outform PEM`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.",
+			"examples": [
+				"-----BEGIN CERTIFICATE-----\n..."
+			],
+			"pattern": "^-----BEGIN CERTIFICATE-----\n",
+			"type": "string"
+		},
+		"exclude": {
+			"description": "A list of repositories to never mirror from this Bitbucket Server / Bitbucket Data Center instance. Takes precedence over \"repos\" and \"repositoryQuery\".\n\nSupports excluding by name ({\"name\": \"projectKey/repositorySlug\"}) or by ID ({\"id\": 42}).",
+			"examples": [
+				[
+					{
+						"name": "myproject/myrepo"
+					},
+					{
+						"id": 42
+					}
+				],
+				[
+					{
+						"name": "myproject/myrepo"
+					},
+					{
+						"name": "myproject/myotherrepo"
+					},
+					{
+						"name": "~USER/theirrepo"
+					},
+					{
+						"pattern": "^topsecretproject/.*"
+					}
+				]
+			],
+			"items": {
+				"additionalProperties": false,
+				"anyOf": [
+					{
+						"required": [
+							"name"
+						]
+					},
+					{
+						"required": [
+							"id"
+						]
+					},
+					{
+						"required": [
+							"pattern"
+						]
+					}
+				],
+				"properties": {
+					"id": {
+						"description": "The ID of a Bitbucket Server / Bitbucket Data Center repo (as returned by the Bitbucket Server / Bitbucket Data Center instance's API) to exclude from mirroring.",
+						"type": "integer"
+					},
+					"name": {
+						"description": "The name of a Bitbucket Server / Bitbucket Data Center repo (\"projectKey/repositorySlug\") to exclude from mirroring.",
+						"pattern": "^~?[\\w-]+/[\\w.-]+$",
+						"type": "string"
+					},
+					"pattern": {
+						"description": "Regular expression which matches against the name of a Bitbucket Server / Bitbucket Data Center repo.",
+						"format": "regex",
+						"type": "string"
+					}
+				},
+				"title": "ExcludedBitbucketServerRepo",
+				"type": "object"
+			},
+			"minItems": 1,
+			"type": "array"
+		},
+		"excludePersonalRepositories": {
+			"default": false,
+			"description": "Whether or not personal repositories should be excluded or not. When true, Sourcegraph will ignore personal repositories it may have access to. See https://sourcegraph.com/docs/integration/bitbucket_server#excluding-personal-repositories for more information.",
+			"type": "boolean"
+		},
+		"gitSSHCipher": {
+			"$ref": "git.schema.json#/definitions/gitSSHCipher",
+			"description": "SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`."
+		},
+		"gitSSHCredential": {
+			"$ref": "git.schema.json#/definitions/gitSSHCredential",
+			"description": "SSH keys to use when cloning Git repo."
+		},
+		"gitURLType": {
+			"default": "http",
+			"description": "The type of Git URLs to use for cloning and fetching Git repositories on this Bitbucket Server / Bitbucket Data Center instance.\n\nIf \"http\", Sourcegraph will access Bitbucket Server / Bitbucket Data Center repositories using Git URLs of the form http(s)://bitbucket.example.com/scm/myproject/myrepo.git (using https: if the Bitbucket Server / Bitbucket Data Center instance uses HTTPS).\n\nIf \"ssh\", Sourcegraph will access Bitbucket Server / Bitbucket Data Center repositories using Git URLs of the form ssh://git@example.bitbucket.org/myproject/myrepo.git. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth.",
+			"enum": [
+				"http",
+				"ssh"
+			],
+			"examples": [
+				"ssh"
+			],
+			"type": "string"
+		},
+		"initialRepositoryEnablement": {
+			"default": false,
+			"description": "Deprecated and ignored field which will be removed entirely in the next release. BitBucket repositories can no longer be enabled or disabled explicitly.",
+			"type": "boolean"
+		},
+		"maxDeletions": {
+			"default": 0,
+			"description": "The maximum number of repos that will be deleted per sync. A value of 0 or less indicates no maximum.",
+			"type": "integer"
+		},
+		"password": {
+			"description": "The password to use when authenticating to the Bitbucket Server / Bitbucket Data Center instance. Also set the corresponding \"username\" field.\n\nFor Bitbucket Server / Bitbucket Data Center instances that support personal access tokens (Bitbucket Server / Bitbucket Data Center version 5.5 and newer), it is recommended to provide a token instead (in the \"token\" field).",
+			"type": "string"
+		},
+		"plugin": {
+			"description": "Configuration for Bitbucket Server / Bitbucket Data Center Sourcegraph plugin",
+			"properties": {
+				"permissions": {
+					"default": "disabled",
+					"description": "Enables fetching Bitbucket Server / Bitbucket Data Center permissions through the roaring bitmap endpoint. Warning: there may be performance degradation under significant load.",
+					"enum": [
+						"enabled",
+						"disabled"
+					],
+					"type": "string"
+				},
+				"webhooks": {
+					"deprecationMessage": "Deprecated in favour of first class webhooks. See https://sourcegraph.com/docs/admin/config/webhooks/incoming#deprecation-notice",
+					"properties": {
+						"disableSync": {
+							"default": false,
+							"description": "Disallow Sourcegraph from automatically syncing webhook config with the Bitbucket Server / Bitbucket Data Center instance. For details of how the webhook is configured, see our docs: https://sourcegraph.com/docs/admin/code_hosts/bitbucket_server#webhooks",
+							"type": "boolean"
+						},
+						"secret": {
+							"description": "Secret for authenticating incoming webhook payloads",
+							"minLength": 1,
+							"type": "string"
+						}
+					},
+					"required": [
+						"secret"
+					],
+					"title": "BitbucketServerPluginWebhooks",
+					"type": "object"
+				}
+			},
+			"title": "BitbucketServerPlugin",
+			"type": "object"
+		},
+		"projectKeys": {
+			"description": "An array of project key strings that defines a collection of repositories related to their associated project keys",
+			"items": {
+				"type": "string"
+			},
+			"type": "array"
+		},
+		"rateLimit": {
+			"default": {
+				"enabled": true,
+				"requestsPerHour": 28800
+			},
+			"description": "Rate limit applied when making background API requests to BitbucketServer.",
+			"properties": {
+				"enabled": {
+					"default": true,
+					"description": "true if rate limiting is enabled.",
+					"type": "boolean"
+				},
+				"requestsPerHour": {
+					"default": 28800,
+					"description": "Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 500, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 500 requests immediately, provided that the complexity cost of each request is 1.",
+					"minimum": 0,
+					"type": "number"
+				}
+			},
+			"required": [
+				"enabled",
+				"requestsPerHour"
+			],
+			"title": "BitbucketServerRateLimit",
+			"type": "object"
+		},
+		"repos": {
+			"description": "An array of repository \"projectKey/repositorySlug\" strings specifying repositories to mirror on Sourcegraph.",
+			"examples": [
+				[
+					"myproject/myrepo",
+					"myproject/myotherrepo",
+					"~USER/theirrepo"
+				]
+			],
+			"items": {
+				"pattern": "^~?[\\w-]+/[\\w.-]+$",
+				"type": "string"
+			},
+			"minItems": 1,
+			"type": "array"
+		},
+		"repositoryPathPattern": {
+			"default": "{host}/{projectKey}/{repositorySlug}",
+			"description": "The pattern used to generate the corresponding Sourcegraph repository name for a Bitbucket Server / Bitbucket Data Center repository.\n\n - \"{host}\" is replaced with the Bitbucket Server / Bitbucket Data Center URL's host (such as bitbucket.example.com)\n - \"{projectKey}\" is replaced with the Bitbucket repository's parent project key (such as \"PRJ\")\n - \"{repositorySlug}\" is replaced with the Bitbucket repository's slug key (such as \"my-repo\").\n\nFor example, if your Bitbucket Server / Bitbucket Data Center is https://bitbucket.example.com and your Sourcegraph is https://src.example.com, then a repositoryPathPattern of \"{host}/{projectKey}/{repositorySlug}\" would mean that a Bitbucket Server / Bitbucket Data Center repository at https://bitbucket.example.com/projects/PRJ/repos/my-repo is available on Sourcegraph at https://src.example.com/bitbucket.example.com/PRJ/my-repo.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.",
+			"examples": [
+				"{projectKey}/{repositorySlug}"
+			],
+			"type": "string"
+		},
+		"repositoryQuery": {
+			"default": [
+				"none"
+			],
+			"description": "An array of strings specifying which repositories to mirror on Sourcegraph. Each string is a URL query string with parameters that filter the list of returned repos. Examples: \"?name=my-repo\u0026projectname=PROJECT\u0026visibility=private\".\n\nThe special string \"none\" can be used as the only element to disable this feature. Repositories matched by multiple query strings are only imported once. Here's the official Bitbucket Server / Bitbucket Data Center documentation about which query string parameters are valid: https://docs.atlassian.com/bitbucket-server/rest/6.1.2/bitbucket-rest.html#idp355",
+			"examples": [
+				[
+					"?name=my-repo\u0026projectname=PROJECT\u0026visibility=private"
+				]
+			],
+			"items": {
+				"minLength": 1,
+				"type": "string"
+			},
+			"minItems": 1,
+			"type": "array"
+		},
+		"token": {
+			"description": "A Bitbucket Server / Bitbucket Data Center personal access token with Read permissions. When using batch changes, the token needs Write permissions. Create one at https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add. Also set the corresponding \"username\" field.\n\nFor Bitbucket Server / Bitbucket Data Center instances that don't support personal access tokens (Bitbucket Server / Bitbucket Data Center version 5.4 and older), specify user-password credentials in the \"username\" and \"password\" fields.",
+			"minLength": 1,
+			"type": "string"
+		},
+		"url": {
+			"!go": {
+				"typeName": "NormalizedURL"
+			},
+			"description": "URL of a Bitbucket Server / Bitbucket Data Center instance, such as https://bitbucket.example.com.",
+			"examples": [
+				"https://bitbucket.example.com"
+			],
+			"format": "uri",
+			"not": {
+				"pattern": "example\\.com",
+				"type": "string"
+			},
+			"pattern": "^https?://",
+			"type": "string"
+		},
+		"username": {
+			"description": "The username to use when authenticating to the Bitbucket Server / Bitbucket Data Center instance. Also set the corresponding \"token\" or \"password\" field.",
+			"type": "string"
+		},
+		"webhooks": {
+			"description": "DEPRECATED: Switch to \"plugin.webhooks\"",
+			"properties": {
+				"secret": {
+					"description": "Secret for authenticating incoming webhook payloads",
+					"minLength": 1,
+					"type": "string"
+				}
+			},
+			"type": "object"
+		}
+	},
+	"required": [
+		"username",
+		"url"
+	],
+	"title": "BitbucketServerConnection",
+	"type": "object"
 }
 ```
 {/* SCHEMA_SYNC_END: admin/code_hosts/bitbucket_server.schema.json */}
-
 ## Configuration Notes
 
 Bitbucket Server/Data Center connections provide comprehensive configuration options for enterprise environments:

--- a/docs/admin/code_hosts/gerrit.mdx
+++ b/docs/admin/code_hosts/gerrit.mdx
@@ -110,51 +110,145 @@ Gerrit connections support the following configuration options, which are specif
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/gerrit.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T19:22:28Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
-	// If non-null, enforces Gerrit repository permissions. This requires that there is an item in the [site configuration json](https://sourcegraph.com/docs/admin/config/site_config#auth-providers) `auth.providers` field, of type "gerrit" with the same `url` field as specified in this `GerritConnection`.
-	"authorization": null,
-
-	// The password associated with the Gerrit username used for authentication.
-	"password": null,
-
-	// An array of project strings specifying which Gerrit projects to mirror on Sourcegraph. If empty, all projects will be mirrored.
-	"projects": null,
-	// Other example values:
-	// - ["name","owner/name"]
-	// - [
-	//     "docs",
-	//     "kubernetes/kubernetes",
-	//     "golang/go",
-	//     "facebook/react"
-	//   ]
-
-	// A list of repositories to never mirror from this Gerrit instance. Takes precedence over \"projects\" configuration.
-	//
-	// Supports excluding by name ({"name": "owner/name"})
-	"exclude": null,
-	// Other example values:
-	// - [
-	//     {
-	//       "name": "docs"
-	//     },
-	//     {
-	//       "name": "php/php-src"
-	//     }
-	//   ]
-
-	// URL of a Gerrit instance, such as https://gerrit.example.com.
-	"url": null,
-	// Other example values:
-	// - "https://gerrit.example.com"
-
-	// A username for authentication withe the Gerrit code host.
-	"username": null
+	"$id": "gerrit.schema.json#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": false,
+	"allowComments": true,
+	"description": "Configuration for a connection to Gerrit.",
+	"properties": {
+		"authorization": {
+			"description": "If non-null, enforces Gerrit repository permissions. This requires that there is an item in the [site configuration json](https://sourcegraph.com/docs/admin/config/site_config#auth-providers) `auth.providers` field, of type \"gerrit\" with the same `url` field as specified in this `GerritConnection`.",
+			"properties": {
+				"identityProvider": {
+					"description": "The identity provider to use for user information. If not set, the `url` field is used.",
+					"type": "string"
+				}
+			},
+			"title": "GerritAuthorization",
+			"type": "object"
+		},
+		"exclude": {
+			"description": "A list of repositories to never mirror from this Gerrit instance. Takes precedence over \"projects\" configuration.\n\nSupports excluding by name ({\"name\": \"owner/name\"})",
+			"examples": [
+				[
+					{
+						"name": "docs"
+					},
+					{
+						"name": "php/php-src"
+					}
+				]
+			],
+			"items": {
+				"additionalProperties": false,
+				"anyOf": [
+					{
+						"required": [
+							"name"
+						]
+					}
+				],
+				"properties": {
+					"name": {
+						"description": "The name of a Gerrit project to exclude from mirroring.",
+						"type": "string"
+					}
+				},
+				"title": "ExcludedGerritProject",
+				"type": "object"
+			},
+			"minItems": 1,
+			"type": "array"
+		},
+		"gitSSHCipher": {
+			"$ref": "git.schema.json#/definitions/gitSSHCipher",
+			"description": "SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`."
+		},
+		"gitSSHCredential": {
+			"$ref": "git.schema.json#/definitions/gitSSHCredential",
+			"description": "SSH keys to use when cloning Git repo."
+		},
+		"gitURLType": {
+			"default": "http",
+			"description": "The type of Git URLs to use for cloning and fetching Git repositories on this Gerrit instance.\n\nIf \"http\", Sourcegraph will access Gerrit repositories using Git URLs of the form http(s)://gerrit.example.com/a/myteam/myproject.git (using https: if the Gerrit instance uses HTTPS).\n\nIf \"ssh\", Sourcegraph will access Gerrit repositories using Git URLs of the form git@gerrit.example.com:myteam/myproject.git. The exact hostname and port will be fetched from /ssh_info. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth.",
+			"enum": [
+				"http",
+				"ssh"
+			],
+			"type": "string"
+		},
+		"password": {
+			"description": "The password associated with the Gerrit username used for authentication.",
+			"minLength": 1,
+			"type": "string"
+		},
+		"projectQuery": {
+			"description": "Any number of query parameters as supported by the Gerrit REST API: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html",
+			"examples": [
+				"query=name:kubernetes",
+				"r=.*test"
+			],
+			"type": "string"
+		},
+		"projects": {
+			"description": "An array of project strings specifying which Gerrit projects to mirror on Sourcegraph. If empty, all projects will be mirrored.",
+			"examples": [
+				[
+					"name",
+					"owner/name"
+				],
+				[
+					"docs",
+					"kubernetes/kubernetes",
+					"golang/go",
+					"facebook/react"
+				]
+			],
+			"items": {
+				"type": "string"
+			},
+			"type": "array"
+		},
+		"repositoryPathPattern": {
+			"default": "{host}/{name}",
+			"description": "The pattern used to generate the corresponding Sourcegraph repository name for a Gerrit repository. In the pattern, the variable \"{host}\" is replaced with the Gerrit host (such as gerrit.example.com), and \"{name}\" is replaced with the Gerrit repository's name (such as \"myrepo\").\n\nFor example, if your Gerrit URL is https://gerrit.example.com and your Sourcegraph URL is https://src.example.com, then a repositoryPathPattern of \"{host}/{name}\" would mean that a Gerrit repository at https://gerrit.example.com/myrepo is available on Sourcegraph at https://src.example.com/gerrit.example.com/myrepo.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.",
+			"type": "string"
+		},
+		"url": {
+			"!go": {
+				"typeName": "NormalizedURL"
+			},
+			"description": "URL of a Gerrit instance, such as https://gerrit.example.com.",
+			"examples": [
+				"https://gerrit.example.com"
+			],
+			"format": "uri",
+			"not": {
+				"pattern": "example\\.com",
+				"type": "string"
+			},
+			"pattern": "^https?://",
+			"type": "string"
+		},
+		"username": {
+			"description": "A username for authentication with the Gerrit code host.",
+			"minLength": 1,
+			"type": "string"
+		}
+	},
+	"required": [
+		"url",
+		"username",
+		"password"
+	],
+	"title": "GerritConnection",
+	"type": "object"
 }
 ```
 {/* SCHEMA_SYNC_END: admin/code_hosts/gerrit.schema.json */}
-
 ## Configuration Notes
 
 ### HTTP Credentials Setup

--- a/docs/admin/code_hosts/github.mdx
+++ b/docs/admin/code_hosts/github.mdx
@@ -447,153 +447,444 @@ GitHub connections support the following configuration options, which are specif
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/github.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T19:22:22Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
-	// If non-null, enforces GitHub repository permissions. This requires that there is an item in the [site configuration json](https://sourcegraph.com/docs/admin/config/site_config#auth-providers) `auth.providers` field, of type "github" with the same `url` field as specified in this `GitHubConnection`.
-	"authorization": null,
-
-	// TLS certificate of the GitHub Enterprise instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
-	"certificate": null,
-	// Other example values:
-	// - "-----BEGIN CERTIFICATE-----\n..."
-
-	// Only used to override the cloud_default column from a config file specified by EXTSVC_CONFIG_FILE
-	"cloudDefault": false,
-
-	// When set to true, this external service will be chosen as our 'Global' GitHub service. Only valid on Sourcegraph.com. Only one service can have this flag set.
-	"cloudGlobal": false,
-
-	// A list of repositories to never mirror from this GitHub instance. Takes precedence over "orgs", "repos", and "repositoryQuery" configuration.
-	//
-	// Supports excluding by name ({"name": "owner/name"}) or by ID ({"id": "MDEwOlJlcG9zaXRvcnkxMTczMDM0Mg=="}).
-	//
-	// Note: ID is the GitHub GraphQL ID, not the GitHub database ID. eg: "curl https://api.github.com/repos/vuejs/vue | jq .node_id"
-	"exclude": null,
-	// Other example values:
-	// - [{"forks":true}]
-	// - [
-	//     {
-	//       "name": "owner/name"
-	//     },
-	//     {
-	//       "id": "MDEwOlJlcG9zaXRvcnkxMTczMDM0Mg=="
-	//     }
-	//   ]
-	// - [
-	//     {
-	//       "name": "vuejs/vue"
-	//     },
-	//     {
-	//       "name": "php/php-src"
-	//     },
-	//     {
-	//       "pattern": "^topsecretorg/.*"
-	//     }
-	//   ]
-	// - [
-	//     {
-	//       "size": "\u003e= 1GB",
-	//       "stars": "\u003c 100"
-	//     }
-	//   ]
-
-	// If non-null, this is a GitHub App connection with some additional properties.
-	"gitHubAppDetails": null,
-
-	// The type of Git URLs to use for cloning and fetching Git repositories on this GitHub instance.
-	//
-	// If "http", Sourcegraph will access GitHub repositories using Git URLs of the form http(s)://github.com/myteam/myproject.git (using https: if the GitHub instance uses HTTPS).
-	//
-	// If "ssh", Sourcegraph will access GitHub repositories using Git URLs of the form git@github.com:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.
-	"gitURLType": "http",
-
-	// DEPRECATED: The installation ID of the GitHub App.
-	"githubAppInstallationID": null,
-
-	// Deprecated and ignored field which will be removed entirely in the next release. GitHub repositories can no longer be enabled or disabled explicitly. Configure repositories to be mirrored via "repos", "exclude" and "repositoryQuery" instead.
-	"initialRepositoryEnablement": null,
-
-	// An array of organization names identifying GitHub organizations whose repositories should be mirrored on Sourcegraph.
-	"orgs": null,
-	// Other example values:
-	// - ["name"]
-	// - [
-	//     "kubernetes",
-	//     "golang",
-	//     "facebook"
-	//   ]
-
-	// Whether the code host connection is in a pending state.
-	"pending": false,
-
-	// Rate limit applied when making background API requests to GitHub.
-	"rateLimit": {
-		"enabled": true,
-		"requestsPerHour": 5000
-	},
-
-	// An array of repository "owner/name" strings specifying which GitHub or GitHub Enterprise repositories to mirror on Sourcegraph.
-	"repos": null,
-	// Other example values:
-	// - ["owner/name"]
-	// - [
-	//     "kubernetes/kubernetes",
-	//     "golang/go",
-	//     "facebook/react"
-	//   ]
-
-	// The pattern used to generate the corresponding Sourcegraph repository name for a GitHub or GitHub Enterprise repository. In the pattern, the variable "{host}" is replaced with the GitHub host (such as github.example.com), and "{nameWithOwner}" is replaced with the GitHub repository's "owner/path" (such as "myorg/myrepo").
-	//
-	// For example, if your GitHub Enterprise URL is https://github.example.com and your Sourcegraph URL is https://src.example.com, then a repositoryPathPattern of "{host}/{nameWithOwner}" would mean that a GitHub repository at https://github.example.com/myorg/myrepo is available on Sourcegraph at https://src.example.com/github.example.com/myorg/myrepo.
-	//
-	// It is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.
-	"repositoryPathPattern": "{host}/{nameWithOwner}",
-
-	// An array of strings specifying which GitHub or GitHub Enterprise repositories to mirror on Sourcegraph. The valid values are:
-	//
-	// - `public` mirrors all public repositories for GitHub Enterprise and is the equivalent of `none` for GitHub
-	//
-	// - `internal` mirrors all internal repositories for GitHub Enterprise and is the equivalent of `none` for GitHub
-	//
-	// - `affiliated` mirrors all repositories affiliated with the configured token's user:
-	// 	- Private repositories with read access
-	// 	- Public repositories owned by the user or their orgs
-	// 	- Public repositories with write access
-	//
-	// - `none` mirrors no repositories (except those specified in the `repos` configuration property or added manually)
-	//
-	// - All other values are executed as a GitHub advanced repository search as described at https://github.com/search/advanced. Example: to sync all repositories from the "sourcegraph" organization including forks the query would be "org:sourcegraph fork:true".
-	//
-	// If multiple values are provided, their results are unioned.
-	//
-	// If you need to narrow the set of mirrored repositories further (and don't want to enumerate it with a list or query set as above), create a new bot/machine user on GitHub or GitHub Enterprise that is only affiliated with the desired repositories.
-	"repositoryQuery": [
-		"none"
+	"$id": "github.schema.json#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": false,
+	"allowComments": true,
+	"description": "Configuration for a connection to GitHub or GitHub Enterprise.",
+	"oneOf": [
+		{
+			"required": [
+				"token"
+			]
+		},
+		{
+			"required": [
+				"gitHubAppDetails"
+			]
+		},
+		{
+			"required": [
+				"externalAccount"
+			]
+		},
+		{
+			"required": [
+				"useRandomExternalAccount"
+			]
+		},
+		{
+			"not": {
+				"anyOf": [
+					{
+						"required": [
+							"token"
+						]
+					},
+					{
+						"required": [
+							"gitHubAppDetails"
+						]
+					},
+					{
+						"required": [
+							"externalAccount"
+						]
+					},
+					{
+						"required": [
+							"useRandomExternalAccount"
+						]
+					}
+				]
+			}
+		}
 	],
-
-	// A GitHub personal access token. Create one for GitHub.com at https://github.com/settings/tokens/new?description=Sourcegraph (for GitHub Enterprise, replace github.com with your instance's hostname). See https://sourcegraph.com/docs/admin/code_host_connection/github#github-api-token-and-access for which scopes are required for which use cases.
-	"token": null,
-
-	// URL of a GitHub instance, such as https://github.com or https://github-enterprise.example.com.
-	"url": null,
-	// Other example values:
-	// - "https://github.com"
-	// - "https://github-enterprise.example.com"
-
-	// An array of configurations defining existing GitHub webhooks that send updates back to Sourcegraph.
-	"webhooks": null
-	// Other example values:
-	// - [
-	//     {
-	//       "org": "yourorgname",
-	//       "secret": "webhook-secret"
-	//     }
-	//   ]
+	"properties": {
+		"authorization": {
+			"description": "If non-null, enforces GitHub repository permissions. This requires that there is an item in the [site configuration json](https://sourcegraph.com/docs/admin/config/site_config#auth-providers) `auth.providers` field, of type \"github\" with the same `url` field as specified in this `GitHubConnection`.",
+			"properties": {
+				"groupsCacheTTL": {
+					"default": 72,
+					"description": "Experimental: If set, configures hours cached permissions from teams and organizations should be kept for. Setting a negative value disables syncing from teams and organizations, and falls back to the default behaviour of syncing all permisisons directly from user-repository affiliations instead. [Learn more](https://sourcegraph.com/docs/admin/code_hosts/github#teams-and-organizations-permissions-caching).",
+					"type": "number"
+				},
+				"markInternalReposAsPublic": {
+					"default": false,
+					"description": "If true, internal repositories will be accessible to all users on Sourcegraph as if they were public. This overrides repository permissions but allows easier discovery and access to internal repositories, and may be desirable if all users on the Sourcegraph instance should have access to all internal repositories anyways. Defaults to false.",
+					"type": "boolean"
+				},
+				"syncInternalRepoPermissions": {
+					"default": false,
+					"description": "If true, access to internal repositories will be synced as part of user permission syncs. This can lead to slower user permission syncs for organizations with many internal repositories. Defaults to false.",
+					"type": "boolean"
+				}
+			},
+			"title": "GitHubAuthorization",
+			"type": "object"
+		},
+		"certificate": {
+			"description": "TLS certificate of the GitHub Enterprise instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run `openssl s_client -connect HOST:443 -showcerts \u003c /dev/null 2\u003e /dev/null | openssl x509 -outform PEM`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.",
+			"examples": [
+				"-----BEGIN CERTIFICATE-----\n..."
+			],
+			"pattern": "^-----BEGIN CERTIFICATE-----\n",
+			"type": "string"
+		},
+		"exclude": {
+			"description": "A list of repository entries that define which repositories to never mirror from this GitHub instance. Takes precedence over \"orgs\", \"repos\", and \"repositoryQuery\" configuration.\n\nEach entry in the list can be either a name ({\"name\": \"owner/name\"}), an ID ({\"id\": \"MDEwOlJlcG9zaXRvcnkxMTczMDM0Mg==\"}), or a set of conditions like pattern, size, stars, etc. If multiple conditions are specified within a single entry, ALL of those conditions must be met for a repository to be excluded (AND). If multiple entries exist in the exclude list, a repository matching ANY of the entries (OR) will be excluded from syncing.\n\nNote: ID is the GitHub GraphQL ID, not the GitHub database ID. eg: \"curl https://api.github.com/repos/vuejs/vue | jq .node_id\"",
+			"examples": [
+				[
+					{
+						"forks": true
+					}
+				],
+				[
+					{
+						"name": "owner/name"
+					},
+					{
+						"id": "MDEwOlJlcG9zaXRvcnkxMTczMDM0Mg=="
+					}
+				],
+				[
+					{
+						"name": "vuejs/vue"
+					},
+					{
+						"name": "php/php-src"
+					},
+					{
+						"pattern": "^topsecretorg/.*"
+					}
+				],
+				[
+					{
+						"size": "\u003e= 1GB",
+						"stars": "\u003c 100"
+					}
+				]
+			],
+			"items": {
+				"additionalProperties": false,
+				"oneOf": [
+					{
+						"anyOf": [
+							{
+								"required": [
+									"name"
+								]
+							},
+							{
+								"required": [
+									"id"
+								]
+							}
+						]
+					},
+					{
+						"anyOf": [
+							{
+								"required": [
+									"pattern"
+								]
+							},
+							{
+								"required": [
+									"forks"
+								]
+							},
+							{
+								"required": [
+									"archived"
+								]
+							},
+							{
+								"required": [
+									"stars"
+								]
+							},
+							{
+								"required": [
+									"size"
+								]
+							}
+						]
+					}
+				],
+				"properties": {
+					"archived": {
+						"description": "If set to true, archived repositories will be excluded.",
+						"type": "boolean"
+					},
+					"forks": {
+						"description": "If set to true, forks will be excluded.",
+						"type": "boolean"
+					},
+					"id": {
+						"description": "The node ID of a GitHub repository (as returned by the GitHub instance's API) to exclude from mirroring. Use this to exclude the repository, even if renamed. Note: This is the GraphQL ID, not the GitHub database ID. eg: \"curl https://api.github.com/repos/vuejs/vue | jq .node_id\"",
+						"minLength": 1,
+						"type": "string"
+					},
+					"name": {
+						"description": "The name of a GitHub repository (\"owner/name\") to exclude from mirroring.",
+						"pattern": "^[\\w-]+/[\\w.-]+$",
+						"type": "string"
+					},
+					"pattern": {
+						"description": "Regular expression which matches against the name of a GitHub repository (\"owner/name\").",
+						"format": "regex",
+						"type": "string"
+					},
+					"size": {
+						"description": "If set, repositories with a size above the specified one will be excluded.",
+						"minLength": 2,
+						"pattern": "^[\u003c\u003e]{1}[=]{0,1}\\s*\\d+\\s*\\w+$",
+						"type": "string"
+					},
+					"stars": {
+						"description": "If set, repositories stars less than the specified number will be.",
+						"minLength": 2,
+						"pattern": "^[\u003c\u003e]{1}[=]{0,1}\\s*\\d+$",
+						"type": "string"
+					}
+				},
+				"title": "ExcludedGitHubRepo",
+				"type": "object"
+			},
+			"minItems": 1,
+			"type": "array"
+		},
+		"externalAccount": {
+			"description": "GitHub external account to use for authentication.",
+			"properties": {
+				"accountID": {
+					"description": "The ID of the account on GitHub.",
+					"type": "string"
+				},
+				"clientID": {
+					"description": "The Client ID of the OAuth app that added the account.",
+					"type": "string"
+				}
+			},
+			"required": [
+				"accountID",
+				"clientID"
+			],
+			"title": "GitHubExternalAccount",
+			"type": "object"
+		},
+		"gitHubAppDetails": {
+			"description": "If non-null, this is a GitHub App connection with some additional properties.",
+			"properties": {
+				"appID": {
+					"description": "The ID of the GitHub App.",
+					"minimum": 1,
+					"type": "integer"
+				},
+				"baseURL": {
+					"description": "The base URL of the GitHub App.",
+					"pattern": "^https?://",
+					"type": "string"
+				},
+				"cloneAllRepositories": {
+					"default": false,
+					"description": "Clone all repositories for this App installation.",
+					"type": "boolean"
+				},
+				"installationID": {
+					"description": "The installation ID of this connection.",
+					"minimum": 1,
+					"type": "integer"
+				}
+			},
+			"type": "object"
+		},
+		"gitSSHCipher": {
+			"$ref": "git.schema.json#/definitions/gitSSHCipher",
+			"description": "SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`."
+		},
+		"gitSSHCredential": {
+			"$ref": "git.schema.json#/definitions/gitSSHCredential",
+			"description": "SSH keys to use when cloning Git repo."
+		},
+		"gitURLType": {
+			"default": "http",
+			"description": "The type of Git URLs to use for cloning and fetching Git repositories on this GitHub instance.\n\nIf \"http\", Sourcegraph will access GitHub repositories using Git URLs of the form http(s)://github.com/myteam/myproject.git (using https: if the GitHub instance uses HTTPS).\n\nIf \"ssh\", Sourcegraph will access GitHub repositories using Git URLs of the form git@github.com:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth.",
+			"enum": [
+				"http",
+				"ssh"
+			],
+			"type": "string"
+		},
+		"githubAppInstallationID": {
+			"description": "DEPRECATED: The installation ID of the GitHub App.",
+			"type": "string"
+		},
+		"initialRepositoryEnablement": {
+			"description": "Deprecated and ignored field which will be removed entirely in the next release. GitHub repositories can no longer be enabled or disabled explicitly. Configure repositories to be mirrored via \"repos\", \"exclude\" and \"repositoryQuery\" instead.",
+			"type": "boolean"
+		},
+		"maxDeletions": {
+			"default": 0,
+			"description": "The maximum number of repos that will be deleted per sync. A value of 0 or less indicates no maximum.",
+			"type": "integer"
+		},
+		"orgs": {
+			"description": "An array of organization names identifying GitHub organizations whose repositories should be mirrored on Sourcegraph.",
+			"examples": [
+				[
+					"name"
+				],
+				[
+					"kubernetes",
+					"golang",
+					"facebook"
+				]
+			],
+			"items": {
+				"pattern": "^[\\w-]+$",
+				"type": "string"
+			},
+			"type": "array"
+		},
+		"pending": {
+			"default": false,
+			"description": "Whether the code host connection is in a pending state.",
+			"type": "boolean"
+		},
+		"rateLimit": {
+			"default": {
+				"enabled": true,
+				"requestsPerHour": 5000
+			},
+			"description": "Rate limit applied when making background API requests to GitHub.",
+			"properties": {
+				"enabled": {
+					"default": true,
+					"description": "true if rate limiting is enabled.",
+					"type": "boolean"
+				},
+				"requestsPerHour": {
+					"default": 5000,
+					"description": "Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.",
+					"minimum": 0,
+					"type": "number"
+				}
+			},
+			"required": [
+				"enabled",
+				"requestsPerHour"
+			],
+			"title": "GitHubRateLimit",
+			"type": "object"
+		},
+		"repos": {
+			"description": "An array of repository \"owner/name\" strings specifying which GitHub or GitHub Enterprise repositories to mirror on Sourcegraph.",
+			"examples": [
+				[
+					"owner/name"
+				],
+				[
+					"kubernetes/kubernetes",
+					"golang/go",
+					"facebook/react"
+				]
+			],
+			"items": {
+				"pattern": "^[\\w-]+/[\\w.-]+$",
+				"type": "string"
+			},
+			"type": "array"
+		},
+		"repositoryPathPattern": {
+			"default": "{host}/{nameWithOwner}",
+			"description": "The pattern used to generate the corresponding Sourcegraph repository name for a GitHub or GitHub Enterprise repository. In the pattern, the variable \"{host}\" is replaced with the GitHub host (such as github.example.com), and \"{nameWithOwner}\" is replaced with the GitHub repository's \"owner/path\" (such as \"myorg/myrepo\").\n\nFor example, if your GitHub Enterprise URL is https://github.example.com and your Sourcegraph URL is https://src.example.com, then a repositoryPathPattern of \"{host}/{nameWithOwner}\" would mean that a GitHub repository at https://github.example.com/myorg/myrepo is available on Sourcegraph at https://src.example.com/github.example.com/myorg/myrepo.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.",
+			"type": "string"
+		},
+		"repositoryQuery": {
+			"default": [
+				"none"
+			],
+			"description": "An array of strings specifying which GitHub or GitHub Enterprise repositories to mirror on Sourcegraph. The valid values are:\n\n- `public` mirrors all public repositories for GitHub Enterprise and is the equivalent of `none` for GitHub\n\n- `internal` mirrors all internal repositories for GitHub Enterprise and is the equivalent of `none` for GitHub\n\n- `affiliated` mirrors all repositories affiliated with the configured token's user:\n\t- Private repositories with read access\n\t- Public repositories owned by the user or their orgs\n\t- Public repositories with write access\n\n- `none` mirrors no repositories (except those specified in the `repos` configuration property or added manually)\n\n- All other values are executed as a GitHub advanced repository search as described at https://github.com/search/advanced. Example: to sync all repositories from the \"sourcegraph\" organization including forks the query would be \"org:sourcegraph fork:true\".\n\nIf multiple values are provided, their results are unioned.\n\nIf you need to narrow the set of mirrored repositories further (and don't want to enumerate it with a list or query set as above), create a new bot/machine user on GitHub or GitHub Enterprise that is only affiliated with the desired repositories.",
+			"items": {
+				"minLength": 1,
+				"type": "string"
+			},
+			"minItems": 1,
+			"type": "array"
+		},
+		"token": {
+			"description": "A GitHub personal access token. Create one for GitHub.com at https://github.com/settings/tokens/new?description=Sourcegraph (for GitHub Enterprise, replace github.com with your instance's hostname). See https://sourcegraph.com/docs/admin/code_hosts/github#github-api-access for which scopes are required for which use cases.",
+			"minLength": 1,
+			"type": "string"
+		},
+		"url": {
+			"!go": {
+				"typeName": "NormalizedURL"
+			},
+			"description": "URL of a GitHub instance, such as https://github.com or https://github-enterprise.example.com.",
+			"examples": [
+				"https://github.com",
+				"https://github-enterprise.example.com"
+			],
+			"format": "uri",
+			"not": {
+				"pattern": "example\\.com",
+				"type": "string"
+			},
+			"pattern": "^https?://",
+			"type": "string"
+		},
+		"useRandomExternalAccount": {
+			"description": "Use a random user external account for authentication. When set, the code host connection will only be able to add public repositories.",
+			"type": "boolean"
+		},
+		"webhooks": {
+			"deprecationMessage": "Deprecated in favour of first class webhooks. See https://sourcegraph.com/docs/admin/config/webhooks/incoming#deprecation-notice",
+			"description": "An array of configurations defining existing GitHub webhooks that send updates back to Sourcegraph.",
+			"examples": [
+				[
+					{
+						"org": "yourorgname",
+						"secret": "webhook-secret"
+					}
+				]
+			],
+			"items": {
+				"properties": {
+					"org": {
+						"description": "The name of the GitHub organization to which the webhook belongs",
+						"minLength": 1,
+						"type": "string"
+					},
+					"secret": {
+						"description": "The secret used when creating the webhook",
+						"minLength": 1,
+						"type": "string"
+					}
+				},
+				"required": [
+					"org",
+					"secret"
+				],
+				"title": "GitHubWebhook",
+				"type": "object"
+			},
+			"type": "array"
+		}
+	},
+	"required": [
+		"url"
+	],
+	"title": "GitHubConnection",
+	"type": "object"
 }
 ```
 {/* SCHEMA_SYNC_END: admin/code_hosts/github.schema.json */}
-
 ## Default branch
 
 Sourcegraph displays search results from the default branch of a repository when no `revision:` [parameter](/code-search/queries#repository-revisions) is specified. If you'd like the search results to be displayed from another branch by default, you may [change a repo's default branch on the github repo settings page](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/changing-the-default-branch). If this is not an option, consider using [search contexts](/code-search/working/search_contexts) instead.

--- a/docs/admin/code_hosts/gitlab.mdx
+++ b/docs/admin/code_hosts/gitlab.mdx
@@ -187,157 +187,405 @@ See [Internal rate limits](/admin/code_hosts/rate_limits#internal-rate-limits).
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/gitlab.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T19:22:23Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
-	// If non-null, enforces GitLab repository permissions. This requires that there be an item in the `auth.providers` field of type "gitlab" with the same `url` field as specified in this `GitLabConnection`.
-	"authorization": null,
-
-	// TLS certificate of the GitLab instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
-	"certificate": null,
-	// Other example values:
-	// - "-----BEGIN CERTIFICATE-----\n..."
-
-	// Only used to override the cloud_default column from a config file specified by EXTSVC_CONFIG_FILE
-	"cloudDefault": false,
-
-	// When set to true, this external service will be chosen as our 'Global' GitLab service. Only valid on Sourcegraph.com. Only one service can have this flag set.
-	"cloudGlobal": false,
-
-	// A list of projects to never mirror from this GitLab instance. Takes precedence over \"projects\" and \"projectQuery\" configuration. You can exclude projects by: name ({"name": "group/name"}), ID ({"id": 42}), regular expression matching pattern ({"pattern": "^group/project-.*"}), or by excluding empty repositories ({"emptyRepos": true}).
-	"exclude": null,
-	// Other example values:
-	// - [
-	//     {
-	//       "name": "group/name"
-	//     },
-	//     {
-	//       "id": 42
-	//     },
-	//     {
-	//       "emptyRepos": true
-	//     }
-	//   ]
-	// - [
-	//     {
-	//       "name": "gitlab-org/gitlab-ee"
-	//     },
-	//     {
-	//       "name": "gitlab-com/www-gitlab-com"
-	//     }
-	//   ]
-
-	// The type of Git URLs to use for cloning and fetching Git repositories on this GitLab instance.
-	//
-	// If "http", Sourcegraph will access GitLab repositories using Git URLs of the form http(s)://gitlab.example.com/myteam/myproject.git (using https: if the GitLab instance uses HTTPS).
-	//
-	// If "ssh", Sourcegraph will access GitLab repositories using Git URLs of the form git@example.gitlab.com:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.
-	"gitURLType": "http",
-
-	// Deprecated and ignored field which will be removed entirely in the next release. GitLab repositories can no longer be enabled or disabled explicitly.
-	"initialRepositoryEnablement": null,
-
-	// If true, internal repositories will be accessible to all users on Sourcegraph as if they were public, and user permission syncs will no longer check for public repositories. This overrides repository permissions but allows easier discovery and access to internal repositories, and may be desirable if all users on the Sourcegraph instance should have access to all internal repositories anyways. Defaults to false.
-	"markInternalReposAsPublic": false,
-
-	// An array of transformations will apply to the repository name. Currently, only regex replacement is supported. All transformations happen after "repositoryPathPattern" is processed.
-	"nameTransformations": null,
-	// Other example values:
-	// - [
-	//     {
-	//       "regex": "\\.d/",
-	//       "replacement": "/"
-	//     },
-	//     {
-	//       "regex": "-git$",
-	//       "replacement": ""
-	//     }
-	//   ]
-
-	// An array of strings specifying which GitLab projects to mirror on Sourcegraph. Each string is a URL path and query that targets a GitLab API endpoint returning a list of projects. If the string only contains a query, then "projects" is used as the path. Examples: "?membership=true&search=foo", "groups/mygroup/projects".
-	//
-	// The special string "none" can be used as the only element to disable this feature. Projects matched by multiple query strings are only imported once. Here are a few endpoints that return a list of projects: https://docs.gitlab.com/ee/api/projects.html#list-all-projects, https://docs.gitlab.com/ee/api/groups.html#list-a-groups-projects, https://docs.gitlab.com/ee/api/search.html#scope-projects.
-	"projectQuery": [
-		"none"
-	],
-	// Other example values:
-	// - [
-	//     "?membership=true\u0026search=foo",
-	//     "groups/mygroup/projects"
-	//   ]
-
-	// A list of projects to mirror from this GitLab instance. Supports including by name ({"name": "group/name"}) or by ID ({"id": 42}).
-	"projects": null,
-	// Other example values:
-	// - [
-	//     {
-	//       "name": "group/name"
-	//     },
-	//     {
-	//       "id": 42
-	//     }
-	//   ]
-	// - [
-	//     {
-	//       "name": "gnachman/iterm2"
-	//     },
-	//     {
-	//       "name": "gitlab-org/gitlab-ce"
-	//     }
-	//   ]
-
-	// Rate limit applied when making background API requests to GitLab.
-	"rateLimit": {
-		"enabled": true,
-		"requestsPerHour": 36000
+	"$id": "gitlab.schema.json#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": false,
+	"allowComments": true,
+	"definitions": {
+		"NameTransformation": {
+			"additionalProperties": false,
+			"anyOf": [
+				{
+					"required": [
+						"regex",
+						"replacement"
+					]
+				}
+			],
+			"properties": {
+				"regex": {
+					"description": "The regex to match for the occurrences of its replacement.",
+					"format": "regex",
+					"type": "string"
+				},
+				"replacement": {
+					"description": "The replacement used to replace all matched occurrences by the regex.",
+					"type": "string"
+				}
+			},
+			"title": "GitLabNameTransformation",
+			"type": "object"
+		},
+		"OAuthIdentity": {
+			"additionalProperties": false,
+			"properties": {
+				"type": {
+					"const": "oauth",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type"
+			],
+			"type": "object"
+		},
+		"UsernameIdentity": {
+			"additionalProperties": false,
+			"properties": {
+				"type": {
+					"const": "username",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type"
+			],
+			"type": "object"
+		}
 	},
-
-	// The pattern used to generate a the corresponding Sourcegraph repository name for a GitLab project. In the pattern, the variable "{host}" is replaced with the GitLab URL's host (such as gitlab.example.com), and "{pathWithNamespace}" is replaced with the GitLab project's "namespace/path" (such as "myteam/myproject").
-	//
-	// For example, if your GitLab is https://gitlab.example.com and your Sourcegraph is https://src.example.com, then a repositoryPathPattern of "{host}/{pathWithNamespace}" would mean that a GitLab project at https://gitlab.example.com/myteam/myproject is available on Sourcegraph at https://src.example.com/gitlab.example.com/myteam/myproject.
-	//
-	// It is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.
-	"repositoryPathPattern": "{host}/{pathWithNamespace}",
-
-	// A GitLab access token with "api" scope. Can be a personal access token (PAT) or an OAuth token. If you are enabling permissions with identity provider type "external", this token should also have "sudo" scope.
-	"token": null,
-
-	// The OAuth token expiry (Unix timestamp in seconds)
-	"token.oauth.expiry": null,
-
-	// The OAuth refresh token
-	"token.oauth.refresh": null,
-
-	// The type of the token
-	"token.type": "pat",
-
-	// URL of a GitLab instance, such as https://gitlab.example.com or (for GitLab.com) https://gitlab.com.
-	"url": null,
-	// Other example values:
-	// - "https://gitlab.com"
-	// - "https://gitlab.example.com"
-
-	// An array of webhook configurations
-	"webhooks": null
-}
-```
-
-## Native integration
-
-To provide out-of-the-box code navigation features to your users on GitLab, you will need to [configure your GitLab instance](https://docs.gitlab.com/ee/integration/sourcegraph.html). If you are using an HTTPS connection to GitLab, you will need to [configure HTTPS](/admin/http_https_configuration) for your Sourcegraph instance.
-
-The Sourcegraph instance's site admin must [update the `corsOrigin` site config property](/admin/config/site_config) to allow the GitLab instance to communicate with the Sourcegraph instance. For example:
-
-```json
-{
-  // ...
-  "corsOrigin":
-    "https://my-gitlab.example.com"
-  // ...
+	"description": "Configuration for a connection to GitLab (GitLab.com or GitLab self-managed).",
+	"properties": {
+		"authorization": {
+			"additionalProperties": false,
+			"description": "If non-null, enforces GitLab repository permissions. This requires that there be an item in the `auth.providers` field of type \"gitlab\" with the same `url` field as specified in this `GitLabConnection`.",
+			"properties": {
+				"identityProvider": {
+					"!go": {
+						"taggedUnionType": true
+					},
+					"description": "The source of identity to use when computing permissions. This defines how to compute the GitLab identity to use for a given Sourcegraph user.",
+					"oneOf": [
+						{
+							"$ref": "#/definitions/OAuthIdentity"
+						},
+						{
+							"$ref": "#/definitions/UsernameIdentity"
+						}
+					],
+					"properties": {
+						"type": {
+							"enum": [
+								"oauth",
+								"username"
+							],
+							"type": "string"
+						}
+					},
+					"required": [
+						"type"
+					],
+					"type": "object"
+				}
+			},
+			"required": [
+				"identityProvider"
+			],
+			"title": "GitLabAuthorization",
+			"type": "object"
+		},
+		"certificate": {
+			"description": "TLS certificate of the GitLab instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run `openssl s_client -connect HOST:443 -showcerts \u003c /dev/null 2\u003e /dev/null | openssl x509 -outform PEM`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.",
+			"examples": [
+				"-----BEGIN CERTIFICATE-----\n..."
+			],
+			"pattern": "^-----BEGIN CERTIFICATE-----\n",
+			"type": "string"
+		},
+		"exclude": {
+			"description": "A list of projects to never mirror from this GitLab instance. Takes precedence over \"projects\" and \"projectQuery\" configuration. You can exclude projects by: name ({\"name\": \"group/name\"}), ID ({\"id\": 42}), regular expression matching pattern ({\"pattern\": \"^group\\/project-.*\"}), or by excluding empty repositories ({\"emptyRepos\": true}).",
+			"examples": [
+				[
+					{
+						"name": "group/name"
+					},
+					{
+						"id": 42
+					},
+					{
+						"emptyRepos": true
+					}
+				],
+				[
+					{
+						"name": "gitlab-org/gitlab-ee"
+					},
+					{
+						"name": "gitlab-com/www-gitlab-com"
+					}
+				]
+			],
+			"items": {
+				"additionalProperties": false,
+				"anyOf": [
+					{
+						"required": [
+							"name"
+						]
+					},
+					{
+						"required": [
+							"id"
+						]
+					},
+					{
+						"required": [
+							"emptyRepos"
+						]
+					},
+					{
+						"required": [
+							"pattern"
+						]
+					}
+				],
+				"properties": {
+					"emptyRepos": {
+						"description": "Whether to exclude empty repositories.",
+						"type": "boolean"
+					},
+					"id": {
+						"description": "The ID of a GitLab project (as returned by the GitLab instance's API) to exclude from mirroring.",
+						"type": "integer"
+					},
+					"name": {
+						"description": "The name of a GitLab project (\"group/name\") to exclude from mirroring.",
+						"pattern": "^[\\w.-]+(/[\\w.-]+)+$",
+						"type": "string"
+					},
+					"pattern": {
+						"description": "Regular expression which matches against the name of a GitLab project (\"group/name\").",
+						"format": "regex",
+						"type": "string"
+					}
+				},
+				"title": "ExcludedGitLabProject",
+				"type": "object"
+			},
+			"type": "array"
+		},
+		"gitSSHCipher": {
+			"$ref": "git.schema.json#/definitions/gitSSHCipher",
+			"description": "SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`."
+		},
+		"gitSSHCredential": {
+			"$ref": "git.schema.json#/definitions/gitSSHCredential",
+			"description": "SSH keys to use when cloning Git repo."
+		},
+		"gitURLType": {
+			"default": "http",
+			"description": "The type of Git URLs to use for cloning and fetching Git repositories on this GitLab instance.\n\nIf \"http\", Sourcegraph will access GitLab repositories using Git URLs of the form http(s)://gitlab.example.com/myteam/myproject.git (using https: if the GitLab instance uses HTTPS).\n\nIf \"ssh\", Sourcegraph will access GitLab repositories using Git URLs of the form git@example.gitlab.com:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.",
+			"enum": [
+				"http",
+				"ssh"
+			],
+			"type": "string"
+		},
+		"initialRepositoryEnablement": {
+			"description": "Deprecated and ignored field which will be removed entirely in the next release. GitLab repositories can no longer be enabled or disabled explicitly.",
+			"type": "boolean"
+		},
+		"markInternalReposAsPublic": {
+			"default": false,
+			"description": "If true, internal repositories will be accessible to all users on Sourcegraph as if they were public, and user permission syncs will no longer check for public repositories. This overrides repository permissions but allows easier discovery and access to internal repositories, and may be desirable if all users on the Sourcegraph instance should have access to all internal repositories anyways. Defaults to false.",
+			"type": "boolean"
+		},
+		"maxDeletions": {
+			"default": 0,
+			"description": "The maximum number of repos that will be deleted per sync. A value of 0 or less indicates no maximum.",
+			"type": "integer"
+		},
+		"nameTransformations": {
+			"description": "An array of transformations will apply to the repository name. Currently, only regex replacement is supported. All transformations happen after \"repositoryPathPattern\" is processed.",
+			"examples": [
+				[
+					{
+						"regex": "\\.d/",
+						"replacement": "/"
+					},
+					{
+						"regex": "-git$",
+						"replacement": ""
+					}
+				]
+			],
+			"items": {
+				"$ref": "#/definitions/NameTransformation"
+			},
+			"type": "array"
+		},
+		"projectQuery": {
+			"default": [
+				"none"
+			],
+			"description": "An array of strings specifying which GitLab projects to mirror on Sourcegraph. Each string is a URL path and query that targets a GitLab API endpoint returning a list of projects. If the string only contains a query, then \"projects\" is used as the path. Examples: \"?membership=true\u0026search=foo\", \"groups/mygroup/projects\".\n\nThe special string \"none\" can be used as the only element to disable this feature. Projects matched by multiple query strings are only imported once. Here are a few endpoints that return a list of projects: https://docs.gitlab.com/ee/api/projects.html#list-all-projects, https://docs.gitlab.com/ee/api/groups.html#list-a-groups-projects, https://docs.gitlab.com/ee/api/search.html#scope-projects.",
+			"examples": [
+				[
+					"?membership=true\u0026search=foo",
+					"groups/mygroup/projects"
+				]
+			],
+			"items": {
+				"minLength": 1,
+				"type": "string"
+			},
+			"minItems": 1,
+			"type": "array"
+		},
+		"projects": {
+			"description": "A list of projects to mirror from this GitLab instance. Supports including by name ({\"name\": \"group/name\"}) or by ID ({\"id\": 42}).",
+			"examples": [
+				[
+					{
+						"name": "group/name"
+					},
+					{
+						"id": 42
+					}
+				],
+				[
+					{
+						"name": "gnachman/iterm2"
+					},
+					{
+						"name": "gitlab-org/gitlab-ce"
+					}
+				]
+			],
+			"items": {
+				"additionalProperties": false,
+				"oneOf": [
+					{
+						"required": [
+							"name"
+						]
+					},
+					{
+						"required": [
+							"id"
+						]
+					}
+				],
+				"properties": {
+					"id": {
+						"description": "The ID of a GitLab project (as returned by the GitLab instance's API) to mirror.",
+						"type": "integer"
+					},
+					"name": {
+						"description": "The name of a GitLab project (\"group/name\") to mirror.",
+						"pattern": "^[\\w.-]+(/[\\w.-]+)+$",
+						"type": "string"
+					}
+				},
+				"title": "GitLabProject",
+				"type": "object"
+			},
+			"minItems": 1,
+			"type": "array"
+		},
+		"rateLimit": {
+			"default": {
+				"enabled": true,
+				"requestsPerHour": 36000
+			},
+			"description": "Rate limit applied when making background API requests to GitLab.",
+			"properties": {
+				"enabled": {
+					"default": true,
+					"description": "true if rate limiting is enabled.",
+					"type": "boolean"
+				},
+				"requestsPerHour": {
+					"default": 36000,
+					"description": "Requests per hour permitted. This is an average, calculated per second. Internally the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.",
+					"minimum": 0,
+					"type": "number"
+				}
+			},
+			"required": [
+				"enabled",
+				"requestsPerHour"
+			],
+			"title": "GitLabRateLimit",
+			"type": "object"
+		},
+		"repositoryPathPattern": {
+			"default": "{host}/{pathWithNamespace}",
+			"description": "The pattern used to generate a the corresponding Sourcegraph repository name for a GitLab project. In the pattern, the variable \"{host}\" is replaced with the GitLab URL's host (such as gitlab.example.com), and \"{pathWithNamespace}\" is replaced with the GitLab project's \"namespace/path\" (such as \"myteam/myproject\").\n\nFor example, if your GitLab is https://gitlab.example.com and your Sourcegraph is https://src.example.com, then a repositoryPathPattern of \"{host}/{pathWithNamespace}\" would mean that a GitLab project at https://gitlab.example.com/myteam/myproject is available on Sourcegraph at https://src.example.com/gitlab.example.com/myteam/myproject.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.",
+			"type": "string"
+		},
+		"token": {
+			"description": "A GitLab access token with \"api\" scope. Can be a personal access token (PAT) or an OAuth token. If you are enabling permissions with identity provider type \"username\", this token should also have \"sudo\" scope.",
+			"minLength": 1,
+			"type": "string"
+		},
+		"token.oauth.expiry": {
+			"description": "The OAuth token expiry (Unix timestamp in seconds)",
+			"type": "integer"
+		},
+		"token.oauth.refresh": {
+			"description": "The OAuth refresh token",
+			"type": "string"
+		},
+		"token.type": {
+			"default": "pat",
+			"description": "The type of the token",
+			"enum": [
+				"pat",
+				"oauth"
+			],
+			"type": "string"
+		},
+		"url": {
+			"!go": {
+				"typeName": "NormalizedURL"
+			},
+			"description": "URL of a GitLab instance, such as https://gitlab.example.com or (for GitLab.com) https://gitlab.com.",
+			"examples": [
+				"https://gitlab.com",
+				"https://gitlab.example.com"
+			],
+			"format": "uri",
+			"not": {
+				"pattern": "example\\.com",
+				"type": "string"
+			},
+			"pattern": "^https?://",
+			"type": "string"
+		},
+		"webhooks": {
+			"deprecationMessage": "Deprecated in favour of first class webhooks. See https://sourcegraph.com/docs/admin/config/webhooks/incoming#deprecation-notice",
+			"description": "An array of webhook configurations",
+			"items": {
+				"additionalProperties": false,
+				"properties": {
+					"secret": {
+						"description": "The secret used to authenticate incoming webhook requests",
+						"minLength": 1,
+						"type": "string"
+					}
+				},
+				"required": [
+					"secret"
+				],
+				"title": "GitLabWebhook",
+				"type": "object"
+			},
+			"type": "array"
+		}
+	},
+	"required": [
+		"url",
+		"token",
+		"projectQuery"
+	],
+	"title": "GitLabConnection",
+	"type": "object"
 }
 ```
 {/* SCHEMA_SYNC_END: admin/code_hosts/gitlab.schema.json */}
-
 ## Configuration Notes
 
 GitLab connections provide flexible configuration options for different deployment scenarios:

--- a/docs/admin/code_hosts/gitolite.mdx
+++ b/docs/admin/code_hosts/gitolite.mdx
@@ -27,43 +27,129 @@ To connect Gitolite to Sourcegraph:
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/gitolite.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T19:22:29Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
-	// A list of repositories to never mirror from this Gitolite instance. Supports excluding by exact name ({"name": "foo"}).
-	"exclude": null,
-	// Other example values:
-	// - [
-	//     {
-	//       "name": "myrepo"
-	//     },
-	//     {
-	//       "pattern": ".*secret.*"
-	//     }
-	//   ]
-
-	// Gitolite host that stores the repositories (e.g., git@gitolite.example.com, ssh://git@gitolite.example.com:2222/).
-	"host": null,
-	// Other example values:
-	// - "git@gitolite.example.com"
-	// - "ssh://git@gitolite.example.com:2222/"
-
-	// This is DEPRECATED
-	"phabricator": null,
-
-	// This is DEPRECATED
-	"phabricatorMetadataCommand": null,
-
-	// Repository name prefix that will map to this Gitolite host. This should likely end with a trailing slash. E.g., "gitolite.example.com/".
-	//
-	// It is important that the Sourcegraph repository name generated with this prefix be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.
-	"prefix": null
-	// Other example values:
-	// - "gitolite.example.com/"
+	"$id": "gitolite.schema.json#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": false,
+	"allowComments": true,
+	"description": "Configuration for a connection to Gitolite.",
+	"properties": {
+		"exclude": {
+			"description": "A list of repositories to never mirror from this Gitolite instance. Supports excluding by exact name ({\"name\": \"foo\"}).",
+			"examples": [
+				[
+					{
+						"name": "myrepo"
+					},
+					{
+						"pattern": ".*secret.*"
+					}
+				]
+			],
+			"items": {
+				"additionalProperties": false,
+				"anyOf": [
+					{
+						"required": [
+							"name"
+						]
+					},
+					{
+						"required": [
+							"pattern"
+						]
+					}
+				],
+				"properties": {
+					"name": {
+						"description": "The name of a Gitolite repo (\"my-repo\") to exclude from mirroring.",
+						"minLength": 1,
+						"type": "string"
+					},
+					"pattern": {
+						"description": "Regular expression which matches against the name of a Gitolite repo to exclude from mirroring.",
+						"format": "regex",
+						"type": "string"
+					}
+				},
+				"title": "ExcludedGitoliteRepo",
+				"type": "object"
+			},
+			"minItems": 1,
+			"type": "array"
+		},
+		"gitSSHCipher": {
+			"$ref": "git.schema.json#/definitions/gitSSHCipher",
+			"description": "SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`."
+		},
+		"gitSSHCredential": {
+			"$ref": "git.schema.json#/definitions/gitSSHCredential",
+			"description": "SSH keys to use when cloning Git repo."
+		},
+		"host": {
+			"description": "Gitolite host that stores the repositories (e.g., git@gitolite.example.com, ssh://git@gitolite.example.com:2222/).",
+			"examples": [
+				"git@gitolite.example.com",
+				"ssh://git@gitolite.example.com:2222/"
+			],
+			"not": {
+				"pattern": "example\\.com",
+				"type": "string"
+			},
+			"type": "string"
+		},
+		"phabricator": {
+			"additionalProperties": false,
+			"deprecationMessage": "DEPRECATED: the Phabricator integration with Gitolite code hosts is deprecated",
+			"description": "This is DEPRECATED",
+			"properties": {
+				"callsignCommand": {
+					"description": " Bash command that prints out the Phabricator callsign for a Gitolite repository. This will be run with environment variable $REPO set to the name of the repository and used to obtain the Phabricator metadata for a Gitolite repository. (Note: this requires `bash` to be installed.)",
+					"type": "string"
+				},
+				"url": {
+					"!go": {
+						"typeName": "NormalizedURL"
+					},
+					"description": "URL of the Phabricator instance that integrates with this Gitolite instance. This should be set ",
+					"format": "uri",
+					"type": "string"
+				}
+			},
+			"required": [
+				"url",
+				"callsignCommand"
+			],
+			"type": "object"
+		},
+		"phabricatorMetadataCommand": {
+			"deprecationMessage": "DEPRECATED: the Phabricator integration with Gitolite code hosts is deprecated",
+			"description": "This is DEPRECATED",
+			"type": "string"
+		},
+		"prefix": {
+			"description": "Repository name prefix that will map to this Gitolite host. This should likely end with a trailing slash. E.g., \"gitolite.example.com/\".\n\nIt is important that the Sourcegraph repository name generated with this prefix be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.",
+			"examples": [
+				"gitolite.example.com/"
+			],
+			"not": {
+				"pattern": "example\\.com",
+				"type": "string"
+			},
+			"type": "string"
+		}
+	},
+	"required": [
+		"prefix",
+		"host"
+	],
+	"title": "GitoliteConnection",
+	"type": "object"
 }
 ```
 {/* SCHEMA_SYNC_END: admin/code_hosts/gitolite.schema.json */}
-
 ## Configuration Notes
 
 - **SSH Authentication Required**: Gitolite requires SSH key-based authentication. Ensure your Sourcegraph instance has proper SSH access to the Gitolite server.

--- a/docs/admin/code_hosts/other.mdx
+++ b/docs/admin/code_hosts/other.mdx
@@ -70,51 +70,120 @@ Repositories must be listed individually:
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/other_external_service.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T19:22:30Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
-	// A list of repositories to never mirror by name after applying repositoryPathPattern. Supports excluding by exact name ({"name": "myrepo"}) or regular expression ({"pattern": ".*secret.*"}).
-	"exclude": null,
-	// Other example values:
-	// - [
-	//     {
-	//       "name": "myrepo"
-	//     },
-	//     {
-	//       "pattern": ".*secret.*"
-	//     }
-	//   ]
-
-	// Whether or not these repositories should be marked as public on Sourcegraph.com. Defaults to false.
-	"makeReposPublicOnDotCom": false,
-
-	"repos": null,
-
-	// The pattern used to generate the corresponding Sourcegraph repository name for the repositories. In the pattern, the variable "{base}" is replaced with the Git clone base URL host and path, and "{repo}" is replaced with the repository path taken from the `repos` field.
-	//
-	// For example, if your Git clone base URL is https://git.example.com/repos and `repos` contains the value "my/repo", then a repositoryPathPattern of "{base}/{repo}" would mean that a repository at https://git.example.com/repos/my/repo is available on Sourcegraph at https://sourcegraph.example.com/git.example.com/repos/my/repo.
-	//
-	// It is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.
-	//
-	// Note: These patterns are ignored if using src-expose / src-serve / src-serve-local.
-	"repositoryPathPattern": "{base}/{repo}",
-	// Other example values:
-	// - "pretty-host-name/{repo}"
-
-	// The root directory to walk for discovering local git repositories to mirror. To sync with local repositories and use this root property one must run Cody App and define the repos configuration property such as ["src-serve-local"].
-	"root": "",
-	// Other example values:
-	// - "path/to/my/repos"
-
-	"url": null
-	// Other example values:
-	// - "https://github.com/?access_token=secret"
-	// - "ssh://user@host.xz:2333/"
-	// - "git://host.xz:2333/"
+	"$id": "other_external_service.schema.json#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": false,
+	"allowComments": true,
+	"description": "Configuration for a Connection to Git repositories for which an external service integration isn't yet available.",
+	"properties": {
+		"exclude": {
+			"description": "A list of repositories to never mirror by name after applying repositoryPathPattern. Supports excluding by exact name ({\"name\": \"myrepo\"}) or regular expression ({\"pattern\": \".*secret.*\"}).",
+			"examples": [
+				[
+					{
+						"name": "myrepo"
+					},
+					{
+						"pattern": ".*secret.*"
+					}
+				]
+			],
+			"items": {
+				"additionalProperties": false,
+				"anyOf": [
+					{
+						"required": [
+							"name"
+						]
+					},
+					{
+						"required": [
+							"pattern"
+						]
+					}
+				],
+				"properties": {
+					"name": {
+						"description": "The name of a Other repo (\"my-repo\") to exclude from mirroring.",
+						"minLength": 1,
+						"type": "string"
+					},
+					"pattern": {
+						"description": "Regular expression which matches against the name of a Other repo to exclude from mirroring.",
+						"format": "regex",
+						"type": "string"
+					}
+				},
+				"title": "ExcludedOtherRepo",
+				"type": "object"
+			},
+			"minItems": 1,
+			"type": "array"
+		},
+		"gitSSHCipher": {
+			"$ref": "git.schema.json#/definitions/gitSSHCipher",
+			"description": "SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`."
+		},
+		"gitSSHCredential": {
+			"$ref": "git.schema.json#/definitions/gitSSHCredential",
+			"description": "SSH keys to use when cloning Git repo."
+		},
+		"makeReposPublicOnDotCom": {
+			"default": false,
+			"description": "Whether or not these repositories should be marked as public on Sourcegraph.com. Defaults to false.",
+			"type": "boolean"
+		},
+		"repos": {
+			"items": {
+				"examples": [
+					"path/to/my/repo",
+					"path/to/my/repo.git/"
+				],
+				"format": "uri-reference",
+				"minLength": 1,
+				"type": "string"
+			},
+			"title": "List of repository clone URLs to be discovered.",
+			"type": "array"
+		},
+		"repositoryPathPattern": {
+			"default": "{base}/{repo}",
+			"description": "The pattern used to generate the corresponding Sourcegraph repository name for the repositories. In the pattern, the variable \"{base}\" is replaced with the Git clone base URL host and path, and \"{repo}\" is replaced with the repository path taken from the `repos` field.\n\nFor example, if your Git clone base URL is https://git.example.com/repos and `repos` contains the value \"my/repo\", then a repositoryPathPattern of \"{base}/{repo}\" would mean that a repository at https://git.example.com/repos/my/repo is available on Sourcegraph at https://sourcegraph.example.com/git.example.com/repos/my/repo.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.\n\nNote: These patterns are ignored if using src-expose / src-serve.",
+			"examples": [
+				"pretty-host-name/{repo}"
+			],
+			"type": "string"
+		},
+		"url": {
+			"!go": {
+				"typeName": "NormalizedURL"
+			},
+			"examples": [
+				"https://github.com/?access_token=secret",
+				"ssh://user@host.xz:2333/",
+				"git://host.xz:2333/"
+			],
+			"format": "uri",
+			"not": {
+				"pattern": "example\\.com",
+				"type": "string"
+			},
+			"pattern": "^(git|ssh|https?)://",
+			"title": "Git clone base URL",
+			"type": "string"
+		}
+	},
+	"required": [
+		"repos"
+	],
+	"title": "OtherExternalServiceConnection",
+	"type": "object"
 }
 ```
 {/* SCHEMA_SYNC_END: admin/code_hosts/other_external_service.schema.json */}
-
 ## Configuration Notes
 
 - **Repository Path Pattern**: The `repositoryPathPattern` field controls how repository names appear in Sourcegraph. Use `{base}` for the clone URL base and `{repo}` for the repository path.

--- a/docs/admin/code_hosts/phabricator.mdx
+++ b/docs/admin/code_hosts/phabricator.mdx
@@ -79,23 +79,85 @@ The Sourcegraph instance's site admin must [update the `corsOrigin` site config 
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/phabricator.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T19:22:30Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
-	// The list of repositories available on Phabricator.
-	"repos": null,
-
-	// API token for the Phabricator instance.
-	"token": null,
-
-	// URL of a Phabricator instance, such as https://phabricator.example.com
-	"url": null
-	// Other example values:
-	// - "https://phabricator.example.com"
+	"$id": "phabricator.schema.json#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": false,
+	"allowComments": true,
+	"anyOf": [
+		{
+			"required": [
+				"token"
+			]
+		},
+		{
+			"required": [
+				"repos"
+			]
+		}
+	],
+	"description": "Configuration for a connection to Phabricator.",
+	"properties": {
+		"gitSSHCipher": {
+			"$ref": "git.schema.json#/definitions/gitSSHCipher",
+			"description": "SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`."
+		},
+		"gitSSHCredential": {
+			"$ref": "git.schema.json#/definitions/gitSSHCredential",
+			"description": "SSH keys to use when cloning Git repo."
+		},
+		"gitURLType": {
+			"default": "http",
+			"description": "The type of Git URLs to use for cloning and fetching Git repositories.",
+			"enum": [
+				"http",
+				"ssh"
+			],
+			"type": "string"
+		},
+		"repos": {
+			"description": "The list of repositories available on Phabricator.",
+			"items": {
+				"additionalProperties": false,
+				"properties": {
+					"callsign": {
+						"description": "The unique Phabricator identifier for the repository, like 'MUX'.",
+						"type": "string"
+					},
+					"path": {
+						"description": "Display path for the url e.g. gitolite/my/repo",
+						"type": "string"
+					}
+				},
+				"required": [
+					"path",
+					"callsign"
+				],
+				"type": "object"
+			},
+			"minItems": 1,
+			"type": "array"
+		},
+		"token": {
+			"description": "API token for the Phabricator instance.",
+			"minLength": 1,
+			"type": "string"
+		},
+		"url": {
+			"description": "URL of a Phabricator instance, such as https://phabricator.example.com",
+			"examples": [
+				"https://phabricator.example.com"
+			],
+			"type": "string"
+		}
+	},
+	"title": "PhabricatorConnection",
+	"type": "object"
 }
 ```
 {/* SCHEMA_SYNC_END: admin/code_hosts/phabricator.schema.json */}
-
 ## Configuration Notes
 
 - **Limited Support**: Phabricator support is limited and not expected to evolve due to Phabricator's end-of-life announcement.

--- a/docs/admin/config/settings.mdx
+++ b/docs/admin/config/settings.mdx
@@ -27,129 +27,652 @@ Settings options and their default values are shown below.
 
 {/* SCHEMA_SYNC_START: admin/config/settings.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T19:22:22Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
-	// Disables observability-related site alert banners.
-	"alerts.hideObservabilitySiteAlerts": true,
-
-	// Whether to show alerts for major and minor version updates. Alerts for patch version updates will be shown if `alerts.showPatchUpdates` is true.
-	"alerts.showMajorMinorUpdates": true,
-
-	// Whether to show alerts for patch version updates. Alerts for major and minor version updates will be shown if `alerts.showMajorMinorUpdatess` is true.
-	"alerts.showPatchUpdates": true,
-
-	// Whether to run global searches over all repositories. On instances with many repositories, this can lead to issues such as: low quality results, slow response times, or significant load on the Sourcegraph instance. Defaults to true.
-	"basicCodeIntel.globalSearchesEnabled": null,
-
-	// Whether to include archived repositories in search results.
-	"basicCodeIntel.includeArchives": null,
-
-	// Whether to include forked repositories in search results.
-	"basicCodeIntel.includeForks": null,
-
-	// Whether to use only indexed requests to the search API.
-	"basicCodeIntel.indexOnly": null,
-
-	// The timeout (in milliseconds) for un-indexed search requests.
-	"basicCodeIntel.unindexedSearchTimeout": null,
-
-	// Whether to fetch multiple precise definitions and references on hover.
-	"codeIntel.disableRangeQueries": null,
-
-	// Never fall back to search-based code intelligence.
-	"codeIntel.disableSearchBased": null,
-
-	// Whether to supplement precise references with search-based results.
-	"codeIntel.mixPreciseAndSearchBasedReferences": null,
-
-	// Whether to enable trace logging on the extension.
-	"codeIntel.traceExtension": null,
-
-	// Whether the sidebar on the repo view should be open by default.
-	"fileSidebarVisibleByDefault": true,
-
-	// Custom page size for the history tab. If set, the history tab will populate that number of commits the first time the history tab is opened and then double the number of commits progressively.
-	"history.defaultPageSize": null,
-
-	// Show absolute timestamps in the history panel and only show relative timestamps (e.g.: "5 days ago") in tooltip when hovering.
-	"history.preferAbsoluteTimestamps": false,
-
-	// DEPRECATED: Use `notices` instead.
-	//
-	// An array (often with just one element) of messages to display at the top of all pages, including for unauthenticated users. Users may dismiss a message (and any message with the same string value will remain dismissed for the user).
-	//
-	// Markdown formatting is supported.
-	//
-	// Usually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that user. (This is useful for testing the correctness of the message's Markdown formatting.)
-	//
-	// MOTD stands for "message of the day" (which is the conventional Unix name for this type of message).
-	"motd": null,
-
-	// Custom informational messages to display to users at specific locations in the Sourcegraph user interface.
-	//
-	// Usually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that single user.
-	"notices": null,
-
-	// Group of settings related to opening files in an editor.
-	"openInEditor": null,
-
-	// If enabled, all members of the org will be treated as admins (e.g. can edit, apply, delete) for all batch changes created in that org.
-	"orgs.allMembersBatchChangesAdmin": false,
-
-	// Key-value pairs of code host URLs to Swarm URLs. Keys should have no prefix and should not end with a slash, like "perforce.company.com:1666". Values should look like "https://swarm.company.com/", with a slash at the end.
-	"perforce.codeHostToSwarmMap": {},
-
-	// DEPRECATED: This setting will be removed in a future version of Sourcegraph.
-	"quicklinks": null,
-
-	// The default number of lines to show as context below and above search results. Default is 1.
-	"search.contextLines": 1,
-
-	// Whether query patterns are treated case sensitively. Patterns are case insensitive by default.
-	"search.defaultCaseSensitive": false,
-
-	// Defines default properties for search behavior. The default is `smart`, which provides query assistance that automatically runs alternative queries when appropriate. When `precise`, search behavior strictly searches for the precise meaning of the query.
-	"search.defaultMode": null,
-
-	// The default pattern type for search queries. Note: to disable keyword search and use the previous behavior, set "search.defaultPatternType: standard".
-	"search.defaultPatternType": null,
-
-	// The number of results we send down during a search. Note: this is different to the count: in the query. The search will continue once we hit displayLimit and updated filters and statistics will continue to stream down. Defaults to 1500.
-	"search.displayLimit": 1500,
-
-	// Disable search suggestions below the search bar when constructing queries. Defaults to false.
-	"search.hideSuggestions": false,
-
-	// Whether searches should include searching archived repositories.
-	"search.includeArchived": false,
-
-	// Whether searches should include searching forked repositories.
-	"search.includeForks": false,
-
-	// DEPRECATED: Saved search queries
-	"search.savedQueries": null,
-
-	// Predefined search snippets that can be appended to any search (also known as search scopes)
-	"search.scopes": null,
-
-//////////////////////////////////////////////////////////////
-// CodeInsights
-//////////////////////////////////////////////////////////////
-
-	// The number of seconds to execute the aggregation for when running in extended timeout mode. This value should always be less than any proxy timeout if one exists. The maximum value is equal to searchLimits.maxTimeoutSeconds
-	"insights.aggregations.extendedTimeout": 55,
-
-//////////////////////////////////////////////////////////////
-// Experimental
-//////////////////////////////////////////////////////////////
-
-	// Experimental features and settings.
-	"experimentalFeatures": null
+	"$id": "settings.schema.json#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": true,
+	"allowComments": true,
+	"definitions": {
+		"QuickLink": {
+			"additionalProperties": false,
+			"properties": {
+				"description": {
+					"description": "A description for this quick link",
+					"type": "string"
+				},
+				"name": {
+					"description": "The human-readable name for this quick link",
+					"type": "string"
+				},
+				"url": {
+					"description": "The URL of this quick link (absolute or relative)",
+					"pattern": "^(https?://|/)",
+					"type": "string"
+				}
+			},
+			"required": [
+				"name",
+				"url"
+			],
+			"type": "object"
+		},
+		"SearchScope": {
+			"additionalProperties": false,
+			"properties": {
+				"name": {
+					"description": "The human-readable name for this search scope",
+					"type": "string"
+				},
+				"value": {
+					"description": "The query string of this search scope",
+					"type": "string"
+				}
+			},
+			"required": [
+				"name",
+				"value"
+			],
+			"type": "object"
+		}
+	},
+	"description": "Configuration settings for users and organizations on Sourcegraph.",
+	"properties": {
+		"alerts.hideObservabilitySiteAlerts": {
+			"!go": {
+				"pointer": true
+			},
+			"default": true,
+			"description": "Disables observability-related site alert banners.",
+			"type": "boolean"
+		},
+		"alerts.showMajorMinorUpdates": {
+			"default": true,
+			"description": "Whether to show alerts for major and minor version updates. Alerts for patch version updates will be shown if `alerts.showPatchUpdates` is true.",
+			"type": "boolean"
+		},
+		"alerts.showPatchUpdates": {
+			"default": true,
+			"description": "Whether to show alerts for patch version updates. Alerts for major and minor version updates will be shown if `alerts.showMajorMinorUpdatess` is true.",
+			"type": "boolean"
+		},
+		"basicCodeIntel.globalSearchesEnabled": {
+			"description": "Whether to run global searches over all repositories. On instances with many repositories, this can lead to issues such as: low quality results, slow response times, or significant load on the Sourcegraph instance. Defaults to true.",
+			"type": "boolean"
+		},
+		"basicCodeIntel.includeArchives": {
+			"description": "Whether to include archived repositories in search results.",
+			"type": "boolean"
+		},
+		"basicCodeIntel.includeForks": {
+			"description": "Whether to include forked repositories in search results.",
+			"type": "boolean"
+		},
+		"basicCodeIntel.indexOnly": {
+			"description": "Whether to use only indexed requests to the search API.",
+			"type": "boolean"
+		},
+		"basicCodeIntel.unindexedSearchTimeout": {
+			"description": "The timeout (in milliseconds) for un-indexed search requests.",
+			"type": "number"
+		},
+		"codeIntel.disableRangeQueries": {
+			"description": "Whether to fetch multiple precise definitions and references on hover.",
+			"type": "boolean"
+		},
+		"codeIntel.disableSearchBased": {
+			"description": "Never fall back to search-based code intelligence.",
+			"type": "boolean"
+		},
+		"codeIntel.mixPreciseAndSearchBasedReferences": {
+			"description": "Whether to supplement precise references with search-based results.",
+			"type": "boolean"
+		},
+		"codeIntel.traceExtension": {
+			"description": "Whether to enable trace logging on the extension.",
+			"type": "boolean"
+		},
+		"cody.notices": {
+			"description": "Custom informational messages to display to users at Cody clients locations.\n\nUsually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that single user.",
+			"items": {
+				"additionalProperties": false,
+				"properties": {
+					"key": {
+						"description": "The notice key, everytime this field is updated the notice message appears in the cody client even if it was previously dismissed.",
+						"type": "string"
+					},
+					"message": {
+						"description": "The message to display. Markdown formatting is supported.",
+						"type": "string"
+					},
+					"title": {
+						"description": "The title of the notice/message.",
+						"type": "string"
+					}
+				},
+				"required": [
+					"key",
+					"title",
+					"message"
+				],
+				"title": "Cody Notice",
+				"type": "object"
+			},
+			"type": "array"
+		},
+		"experimentalFeatures": {
+			"additionalProperties": true,
+			"description": "Experimental features and settings.",
+			"group": "Experimental",
+			"properties": {
+				"batchChangesExecution": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "Enables/disables the Batch Changes server side execution feature.",
+					"type": "boolean"
+				},
+				"boostRelevantRepositories": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "Boosts repositories that users have contributed to in the search results.",
+					"type": "boolean"
+				},
+				"clientSearchResultRanking": {
+					"!go": {
+						"pointer": true
+					},
+					"default": "by-zoekt-ranking",
+					"description": "How to rank search results in the client",
+					"examples": [
+						"by-line-number",
+						"by-zoekt-ranking"
+					],
+					"type": "string"
+				},
+				"codeInsightsCompute": {
+					"!go": {
+						"pointer": true
+					},
+					"default": false,
+					"description": "Enables Compute powered Code Insights",
+					"type": "boolean"
+				},
+				"codeInsightsRepoUI": {
+					"!go": {
+						"pointer": true
+					},
+					"default": "single-search-query",
+					"description": "Specifies which (code insight repo) editor to use for repo query UI",
+					"enum": [
+						"old-strict-list",
+						"single-search-query",
+						"search-query-or-strict-list"
+					],
+					"type": "string"
+				},
+				"disableOrderBySimilarity": {
+					"default": false,
+					"description": "Disables ordering of repository search results by similarity.",
+					"type": "boolean"
+				},
+				"enableLazyBlobSyntaxHighlighting": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "Fetch un-highlighted blob contents to render immediately, decorate with syntax highlighting once loaded.",
+					"type": "boolean"
+				},
+				"enableLazyFileResultSyntaxHighlighting": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "Fetch un-highlighted file result contents to render immediately, decorate with syntax highlighting once loaded.",
+					"type": "boolean"
+				},
+				"enableSearchFilePrefetch": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "Pre-fetch plaintext file revisions from search results on hover/focus.",
+					"type": "boolean"
+				},
+				"enableSidebarFilePrefetch": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "Pre-fetch plaintext file revisions from sidebar on hover/focus.",
+					"type": "boolean"
+				},
+				"fuzzyFinder": {
+					"!go": {
+						"pointer": true
+					},
+					"description": "Enables fuzzy finder with the keyboard shortcut `Cmd+K` on macOS and `Ctrl+K` on Linux/Windows.",
+					"type": "boolean"
+				},
+				"fuzzyFinderActions": {
+					"!go": {
+						"pointer": true
+					},
+					"description": "Enables the 'Actions' tab of the fuzzy finder",
+					"type": "boolean"
+				},
+				"fuzzyFinderAll": {
+					"!go": {
+						"pointer": true
+					},
+					"description": "Enables the 'All' tab of the fuzzy finder",
+					"type": "boolean"
+				},
+				"fuzzyFinderCaseInsensitiveFileCountThreshold": {
+					"!go": {
+						"pointer": true
+					},
+					"default": 25000,
+					"description": "The maximum number of files a repo can have to use case-insensitive fuzzy finding",
+					"type": "number"
+				},
+				"fuzzyFinderNavbar": {
+					"!go": {
+						"pointer": true
+					},
+					"description": "Enables the 'Fuzzy finder' action in the global navigation bar",
+					"type": "boolean"
+				},
+				"fuzzyFinderRepositories": {
+					"!go": {
+						"pointer": true
+					},
+					"description": "Enables the 'Repositories' tab of the fuzzy finder",
+					"type": "boolean"
+				},
+				"fuzzyFinderSymbols": {
+					"!go": {
+						"pointer": true
+					},
+					"description": "Enables the 'Symbols' tab of the fuzzy finder",
+					"type": "boolean"
+				},
+				"goCodeCheckerTemplates": {
+					"!go": {
+						"pointer": true
+					},
+					"default": false,
+					"description": "Shows a panel with code insights templates for go code checker results.",
+					"type": "boolean"
+				},
+				"keywordSearch": {
+					"default": true,
+					"description": "DEPRECATED: this setting is no longer used. To disable keyword search, set `search.defaultPatternType: standard` instead.",
+					"type": "boolean"
+				},
+				"newSearchNavigationUI": {
+					"!go": {
+						"pointer": true
+					},
+					"default": false,
+					"description": "Enables new experimental search UI navigation",
+					"type": "boolean"
+				},
+				"newSearchResultFiltersPanel": {
+					"!go": {
+						"pointer": true
+					},
+					"default": false,
+					"description": "Enables new experimental search results filters panel",
+					"type": "boolean"
+				},
+				"newSearchResultsUI": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "Enables new experimental search results UI, such as preview panel feature and updated search and filter layouts.",
+					"type": "boolean"
+				},
+				"proactiveSearchResultsAggregations": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "Search results aggregations are triggered automatically with a search.",
+					"type": "boolean"
+				},
+				"searchContextsQuery": {
+					"!go": {
+						"pointer": true
+					},
+					"default": false,
+					"description": "DEPRECATED: This feature is now permanently enabled. Enables query based search contexts",
+					"type": "boolean"
+				},
+				"searchQueryInput": {
+					"!go": {
+						"pointer": true
+					},
+					"default": "v1",
+					"description": "Specify which version of the search query input to use",
+					"enum": [
+						"v1",
+						"v2"
+					],
+					"type": "string"
+				},
+				"searchResultsAggregations": {
+					"!go": {
+						"pointer": true
+					},
+					"default": false,
+					"description": "Display aggregations for your search results on the search screen.",
+					"type": "boolean"
+				},
+				"showCodeMonitoringLogs": {
+					"!go": {
+						"pointer": true
+					},
+					"default": false,
+					"description": "Shows code monitoring logs tab.",
+					"type": "boolean"
+				},
+				"symbolKindTags": {
+					"default": false,
+					"description": "Show the initial letter of the symbol kind instead of icons.",
+					"type": "boolean"
+				}
+			},
+			"title": "SettingsExperimentalFeatures",
+			"type": "object"
+		},
+		"fileSidebarVisibleByDefault": {
+			"default": true,
+			"description": "Whether the sidebar on the repo view should be open by default.",
+			"type": "boolean"
+		},
+		"history.defaultPageSize": {
+			"description": "Custom page size for the history tab. If set, the history tab will populate that number of commits the first time the history tab is opened and then double the number of commits progressively.",
+			"maximum": 100,
+			"minimum": 1,
+			"type": "integer"
+		},
+		"history.preferAbsoluteTimestamps": {
+			"default": false,
+			"description": "Show absolute timestamps in the history panel and only show relative timestamps (e.g.: \"5 days ago\") in tooltip when hovering.",
+			"type": "boolean"
+		},
+		"insights.aggregations.extendedTimeout": {
+			"default": 55,
+			"description": "The number of seconds to execute the aggregation for when running in extended timeout mode. This value should always be less than any proxy timeout if one exists. The maximum value is equal to searchLimits.maxTimeoutSeconds",
+			"group": "CodeInsights",
+			"type": "integer"
+		},
+		"motd": {
+			"description": "DEPRECATED: Use `notices` instead.\n\nAn array (often with just one element) of messages to display at the top of all pages, including for unauthenticated users. Users may dismiss a message (and any message with the same string value will remain dismissed for the user).\n\nMarkdown formatting is supported.\n\nUsually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that user. (This is useful for testing the correctness of the message's Markdown formatting.)\n\nMOTD stands for \"message of the day\" (which is the conventional Unix name for this type of message).",
+			"items": {
+				"type": "string"
+			},
+			"type": "array"
+		},
+		"notices": {
+			"description": "Custom informational messages to display to users at specific locations in the Sourcegraph user interface.\n\nUsually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that single user.",
+			"items": {
+				"additionalProperties": false,
+				"properties": {
+					"dismissible": {
+						"default": false,
+						"description": "Whether this notice can be dismissed (closed) by the user.",
+						"type": "boolean"
+					},
+					"location": {
+						"description": "The location where this notice is shown: \"top\" for the top of every page, \"home\" for the homepage.",
+						"enum": [
+							"top",
+							"home"
+						],
+						"type": "string"
+					},
+					"message": {
+						"description": "The message to display. Markdown formatting is supported.",
+						"type": "string"
+					},
+					"styleOverrides": {
+						"description": "Overrides for the notice's default style. You probably want to use notice 'variant' setting instead.",
+						"properties": {
+							"backgroundColor": {
+								"description": "The hex code of the background color for this notice.",
+								"type": "string"
+							},
+							"textCentered": {
+								"description": "Whether the notice text should be centered.",
+								"type": "boolean"
+							},
+							"textColor": {
+								"description": "The hex code of the text color for this notice.",
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"variant": {
+						"enum": [
+							"primary",
+							"secondary",
+							"success",
+							"danger",
+							"warning",
+							"info",
+							"note"
+						],
+						"type": "string"
+					}
+				},
+				"required": [
+					"message",
+					"location"
+				],
+				"title": "Notice",
+				"type": "object"
+			},
+			"type": "array"
+		},
+		"openInEditor": {
+			"additionalProperties": false,
+			"description": "Group of settings related to opening files in an editor.",
+			"properties": {
+				"custom.urlPattern": {
+					"description": "If you add \"custom\" to openineditor.editorIds, this must be set. Use the placeholders \"%file\", \"%line\", and \"%col\" to mark where the file path, line number, and column number must be insterted. Example URL for IntelliJ IDEA: \"idea://open?file=%file\u0026line=%line\u0026column=%col\"",
+					"type": "string"
+				},
+				"editorIds": {
+					"description": "The editor to open files in. If set to this to \"custom\", you must also set \"custom.urlPattern\"",
+					"items": {
+						"enum": [
+							"appcode",
+							"atom",
+							"clion",
+							"goland",
+							"idea",
+							"phpstorm",
+							"pycharm",
+							"rider",
+							"rubymine",
+							"sublime",
+							"vscode",
+							"webstorm",
+							"custom"
+						],
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"jetbrains.forceApi": {
+					"description": "Forces using protocol handlers (like ikea://open?file=...) or the built-in REST API (http://localhost:63342/api/file...). If omitted, protocol handlers are used if available, otherwise the built-in REST API is used.",
+					"enum": [
+						"protocolHandler",
+						"builtInServer"
+					],
+					"type": "string"
+				},
+				"projectPaths.default": {
+					"description": "The absolute path on your computer where your git repositories live. All git repos to open have to be cloned under this path with their original names. \"/Users/yourusername/src\" is a valid absolute path, \"~/src\" is not. Works both with and without a trailing slash.",
+					"type": "string"
+				},
+				"projectPaths.linux": {
+					"description": "Overrides the default path when the browser detects Linux. Works both with and without a trailing slash.",
+					"type": "string"
+				},
+				"projectPaths.mac": {
+					"description": "Overrides the default path when the browser detects macOS. Works both with and without a trailing slash.",
+					"type": "string"
+				},
+				"projectPaths.windows": {
+					"description": "Overrides the default path when the browser detects Windows. Doesn't need a trailing backslash.",
+					"type": "string"
+				},
+				"replacements": {
+					"additionalProperties": {
+						"description": "Replace string. For backreferences to capturing groups, use $1, $2, ...",
+						"type": "string"
+					},
+					"description": "Each key will be replaced by the corresponding value in the final URL. Keys are regular expressions, values can contain backreferences ($1, $2, ...).",
+					"propertyNames": {
+						"description": "A regular expression to match against URLs.",
+						"type": "string"
+					},
+					"type": "object"
+				},
+				"vscode.isProjectPathUNCPath": {
+					"default": false,
+					"description": "Indicates that the given project path is a UNC (Universal Naming Convention) path.",
+					"type": "boolean"
+				},
+				"vscode.remoteHostForSSH": {
+					"description": "The remote host as \"USER@HOSTNAME\". This needs you to install the extension called \"Remote Development by Microsoft\" in your VS Code.",
+					"type": "string"
+				},
+				"vscode.useInsiders": {
+					"default": false,
+					"description": "If set, files will open in VS Code Insiders rather than VS Code.",
+					"type": "boolean"
+				},
+				"vscode.useSSH": {
+					"default": false,
+					"description": "If set, files will open on a remote server via SSH. This requires vscode.remoteHostForSSH to be specified and VS Code extension \"Remote Development by Microsoft\" installed in your VS Code.",
+					"type": "boolean"
+				}
+			},
+			"title": "SettingsOpenInEditor",
+			"type": "object"
+		},
+		"orgs.allMembersBatchChangesAdmin": {
+			"!go": {
+				"pointer": true
+			},
+			"default": false,
+			"description": "If enabled, all members of the org will be treated as admins (e.g. can edit, apply, delete) for all batch changes created in that org.",
+			"type": "boolean"
+		},
+		"perforce.codeHostToSwarmMap": {
+			"additionalProperties": {
+				"type": "string"
+			},
+			"default": {},
+			"description": "Key-value pairs of code host URLs to Swarm URLs. Keys should have no prefix and should not end with a slash, like \"perforce.company.com:1666\". Values should look like \"https://swarm.company.com/\", with a slash at the end.",
+			"type": "object"
+		},
+		"quicklinks": {
+			"description": "DEPRECATED: This setting will be removed in a future version of Sourcegraph.",
+			"items": {
+				"$ref": "#/definitions/QuickLink"
+			},
+			"type": "array"
+		},
+		"search.contextLines": {
+			"!go": {
+				"pointer": true
+			},
+			"default": 1,
+			"description": "The default number of lines to show as context below and above search results. Default is 1.",
+			"minimum": 0,
+			"type": "integer"
+		},
+		"search.defaultCaseSensitive": {
+			"default": false,
+			"description": "Whether query patterns are treated case sensitively. Patterns are case insensitive by default.",
+			"type": "boolean"
+		},
+		"search.defaultMode": {
+			"description": "DEPRECATED: this setting is no longer read when the default 'keyword' patterntype is enabled, which always uses the 'precise' mode. Smart search will be removed in a future release.",
+			"pattern": "precise|smart",
+			"type": "string"
+		},
+		"search.defaultPatternType": {
+			"description": "The default pattern type that search queries will be interpreted as.",
+			"pattern": "standard|literal|regexp|keyword|codycontext",
+			"type": "string"
+		},
+		"search.displayLimit": {
+			"!go": {
+				"pointer": true
+			},
+			"default": 1500,
+			"description": "The number of results we send down during a search. Note: this is different to the count: in the query. The search will continue once we hit displayLimit and updated filters and statistics will continue to stream down. Defaults to 1500.",
+			"minimum": 1,
+			"type": "integer"
+		},
+		"search.hideSuggestions": {
+			"!go": {
+				"pointer": true
+			},
+			"default": false,
+			"description": "Disable search suggestions below the search bar when constructing queries. Defaults to false.",
+			"type": "boolean"
+		},
+		"search.includeArchived": {
+			"!go": {
+				"pointer": true
+			},
+			"default": false,
+			"description": "Whether searches should include searching archived repositories.",
+			"type": "boolean"
+		},
+		"search.includeForks": {
+			"!go": {
+				"pointer": true
+			},
+			"default": false,
+			"description": "Whether searches should include searching forked repositories.",
+			"type": "boolean"
+		},
+		"search.scopes": {
+			"description": "Predefined search snippets that can be appended to any search (also known as search scopes)",
+			"items": {
+				"$ref": "#/definitions/SearchScope"
+			},
+			"type": "array"
+		},
+		"siteWideSearchContext": {
+			"!go": {
+				"pointer": true
+			},
+			"description": "Enables default site wide search context. Only admins can set this. Individual users can override with their own search context.",
+			"title": "SettingsSiteWideSearchContext",
+			"type": "string"
+		}
+	},
+	"title": "Settings",
+	"type": "object"
 }
 ```
 {/* SCHEMA_SYNC_END: admin/config/settings.schema.json */}
-
 ## Configuration Notes
 
 ### Settings Hierarchy and Inheritance

--- a/docs/admin/config/site_config.mdx
+++ b/docs/admin/config/site_config.mdx
@@ -21,922 +21,5979 @@ All site configuration options and their default values are shown below.
 
 {/* SCHEMA_SYNC_START: admin/config/site.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T19:22:20Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
-	// Prompts user to install new browser for non es5
-	"RedirectUnsupportedBrowser": false,
-
-	// Configuration options for App only.
-	"app": null,
-	// Other example values:
-	// - {
-	//     "app": {
-	//       "dotcomAuthToken": "abc123"
-	//     }
-	//   }
-
-	// Enables and configures password policy. This will allow admins to enforce password complexity and length requirements.
-	"auth.passwordPolicy": null,
-	// Other example values:
-	// - {
-	//     "enabled": true,
-	//     "numberOfSpecialCharacters": 1,
-	//     "requireAtLeastOneNumber": true,
-	//     "requireUpperandLowerCase": true
-	//   }
-
-	// When true, site admins will only be able to see private code they have access to via our authz system.
-	"authz.enforceForSiteAdmins": false,
-
-	// Time interval (in seconds) of how often each component picks up authorization changes in external services.
-	"authz.refreshInterval": 5,
-
-	// Reject unverified commits when creating a Batch Change
-	"batchChanges.rejectUnverifiedCommit": false,
-
-	// Customize Sourcegraph homepage logo and search icon.
-	//
-	// Only available in Sourcegraph Enterprise.
-	"branding": null,
-	// Other example values:
-	// - {
-	//     "dark": {
-	//       "logo": "https://example.com/logo_dark.png",
-	//       "symbol": "https://example.com/search_symbol_dark_24x24.png"
-	//     },
-	//     "disableSymbolSpin": true,
-	//     "favicon": "https://example.com/favicon.ico",
-	//     "light": {
-	//       "logo": "https://example.com/logo_light.png",
-	//       "symbol": "https://example.com/search_symbol_light_24x24.png"
-	//     }
-	//   }
-
-	// Whether clone progress should be logged to a file. If enabled, logs are written to files in the OS default path for temporary files.
-	"cloneProgress.log": false,
-
-	// Configuration for the completions service.
-	"completions": null,
-	// Other example values:
-	// - {
-	//     "accessToken": "abc123",
-	//     "chatModel": "chat",
-	//     "completionModel": "code-completion",
-	//     "enabled": true,
-	//     "perUserDailyLimit": 100,
-	//     "provider": "openai"
-	//   }
-
-	// The rate limit (in requests per hour) for the default rate limiter in the rate limiters registry. By default this is disabled and the default rate limit is infinity.
-	"defaultRateLimit": -1,
-
-	// Configuration for embeddings service.
-	"embeddings": null,
-	// Other example values:
-	// - {
-	//     "accessToken": "your-access-token",
-	//     "dimensions": 1536,
-	//     "enabled": true,
-	//     "excludedFilePathPatterns": [
-	//       "*.svg",
-	//       "**/__mocks__/**",
-	//       "**/test/**"
-	//     ],
-	//     "model": "text-embedding-ada-002",
-	//     "url": "https://api.openai.com/v1/embeddings"
-	//   }
-
-	// Configuration for encryption keys used to encrypt data at rest in the database.
-	"encryption.keys": null,
-	// Other example values:
-	// - {
-	//     "externalServiceKey": {
-	//       "filePath": "/path/to/external_service.key",
-	//       "type": "mounted"
-	//     }
-	//   }
-	// - {
-	//     "userExternalAccountKey": {
-	//       "keyname": "projects/my-project/locations/global/keyRings/my-keyring/cryptoKeys/my-key",
-	//       "type": "cloudkms"
-	//     }
-	//   }
-
-	// The shared secret between Sourcegraph and executors. The value must contain at least 20 characters.
-	"executors.accessToken": null,
-	// Other example values:
-	// - "my-super-secret-access-token"
-
-	// The image to use for batch changes in executors. Use this value to pull from a custom image registry.
-	"executors.batcheshelperImage": "sourcegraph/batcheshelper",
-
-	// The tag to use for the batcheshelper image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.
-	"executors.batcheshelperImageTag": null,
-	// Other example values:
-	// - "4.1.0"
-
-	// The URL where Sourcegraph executors can reach the Sourcegraph instance. If not set, defaults to externalURL. URLs with a path (other than `/`) are not allowed. For Docker executors, the special hostname `host.docker.internal` can be used to refer to the Docker container's host.
-	"executors.frontendURL": null,
-	// Other example values:
-	// - "https://sourcegraph.example.com"
-
-	// The tag to use for the lsif-go image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.
-	"executors.lsifGoImage": null,
-	// Other example values:
-	// - "sourcegraph/lsif-go"
-
-	// The configuration for multiqueue executors.
-	"executors.multiqueue": null,
-
-	// The image to use for src-cli in executors. Use this value to pull from a custom image registry.
-	"executors.srcCLIImage": "sourcegraph/src-cli",
-
-	// The tag to use for the src-cli image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.
-	"executors.srcCLIImageTag": null,
-	// Other example values:
-	// - "4.1.0"
-
-	"exportUsageTelemetry": null,
-	// Other example values:
-	// - {
-	//     "batchSize": 1000,
-	//     "enabled": true,
-	//     "topicName": "usage-data",
-	//     "topicProjectName": "my-project"
-	//   }
-	// - {"enabled":false}
-
-	// The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`. Only root URLs are allowed.
-	"externalURL": null,
-	// Other example values:
-	// - "https://sourcegraph.example.com"
-
-	// DEPRECATED: The config options for Sourcegraph GitHub App.
-	"gitHubApp": null,
-	// Other example values:
-	// - {
-	//     "appID": "1234",
-	//     "clientID": "client-id",
-	//     "clientSecret": "client-secret",
-	//     "privateKey": "base64-encoded-private-key",
-	//     "slug": "sourcegraph"
-	//   }
-
-	// Record git operations that are executed on configured repositories.
-	"gitRecorder": null,
-	// Other example values:
-	// - {
-	//     "ignoredGitCommands": [
-	//       "show",
-	//       "rev-parse",
-	//       "log",
-	//       "diff",
-	//       "ls-tree"
-	//     ],
-	//     "repos": [
-	//       "github.com/sourcegraph/sourcegraph",
-	//       "github.com/gorilla/mux"
-	//     ],
-	//     "size": 1000
-	//   }
-
-	// Disk usage threshold at which to display warning notification. Value is a percentage.
-	"gitserver.diskUsageWarningThreshold": 90,
-
-	// Configuration for logging and alerting, including to external services.
-	"log": null,
-
-	// Notifications recieved from Sourcegraph.com to display in Sourcegraph.
-	"notifications": null,
-	// Other example values:
-	// - {
-	//     "key": "2023-03-10-my-key",
-	//     "message": "This is a test notification message."
-	//   }
-
-	// Configure notifications for Sourcegraph's built-in alerts. Not configurable for Sourcegraph Cloud instances.
-	"observability.alerts": null,
-	// Other example values:
-	// - {
-	//     "level": "critical",
-	//     "notifier": {
-	//       "channel": "#alerts",
-	//       "type": "slack",
-	//       "url": "https://hooks.slack.com/services/..."
-	//     }
-	//   }
-	// - {
-	//     "level": "warning",
-	//     "notifier": {
-	//       "address": "alerts@example.com",
-	//       "type": "email"
-	//     }
-	//   }
-
-	// EXPERIMENTAL: Configuration for client observability
-	"observability.client": null,
-	// Other example values:
-	// - {
-	//     "openTelemetry": {
-	//       "endpoint": "/-/debug/otlp"
-	//     }
-	//   }
-	// - {
-	//     "openTelemetry": {
-	//       "endpoint": "https://opentelemetry.example.com"
-	//     }
-	//   }
-
-	// Silence individual Sourcegraph alerts by identifier.
-	"observability.silenceAlerts": null,
-	// Other example values:
-	// - [
-	//     "warning_gitserver_disk_space_remaining"
-	//   ]
-	// - [
-	//     "critical_frontend_down",
-	//     "warning_high_load"
-	//   ]
-
-	// Configures distributed tracing within Sourcegraph. To learn more, refer to https://sourcegraph.com/docs/admin/observability/tracing
-	"observability.tracing": null,
-	// Other example values:
-	// - {
-	//     "debug": false,
-	//     "sampling": "selective",
-	//     "type": "opentelemetry",
-	//     "urlTemplate": "https://ui.honeycomb.io/$ORG/environments/$DATASET/trace?trace_id={{ .TraceID }}"
-	//   }
-	// - {
-	//     "debug": true,
-	//     "sampling": "all",
-	//     "type": "opentelemetry", // Jaeger now uses the OpenTelemetry format, the old jaeger format is deprecated
-	//     "urlTemplate": "{{ .ExternalURL }}/-/debug/jaeger/trace/{{ .TraceID }}"
-	//   }
-
-	// Configuration for organization invitations.
-	"organizationInvitations": null,
-	// Other example values:
-	// - {
-	//     "expiryTime": 48,
-	//     "signingKey": "your-signing-key"
-	//   }
-
-	// The maximum number of outbound requests to retain. This is a global limit across all outbound requests. If the limit is exceeded, older items will be deleted. If the limit is 0, no outbound requests are logged.
-	"outboundRequestLogLimit": 50,
-
-	// Time interval (in seconds) of how often cleanup worker should remove old jobs from permissions sync jobs table.
-	"permissions.syncJobCleanupInterval": 60,
-
-	// The number of last repo/user permission jobs to keep for history.
-	"permissions.syncJobsHistorySize": 5,
-
-	// Number of repo permissions to schedule for syncing in single scheduler iteration.
-	"permissions.syncOldestRepos": 10,
-
-	// Number of user permissions to schedule for syncing in single scheduler iteration.
-	"permissions.syncOldestUsers": 10,
-
-	// Don't sync a repo's permissions if it has synced within the last n seconds.
-	"permissions.syncReposBackoffSeconds": 60,
-
-	// Time interval (in seconds) of how often each component picks up authorization changes in external services.
-	"permissions.syncScheduleInterval": 15,
-
-	// Don't sync a user's permissions if they have synced within the last n seconds.
-	"permissions.syncUsersBackoffSeconds": 60,
-
-	// The maximum number of user-centric permissions syncing jobs that can be spawned concurrently. Server restart is required for changes to take effect.
-	"permissions.syncUsersMaxConcurrency": 1,
-
-	// The maximum number of repo-centric permissions syncing jobs that can be spawned concurrently. Server restart is required for changes to take effect.
-	"permissions.syncReposMaxConcurrency": 5,
-
-	"rateLimits": null,
-
-	// Enables redacting sensitive information from outbound requests. Important: We only respect this setting in development environments. In production, we always redact outbound requests.
-	"redactOutboundRequestHeaders": null,
-	// Other example values:
-	// - true
-
-	// Syntax highlighting configuration
-	"syntaxHighlighting": null,
-	// Other example values:
-	// - {
-	//     "engine": {
-	//       "default": "tree-sitter",
-	//       "overrides": {
-	//         "go": "syntect"
-	//       }
-	//     },
-	//     "languages": {
-	//       "extensions": {
-	//         "go": "go",
-	//         "ts": "typescript"
-	//       },
-	//       "patterns": [
-	//         {
-	//           "language": "cobol",
-	//           "match": "cobol_.*\\.txt"
-	//         }
-	//       ]
-	//     }
-	//   }
-
-	// Configuration for logging incoming webhooks.
-	"webhook.logging": null,
-	// Other example values:
-	// - {
-	//     "enabled": true,
-	//     "retention": "7d"
-	//   }
-
-//////////////////////////////////////////////////////////////
-// Authentication
-//////////////////////////////////////////////////////////////
-
-	// The config options for access requests
-	"auth.accessRequest": null,
-	// Other example values:
-	// - {"enabled":true}
-	// - {"enabled":false}
-
-	// Enables users to change their username after account creation. Warning: setting this to be true has security implications if you have enabled (or will at any point in the future enable) repository permissions with an option that relies on username equivalency between Sourcegraph and an external service or authentication provider. Do NOT set this to true if you are using non-built-in authentication OR rely on username equivalency for repository permissions.
-	"auth.enableUsernameChanges": false,
-
-	// The config options for account lockout
-	"auth.lockout": null,
-	// Other example values:
-	// - {
-	//     "consecutivePeriod": 300,
-	//     "failedAttemptThreshold": 3,
-	//     "lockoutPeriod": 600
-	//   }
-
-	// The minimum number of Unicode code points that a password must contain.
-	"auth.minPasswordLength": 12,
-
-	// The duration (in seconds) that a password reset link is considered valid.
-	"auth.passwordResetLinkExpiry": 14400,
-
-	// The number of auth providers that will be shown to the user on the login screen. Other providers are shown under `Other login methods` section.
-	"auth.primaryLoginProvidersCount": 3,
-
-	// The authentication providers to use for identifying and signing in users. See instructions below for configuring SAML, OpenID Connect (including Google Workspace), and HTTP authentication proxies. Multiple authentication providers are supported (by specifying multiple elements in this array).
-	"auth.providers": [
-		{
-			"allowSignup": true,
-			"type": "builtin"
+	"$id": "site.schema.json#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": true,
+	"allowComments": true,
+	"definitions": {
+		"AWSKMSEncryptionKey": {
+			"description": "AWS KMS Encryption Key, used to encrypt data in AWS environments",
+			"properties": {
+				"credentialsFile": {
+					"type": "string"
+				},
+				"keyId": {
+					"type": "string"
+				},
+				"region": {
+					"type": "string"
+				},
+				"type": {
+					"const": "awskms",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"keyId"
+			],
+			"type": "object"
+		},
+		"AccessTokenQuery": {
+			"additionalProperties": false,
+			"description": "Configuration for how to fetch an access token from a HTTP URL. Currently only valid for ServerSideProviderConfigAWSBedrock, ServerSideProviderConfigAzureOpenAI, ServerSideProviderConfigAnthropicProvider, and ServerSideProviderConfigOpenAICompatibleProvider. Ignored when accessToken field is set at same level",
+			"properties": {
+				"basicAuth": {
+					"$ref": "#/definitions/BasicAuth",
+					"description": "Basic authentication credentials"
+				},
+				"formData": {
+					"additionalProperties": {
+						"type": "string"
+					},
+					"description": "Form URL-encoded data for POST requests",
+					"type": "object"
+				},
+				"headers": {
+					"additionalProperties": {
+						"type": "string"
+					},
+					"description": "Optional headers that should be sent with the request",
+					"type": "object"
+				},
+				"method": {
+					"default": "GET",
+					"description": "HTTP method to use when querying for the access token",
+					"type": "string"
+				},
+				"queryParams": {
+					"additionalProperties": {
+						"type": "string"
+					},
+					"description": "Any query parameters needed on the URL",
+					"type": "object"
+				},
+				"url": {
+					"description": "The HTTP URL where the token can be fetched",
+					"format": "uri",
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"AuthProviderCommon": {
+			"$comment": "This schema is not used directly. The *AuthProvider schemas refer to its properties directly.",
+			"description": "Common properties for authentication providers.",
+			"properties": {
+				"displayName": {
+					"description": "The name to use when displaying this authentication provider in the UI. Defaults to an auto-generated name with the type of authentication provider and other relevant identifiers (such as a hostname).",
+					"type": "string"
+				},
+				"displayPrefix": {
+					"!go": {
+						"pointer": true
+					},
+					"default": "Continue with ",
+					"description": "Defines the prefix of the auth provider button on the login screen. By default we show `Continue with \u003cdisplayName\u003e`. This propery allows you to change the `Continue with ` part to something else. Useful in cases where the displayName is not compatible with the prefix.",
+					"type": "string"
+				},
+				"hidden": {
+					"default": false,
+					"description": "Hides the configured auth provider from regular use through our web interface by omitting it from the JSContext, useful for experimental auth setups.",
+					"type": "boolean"
+				},
+				"noSignIn": {
+					"default": false,
+					"description": "Hides the configured auth provider from the sign in page, but still allows users to connect an external account using their Account Security page to enable permissions syncing.",
+					"type": "boolean"
+				},
+				"order": {
+					"description": "Determines order of auth providers on the login screen. Ordered as numbers, for example 1, 2, 3.",
+					"minimum": 1,
+					"type": "integer"
+				}
+			},
+			"type": "object"
+		},
+		"AzureDevOpsAuthProvider": {
+			"additionalProperties": false,
+			"description": "Azure auth provider for dev.azure.com",
+			"properties": {
+				"allowOrgs": {
+					"default": [],
+					"description": "Restricts new logins and signups (if allowSignup is true) to members of these Azure DevOps organizations only. Existing sessions won't be invalidated. Leave empty or unset for no org restrictions.",
+					"items": {
+						"minLength": 1,
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"allowSignup": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "Allows new visitors to sign up for accounts Azure DevOps authentication. If false, users signing in via Azure DevOps must have an existing Sourcegraph account, which will be linked to their Azure DevOps identity after sign-in.",
+					"type": "boolean"
+				},
+				"apiScope": {
+					"default": "vso.code,vso.identity,vso.project",
+					"deprecated": true,
+					"deprecationMessage": "Deprecated because this changed with the change to Entra Apps. Configure the scopes you want to grant within Entra under API permissions instead.",
+					"description": "DEPRECATED: The OAuth API scope that should be used",
+					"type": "string"
+				},
+				"clientID": {
+					"description": "The app ID of the Azure OAuth app.",
+					"type": "string"
+				},
+				"clientSecret": {
+					"description": "The client Secret of the Azure OAuth app.",
+					"type": "string"
+				},
+				"displayName": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/displayName"
+				},
+				"displayPrefix": {
+					"!go": {
+						"pointer": true
+					},
+					"$ref": "#/definitions/AuthProviderCommon/properties/displayPrefix"
+				},
+				"hidden": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/hidden"
+				},
+				"noSignIn": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/noSignIn"
+				},
+				"order": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/order"
+				},
+				"type": {
+					"const": "azureDevOps",
+					"type": "string"
+				},
+				"url": {
+					"!go": {
+						"typeName": "NormalizedURL"
+					},
+					"description": "Endpoint to authorize with Entra. Required for Entra ID App registrations (all connections created after April 2025)",
+					"example": "https://login.microsoftonline.com/00000002-0000-0000-c000-000000000000",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"clientID",
+				"clientSecret"
+			],
+			"type": "object"
+		},
+		"BasicAuth": {
+			"description": "Basic authentication credentials",
+			"properties": {
+				"password": {
+					"type": "string"
+				},
+				"username": {
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"BitbucketCloudAuthProvider": {
+			"additionalProperties": false,
+			"description": "Configures the Bitbucket Cloud OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your Bitbucket Cloud workspace: https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/. The application should have account, email, and repository scopes and the callback URL set to the concatenation of your Sourcegraph instance URL and \"/.auth/bitbucketcloud/callback\".",
+			"properties": {
+				"allowSignup": {
+					"default": true,
+					"description": "Allows new visitors to sign up for accounts via Bitbucket Cloud authentication. If false, users signing in via Bitbucket Cloud must have an existing Sourcegraph account, which will be linked to their Bitbucket Cloud identity after sign-in.",
+					"type": "boolean"
+				},
+				"apiScope": {
+					"description": "The OAuth API scope that should be used. For permission syncing, specify at least \"account,email,repository\"",
+					"type": "string"
+				},
+				"clientKey": {
+					"description": "The Key of the Bitbucket OAuth app.",
+					"type": "string"
+				},
+				"clientSecret": {
+					"description": "The Client Secret of the Bitbucket OAuth app.",
+					"type": "string"
+				},
+				"displayName": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/displayName"
+				},
+				"displayPrefix": {
+					"!go": {
+						"pointer": true
+					},
+					"$ref": "#/definitions/AuthProviderCommon/properties/displayPrefix"
+				},
+				"hidden": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/hidden"
+				},
+				"noSignIn": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/noSignIn"
+				},
+				"order": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/order"
+				},
+				"type": {
+					"const": "bitbucketcloud",
+					"type": "string"
+				},
+				"url": {
+					"!go": {
+						"typeName": "NormalizedURL"
+					},
+					"default": "https://bitbucket.org/",
+					"description": "URL of the Bitbucket Cloud instance.",
+					"pattern": "^https?://",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"clientKey",
+				"clientSecret"
+			],
+			"type": "object"
+		},
+		"BitbucketServerAuthProvider": {
+			"additionalProperties": false,
+			"description": "Configures the Bitbucket Server OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your Bitbucket Server instance: https://confluence.atlassian.com/bitbucketserver0720/configure-an-incoming-link-1116282013.html. The application should have the repository read permission and the callback URL set to the concatenation of your Sourcegraph instance URL and \"/.auth/bitbucketserver/callback\".",
+			"properties": {
+				"allowSignup": {
+					"default": true,
+					"description": "Allows new visitors to sign up for accounts via Bitbucket Server OAuth. If false, users signing in via Bitbucket Server must have an existing Sourcegraph account, which will be linked to their Bitbucket Server identity after sign-in.",
+					"type": "boolean"
+				},
+				"clientID": {
+					"description": "The ID of the Bitbucket OAuth app.",
+					"type": "string"
+				},
+				"clientSecret": {
+					"description": "The Client Secret of the Bitbucket OAuth app.",
+					"type": "string"
+				},
+				"displayName": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/displayName"
+				},
+				"displayPrefix": {
+					"!go": {
+						"pointer": true
+					},
+					"$ref": "#/definitions/AuthProviderCommon/properties/displayPrefix"
+				},
+				"hidden": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/hidden"
+				},
+				"noSignIn": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/noSignIn"
+				},
+				"order": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/order"
+				},
+				"type": {
+					"const": "bitbucketserver",
+					"type": "string"
+				},
+				"url": {
+					"!go": {
+						"typeName": "NormalizedURL"
+					},
+					"description": "URL of the Bitbucket Server instance.",
+					"example": "https://bitbucket.example.org/",
+					"pattern": "^https?://",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"clientID",
+				"clientSecret"
+			],
+			"type": "object"
+		},
+		"BrandAssets": {
+			"properties": {
+				"logo": {
+					"description": "The URL to the image used on the homepage. This will replace the Sourcegraph logo on the homepage. Maximum width: 320px. We recommend using the following file formats: SVG, PNG",
+					"format": "uri",
+					"type": "string"
+				},
+				"symbol": {
+					"description": "The URL to the symbol used as the search icon. Recommended size: 24x24px. We recommend using the following file formats: SVG, PNG, ICO",
+					"format": "uri",
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"BuiltinAuthProvider": {
+			"additionalProperties": false,
+			"description": "Configures the builtin username-password authentication provider.",
+			"properties": {
+				"allowSignup": {
+					"default": false,
+					"description": "Allows new visitors to sign up for accounts. The sign-up page will be enabled and accessible to all visitors.\n\nSECURITY: If the site has no users (i.e., during initial setup), it will always allow the first user to sign up and become site admin **without any approval** (first user to sign up becomes the admin).",
+					"type": "boolean"
+				},
+				"type": {
+					"const": "builtin",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type"
+			],
+			"type": "object"
+		},
+		"ClientSideModelConfig": {
+			"default": null,
+			"description": "No client-side model configuration is currently available.",
+			"properties": {
+				"openaicompatible": {
+					"$ref": "#/definitions/ClientSideModelConfigOpenAICompatible"
+				}
+			},
+			"type": "object"
+		},
+		"ClientSideModelConfigOpenAICompatible": {
+			"default": null,
+			"description": "Advanced configuration options that are only respected if the model is provided by an openaicompatible provider.",
+			"properties": {
+				"autoCompleteMultilineMaxTokens": {
+					"type": "integer"
+				},
+				"autoCompleteSinglelineMaxTokens": {
+					"type": "integer"
+				},
+				"autoCompleteTemperature": {
+					"!go": {
+						"pointer": true
+					},
+					"type": "number"
+				},
+				"autoCompleteTopK": {
+					"!go": {
+						"pointer": true
+					},
+					"type": "number"
+				},
+				"autoCompleteTopP": {
+					"!go": {
+						"pointer": true
+					},
+					"type": "number"
+				},
+				"autocompleteMultilineTimeout": {
+					"description": "How long the client should wait for autocomplete results to come back (milliseconds), before giving up and not displaying an autocomplete result at all.\n\nThis applies on multi-line completions, which are based on intent-detection when e.g. a code block is being completed, e.g. 'func parseURL(url string) {\u003ccompletion\u003e'\n\nNote: similar to hidden Cody client config option 'cody.autocomplete.advanced.timeout.multiline' If user has configured that, it will be respected instead of this.",
+					"type": "integer"
+				},
+				"autocompleteSinglelineTimeout": {
+					"description": "How long the client should wait for autocomplete results to come back (milliseconds), before giving up and not displaying an autocomplete result at all.\n\nThis applies on single-line completions, e.g. 'var i = \u003ccompletion\u003e'\n\nNote: similar to hidden Cody client config option 'cody.autocomplete.advanced.timeout.singleline' If user has configured that, it will be respected instead of this.",
+					"type": "integer"
+				},
+				"chatMaxTokens": {
+					"type": "integer"
+				},
+				"chatPreInstruction": {
+					"description": "Custom instruction to be included at the start of all chat messages\nwhen using this model, e.g. 'Answer all questions in Spanish.'\n\nNote: similar to Cody client config option 'cody.chat.preInstruction'; if user has configured that it will be used instead of this.",
+					"type": "string"
+				},
+				"chatTemperature": {
+					"!go": {
+						"pointer": true
+					},
+					"type": "number"
+				},
+				"chatTopK": {
+					"!go": {
+						"pointer": true
+					},
+					"type": "number"
+				},
+				"chatTopP": {
+					"!go": {
+						"pointer": true
+					},
+					"type": "number"
+				},
+				"contextSizeHintPrefixCharacters": {
+					"!go": {
+						"pointer": true
+					},
+					"default": null,
+					"description": "A hint the client should use when producing context to send to the LLM.\nThe maximum length of the document prefix (text before the cursor) to include, in characters.",
+					"type": "integer"
+				},
+				"contextSizeHintSuffixCharacters": {
+					"!go": {
+						"pointer": true
+					},
+					"default": null,
+					"description": "A hint the client should use when producing context to send to the LLM.\nThe maximum length of the document suffix (text after the cursor) to include, in characters.",
+					"type": "integer"
+				},
+				"contextSizeHintTotalCharacters": {
+					"!go": {
+						"pointer": true
+					},
+					"default": null,
+					"description": "A hint the client should use when producing context to send to the LLM.\nThe maximum length of all context (prefix + suffix + snippets), in characters.",
+					"type": "integer"
+				},
+				"editMaxTokens": {
+					"type": "integer"
+				},
+				"editPostInstruction": {
+					"description": "Custom instruction to be included at the end of all edit commands\nwhen using this model, e.g. 'Write all unit tests with Jest instead of detected framework.'\n\nNote: similar to Cody client config option 'cody.edit.preInstruction'; if user has configured that it will be respected instead of this.",
+					"type": "string"
+				},
+				"editTemperature": {
+					"!go": {
+						"pointer": true
+					},
+					"type": "number"
+				},
+				"editTopK": {
+					"!go": {
+						"pointer": true
+					},
+					"type": "number"
+				},
+				"editTopP": {
+					"!go": {
+						"pointer": true
+					},
+					"type": "number"
+				},
+				"endOfText": {
+					"description": "End of text identifier used by the model.",
+					"examples": [
+						"\u003c|endoftext|\u003e",
+						"\u003cEOT\u003e"
+					],
+					"type": "string"
+				},
+				"stopSequences": {
+					"items": {
+						"description": "List of stop sequences to use for this model.",
+						"examples": [
+							"\n"
+						],
+						"type": "string"
+					},
+					"type": "array"
+				}
+			},
+			"type": "object"
+		},
+		"ClientSideProviderConfig": {
+			"default": null,
+			"description": "No client-side provider configuration is currently available.",
+			"properties": {},
+			"type": "object"
+		},
+		"CloudKMSEncryptionKey": {
+			"description": "Google Cloud KMS Encryption Key, used to encrypt data in Google Cloud environments",
+			"properties": {
+				"credentialsFile": {
+					"type": "string"
+				},
+				"keyname": {
+					"type": "string"
+				},
+				"type": {
+					"const": "cloudkms",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"keyname"
+			],
+			"type": "object"
+		},
+		"CodyContextFilterItem": {
+			"properties": {
+				"repoNamePattern": {
+					"description": "Regular expression which matches a set of repository names. The pattern is evaluated using Go regular expression syntax (https://golang.org/pkg/regexp/). By default, the pattern matches partially. Use \\\"^...$\\\" for whole-string matching.",
+					"format": "regex",
+					"type": "string"
+				}
+			},
+			"required": [
+				"repoNamePattern"
+			],
+			"type": "object"
+		},
+		"CodyRerankerCohere": {
+			"description": "Re-ranker using Cohere API",
+			"properties": {
+				"apiKey": {
+					"type": "string"
+				},
+				"model": {
+					"default": "rerank-v3.5",
+					"type": "string"
+				},
+				"type": {
+					"const": "cohere",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"apiKey"
+			],
+			"type": "object"
+		},
+		"CodyRerankerIdentity": {
+			"description": "Identity re-ranker",
+			"properties": {
+				"type": {
+					"const": "identity",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type"
+			],
+			"type": "object"
+		},
+		"CodyRerankerSourcegraph": {
+			"description": "Re-ranker using Sourcegraph API",
+			"properties": {
+				"accessToken": {
+					"type": "string"
+				},
+				"endpoint": {
+					"type": "string"
+				},
+				"type": {
+					"const": "sourcegraph",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type"
+			],
+			"type": "object"
+		},
+		"CodyRerankerVoyageAI": {
+			"description": "Re-ranker using VoyageAI API",
+			"properties": {
+				"apiKey": {
+					"type": "string"
+				},
+				"model": {
+					"default": "rerank-2",
+					"type": "string"
+				},
+				"type": {
+					"const": "voyageai",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"apiKey"
+			],
+			"type": "object"
+		},
+		"ContextWindow": {
+			"description": "Context window for the model",
+			"examples": [
+				{
+					"maxInputTokens": 7000,
+					"maxOutputTokens": 4000
+				}
+			],
+			"properties": {
+				"maxInputTokens": {
+					"examples": [
+						7000
+					],
+					"type": "integer"
+				},
+				"maxOutputTokens": {
+					"examples": [
+						4000
+					],
+					"type": "integer"
+				}
+			},
+			"required": [
+				"maxInputTokens",
+				"maxOutputTokens"
+			],
+			"type": "object"
+		},
+		"DefaultModelConfig": {
+			"description": "The model configuration that is applied to every model for a given provider.",
+			"properties": {
+				"capabilities": {
+					"description": "Whether the model can be used for chat, just autocomplete, etc.",
+					"examples": [
+						[
+							"chat",
+							"autocomplete",
+							"vision",
+							"reasoning",
+							"edit",
+							"tools"
+						]
+					],
+					"items": {
+						"enum": [
+							"autocomplete",
+							"chat",
+							"vision",
+							"reasoning",
+							"edit",
+							"tools",
+							"fallback"
+						],
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"category": {
+					"enum": [
+						"balanced",
+						"speed",
+						"other",
+						"accuracy"
+					],
+					"examples": [
+						[
+							"balanced"
+						]
+					],
+					"type": "string"
+				},
+				"clientSideConfig": {
+					"$ref": "#/definitions/ClientSideModelConfig"
+				},
+				"contextWindow": {
+					"$ref": "#/definitions/ContextWindow"
+				},
+				"modelCost": {
+					"$ref": "#/definitions/ModelCost"
+				},
+				"serverSideConfig": {
+					"$ref": "#/definitions/ServerSideModelConfig"
+				},
+				"status": {
+					"enum": [
+						"experimental",
+						"beta",
+						"stable",
+						"deprecated"
+					],
+					"examples": [
+						[
+							"stable"
+						]
+					],
+					"type": "string"
+				}
+			},
+			"required": [
+				"capabilities",
+				"category",
+				"status",
+				"contextWindow"
+			],
+			"type": "object"
+		},
+		"DefaultModels": {
+			"default": null,
+			"properties": {
+				"chat": {
+					"description": "The qualified name of the model to use for chat, in '${ProviderID}::${APIVersionID}::${ModelID}' format",
+					"examples": [
+						[
+							"anthropic::2023-06-01::claude-3-sonnet",
+							"openai::2024-02-01::gpt-4-turbo"
+						]
+					],
+					"type": "string"
+				},
+				"codeCompletion": {
+					"description": "The qualified name of the model to use for code completion, in '${ProviderID}::${APIVersionID}::${ModelID}' format",
+					"examples": [
+						[
+							"anthropic::2023-06-01::claude-3-sonnet",
+							"openai::2024-02-01::gpt-4-turbo"
+						]
+					],
+					"type": "string"
+				},
+				"fallbackChat": {
+					"description": "The qualified name of the model to use for unlimited chat, in '${ProviderID}::${APIVersionID}::${ModelID}' format",
+					"examples": [
+						[
+							"google::v1::gemini-2.0-flash"
+						]
+					],
+					"type": "string"
+				},
+				"fastChat": {
+					"description": "The qualified name of the model to use for fast chat, in '${ProviderID}::${APIVersionID}::${ModelID}' format",
+					"examples": [
+						[
+							"anthropic::2023-06-01::claude-3-sonnet",
+							"openai::2024-02-01::gpt-4-turbo"
+						]
+					],
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"DoNotUsePhonyDiscriminantType": {
+			"properties": {
+				"doNotUseThisProperty": {
+					"description": "Do not use/set this property, it is useless. go-jsonschema has an issue where it does not support writing a tagged union unless it can find a field each of the union types do NOT have in common; this type merely exists to provide a field that is not in common with all other oneOf types. https://sourcegraph.com/github.com/sourcegraph/go-jsonschema/-/blob/compiler/generator_tagged_union_type.go?L47-49",
+					"type": "string"
+				},
+				"type": {
+					"const": "unused",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type"
+			],
+			"type": "object"
+		},
+		"EmailTemplate": {
+			"properties": {
+				"html": {
+					"description": "Template for HTML body",
+					"type": "string"
+				},
+				"subject": {
+					"description": "Template for email subject header",
+					"type": "string"
+				},
+				"text": {
+					"description": "Optional template for plain-text body. If not provided, a plain-text body will be automatically generated from the HTML template.",
+					"type": "string"
+				}
+			},
+			"required": [
+				"subject",
+				"html"
+			],
+			"type": "object"
+		},
+		"EncryptionKey": {
+			"!go": {
+				"taggedUnionType": true
+			},
+			"description": "Config for a key",
+			"oneOf": [
+				{
+					"$ref": "#/definitions/CloudKMSEncryptionKey"
+				},
+				{
+					"$ref": "#/definitions/AWSKMSEncryptionKey"
+				},
+				{
+					"$ref": "#/definitions/MountedEncryptionKey"
+				},
+				{
+					"$ref": "#/definitions/NoOpEncryptionKey"
+				}
+			],
+			"properties": {
+				"type": {
+					"enum": [
+						"cloudkms",
+						"awskms",
+						"mounted",
+						"noop"
+					],
+					"type": "string"
+				}
+			},
+			"required": [
+				"type"
+			],
+			"type": "object"
+		},
+		"GerritAuthProvider": {
+			"additionalProperties": false,
+			"description": "Gerrit auth provider",
+			"properties": {
+				"displayName": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/displayName"
+				},
+				"displayPrefix": {
+					"!go": {
+						"pointer": true
+					},
+					"$ref": "#/definitions/AuthProviderCommon/properties/displayPrefix"
+				},
+				"hidden": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/hidden"
+				},
+				"noSignIn": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/noSignIn"
+				},
+				"order": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/order"
+				},
+				"type": {
+					"const": "gerrit",
+					"type": "string"
+				},
+				"url": {
+					"!go": {
+						"typeName": "NormalizedURL"
+					},
+					"default": "https://gerrit-review.googlesource.com/",
+					"description": "URL of the Gerrit instance, such as https://gerrit-review.googlesource.com or https://gerrit.example.com.",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"url"
+			],
+			"type": "object"
+		},
+		"GitHubAuthProvider": {
+			"additionalProperties": false,
+			"description": "Configures the GitHub (or GitHub Enterprise) OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your GitHub instance: https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/. When a user signs into Sourcegraph or links their GitHub account to their existing Sourcegraph account, GitHub will prompt the user for the repo scope.",
+			"properties": {
+				"allowGroupsPermissionsSync": {
+					"default": false,
+					"description": "Experimental: Allows sync of GitHub teams and organizations permissions across all external services associated with this provider to allow enabling of [repository permissions caching](https://sourcegraph.com/docs/admin/code_hosts/github#teams-and-organizations-permissions-caching).",
+					"type": "boolean"
+				},
+				"allowOrgs": {
+					"default": [],
+					"description": "Restricts new logins and signups (if allowSignup is true) to members of these GitHub organizations. Existing sessions won't be invalidated. Leave empty or unset for no org restrictions.",
+					"items": {
+						"minLength": 1,
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"allowOrgsMap": {
+					"additionalProperties": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"default": {},
+					"description": "Restricts new logins and signups (if allowSignup is true) to members of GitHub teams. Each list of teams should have their Github org name as a key. Subteams inheritance is not supported, therefore only members of the listed teams will be granted access. Existing sessions won't be invalidated. Leave empty or unset for no team restrictions.",
+					"examples": [
+						{
+							"anotherOrgName": [
+								"team2",
+								"team3"
+							],
+							"orgName": [
+								"team1"
+							]
+						}
+					],
+					"type": "object"
+				},
+				"allowSignup": {
+					"default": false,
+					"description": "Allows new visitors to sign up for accounts via GitHub authentication. If false, users signing in via GitHub must have an existing Sourcegraph account, which will be linked to their GitHub identity after sign-in.",
+					"type": "boolean"
+				},
+				"clientID": {
+					"description": "The Client ID of the GitHub OAuth app, accessible from https://github.com/settings/developers (or the same path on GitHub Enterprise).",
+					"type": "string"
+				},
+				"clientSecret": {
+					"description": "The Client Secret of the GitHub OAuth app, accessible from https://github.com/settings/developers (or the same path on GitHub Enterprise).",
+					"type": "string"
+				},
+				"displayName": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/displayName"
+				},
+				"displayPrefix": {
+					"!go": {
+						"pointer": true
+					},
+					"$ref": "#/definitions/AuthProviderCommon/properties/displayPrefix"
+				},
+				"hidden": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/hidden"
+				},
+				"noSignIn": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/noSignIn"
+				},
+				"order": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/order"
+				},
+				"type": {
+					"const": "github",
+					"type": "string"
+				},
+				"url": {
+					"!go": {
+						"typeName": "NormalizedURL"
+					},
+					"default": "https://github.com/",
+					"description": "URL of the GitHub instance, such as https://github.com/ or https://github-enterprise.example.com.",
+					"pattern": "^https?://",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"clientID",
+				"clientSecret"
+			],
+			"type": "object"
+		},
+		"GitLabAuthProvider": {
+			"additionalProperties": false,
+			"description": "Configures the GitLab OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your GitLab instance: https://docs.gitlab.com/ee/integration/oauth_provider.html. The application should have `api` and `read_user` scopes and the callback URL set to the concatenation of your Sourcegraph instance URL and \"/.auth/gitlab/callback\".",
+			"properties": {
+				"allowGroups": {
+					"default": [],
+					"description": "Restricts new logins and signups (if allowSignup is true) to members of these GitLab groups. Existing sessions won't be invalidated. Make sure to inform the full path for groups or subgroups instead of their names. Leave empty or unset for no group restrictions.",
+					"examples": [
+						[
+							"group",
+							"group/subgroup",
+							"group/subgroup/subgroup"
+						]
+					],
+					"items": {
+						"minLength": 1,
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"allowSignup": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "Allows new visitors to sign up for accounts via GitLab authentication. If false, users signing in via GitLab must have an existing Sourcegraph account, which will be linked to their GitLab identity after sign-in.",
+					"type": "boolean"
+				},
+				"apiScope": {
+					"default": "api",
+					"description": "The OAuth API scope that should be used",
+					"enum": [
+						"api",
+						"read_api"
+					],
+					"type": "string"
+				},
+				"clientID": {
+					"description": "The Client ID of the GitLab OAuth app, accessible from https://gitlab.com/oauth/applications (or the same path on your private GitLab instance).",
+					"type": "string"
+				},
+				"clientSecret": {
+					"description": "The Client Secret of the GitLab OAuth app, accessible from https://gitlab.com/oauth/applications (or the same path on your private GitLab instance).",
+					"type": "string"
+				},
+				"displayName": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/displayName"
+				},
+				"displayPrefix": {
+					"!go": {
+						"pointer": true
+					},
+					"$ref": "#/definitions/AuthProviderCommon/properties/displayPrefix"
+				},
+				"hidden": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/hidden"
+				},
+				"noSignIn": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/noSignIn"
+				},
+				"order": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/order"
+				},
+				"ssoURL": {
+					"default": "",
+					"description": "An alternate sign-in URL used to ease SSO sign-in flows, such as https://gitlab.com/groups/your-group/saml/sso?token=xxxxxx",
+					"type": "string"
+				},
+				"syncInternalRepoPermissions": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "Whether to sync permissions for internal repositories on GitLab. Setting this to false can be useful when internal repositories are configured to be public on Sourcegraph.",
+					"type": "boolean"
+				},
+				"tokenRefreshWindowMinutes": {
+					"default": 10,
+					"description": "Time in minutes before token expiry when we should attempt to refresh it",
+					"type": "integer"
+				},
+				"type": {
+					"const": "gitlab",
+					"type": "string"
+				},
+				"url": {
+					"!go": {
+						"typeName": "NormalizedURL"
+					},
+					"default": "https://gitlab.com/",
+					"description": "URL of the GitLab instance, such as https://gitlab.com or https://gitlab.example.com.",
+					"pattern": "^https?://",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"clientID",
+				"clientSecret"
+			],
+			"type": "object"
+		},
+		"HTTPHeaderAuthProvider": {
+			"additionalProperties": false,
+			"description": "Configures the HTTP header authentication provider (which authenticates users by consulting an HTTP request header set by an authentication proxy such as https://github.com/bitly/oauth2_proxy).",
+			"properties": {
+				"allowSignup": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "Creates accounts for new users. Set this value to false to require users with HTTP header attestation to have an existing Sourcegraph account.",
+					"examples": [
+						false
+					],
+					"type": "boolean"
+				},
+				"emailHeader": {
+					"description": "The name (case-insensitive) of an HTTP header whose value is taken to be the email of the client requesting the page. Set this value when using an HTTP proxy that authenticates requests, and you don't want the extra configurability of the other authentication methods.",
+					"examples": [
+						"X-App-Email"
+					],
+					"type": "string"
+				},
+				"stripUsernameHeaderPrefix": {
+					"description": "The prefix that precedes the username portion of the HTTP header specified in `usernameHeader`. If specified, the prefix will be stripped from the header value and the remainder will be used as the username. For example, if using Google Identity-Aware Proxy (IAP) with Google Sign-In, set this value to `accounts.google.com:`.",
+					"examples": [
+						"accounts.google.com:"
+					],
+					"type": "string"
+				},
+				"type": {
+					"const": "http-header",
+					"type": "string"
+				},
+				"usernameHeader": {
+					"description": "The name (case-insensitive) of an HTTP header whose value is taken to be the username of the client requesting the page. Set this value when using an HTTP proxy that authenticates requests, and you don't want the extra configurability of the other authentication methods.",
+					"examples": [
+						"X-Forwarded-User"
+					],
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"usernameHeader"
+			],
+			"type": "object"
+		},
+		"ModelCost": {
+			"description": "Monetary cost of using a particular model with a given usage",
+			"examples": [
+				{
+					"inputTokenCredits": 7000,
+					"outputTokenCredits": 4000,
+					"unit": "mtok"
+				}
+			],
+			"properties": {
+				"inputTokenCredits": {
+					"!go": {
+						"pointer": true
+					},
+					"description": "Cost per unit of input tokens in credits",
+					"examples": [
+						7000
+					],
+					"type": "integer"
+				},
+				"inputTokenPennies": {
+					"!go": {
+						"pointer": true
+					},
+					"description": "DEPRECATED: Use inputTokenCredits instead.",
+					"type": "integer"
+				},
+				"outputTokenCredits": {
+					"!go": {
+						"pointer": true
+					},
+					"description": "Cost per unit of output tokens in credits",
+					"examples": [
+						4000
+					],
+					"type": "integer"
+				},
+				"outputTokenPennies": {
+					"!go": {
+						"pointer": true
+					},
+					"description": "DEPRECATED: Use outputTokenCredits instead.",
+					"type": "integer"
+				},
+				"unit": {
+					"description": "Unit of measurement for token price, either per million or per billion tokens",
+					"enum": [
+						"mtok",
+						"btok"
+					],
+					"examples": [
+						"mtok"
+					],
+					"type": "string"
+				}
+			},
+			"required": [
+				"unit"
+			],
+			"type": "object"
+		},
+		"ModelFilters": {
+			"default": null,
+			"description": "Filters that allow you to constrain which models are available to users.",
+			"properties": {
+				"allow": {
+					"default": [
+						"*"
+					],
+					"description": "Constrain models to only those in this allow list. Wildcards may be used here, but not regexp.",
+					"examples": [
+						"anthropic::*",
+						"openai::2024-02-01::*"
+					],
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"deny": {
+					"default": [],
+					"description": "Any models in this deny list will not be allowed. Wildcards may be used here, but not regexp.",
+					"examples": [
+						[
+							"*gpt*"
+						]
+					],
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"statusFilter": {
+					"default": [
+						"stable"
+					],
+					"description": "Constrain models to just those matching one of the supplied statuses",
+					"examples": [
+						"beta",
+						"stable"
+					],
+					"items": {
+						"enum": [
+							"experimental",
+							"beta",
+							"stable",
+							"deprecated"
+						],
+						"type": "string"
+					},
+					"type": "array"
+				}
+			},
+			"type": "object"
+		},
+		"ModelOverride": {
+			"properties": {
+				"capabilities": {
+					"description": "Whether the model can be used for chat, just autocomplete, etc.",
+					"examples": [
+						[
+							"chat",
+							"autocomplete",
+							"vision",
+							"reasoning",
+							"edit",
+							"tools"
+						]
+					],
+					"items": {
+						"enum": [
+							"autocomplete",
+							"chat",
+							"vision",
+							"reasoning",
+							"edit",
+							"tools",
+							"fallback"
+						],
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"category": {
+					"enum": [
+						"balanced",
+						"speed",
+						"other",
+						"accuracy"
+					],
+					"examples": [
+						"balanced"
+					],
+					"type": "string"
+				},
+				"clientSideConfig": {
+					"$ref": "#/definitions/ClientSideModelConfig"
+				},
+				"contextWindow": {
+					"$ref": "#/definitions/ContextWindow"
+				},
+				"displayName": {
+					"description": "display name",
+					"examples": [
+						"Claude 3 Sonnet",
+						"GPT-4 Turbo"
+					],
+					"type": "string"
+				},
+				"modelCost": {
+					"$ref": "#/definitions/ModelCost"
+				},
+				"modelName": {
+					"description": "model name used when sending requests to the LLM provider's backend API.",
+					"examples": [
+						"claude-3-sonnet-20240229",
+						"gpt-4-turbo"
+					],
+					"type": "string"
+				},
+				"modelRef": {
+					"description": "The qualified name of the model in '${ProviderID}::${APIVersionID}::${ModelID}' format",
+					"examples": [
+						"anthropic::2023-06-01::claude-3-sonnet",
+						"openai::2024-02-01::gpt-4-turbo"
+					],
+					"type": "string"
+				},
+				"reasoningEffort": {
+					"enum": [
+						"low",
+						"medium",
+						"high"
+					],
+					"examples": [
+						"low"
+					],
+					"type": "string"
+				},
+				"serverSideConfig": {
+					"$ref": "#/definitions/ServerSideModelConfig"
+				},
+				"status": {
+					"enum": [
+						"experimental",
+						"beta",
+						"stable",
+						"deprecated"
+					],
+					"examples": [
+						"stable"
+					],
+					"type": "string"
+				}
+			},
+			"required": [
+				"modelRef",
+				"displayName",
+				"modelName",
+				"capabilities",
+				"category",
+				"status",
+				"contextWindow"
+			],
+			"type": "object"
+		},
+		"MountedEncryptionKey": {
+			"description": "This encryption key is mounted from a given file path or an environment variable.",
+			"properties": {
+				"envVarName": {
+					"type": "string"
+				},
+				"filepath": {
+					"type": "string"
+				},
+				"keyname": {
+					"type": "string"
+				},
+				"type": {
+					"const": "mounted",
+					"type": "string"
+				},
+				"version": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"keyname"
+			],
+			"type": "object"
+		},
+		"NoOpEncryptionKey": {
+			"description": "This encryption key is a no op, leaving your data in plaintext (not recommended).",
+			"properties": {
+				"type": {
+					"const": "noop",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type"
+			],
+			"type": "object"
+		},
+		"NotifierEmail": {
+			"description": "Email notifier",
+			"properties": {
+				"address": {
+					"description": "Address to send email to",
+					"type": "string"
+				},
+				"type": {
+					"const": "email",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"address"
+			],
+			"type": "object"
+		},
+		"NotifierOpsGenie": {
+			"description": "OpsGenie notifier",
+			"properties": {
+				"apiKey": {
+					"type": "string"
+				},
+				"apiUrl": {
+					"type": "string"
+				},
+				"priority": {
+					"description": "Defines the importance of an alert. Allowed values are P1, P2, P3, P4, P5 - or a Go template that resolves to one of those values. By default, Sourcegraph will fill this in for you if a value isn't specified here.",
+					"type": "string"
+				},
+				"responders": {
+					"description": "List of responders responsible for notifications.",
+					"items": {
+						"oneOf": [
+							{
+								"required": [
+									"type",
+									"id"
+								]
+							},
+							{
+								"required": [
+									"type",
+									"name"
+								]
+							},
+							{
+								"required": [
+									"type",
+									"username"
+								]
+							}
+						],
+						"properties": {
+							"id": {
+								"type": "string"
+							},
+							"name": {
+								"type": "string"
+							},
+							"type": {
+								"enum": [
+									"team",
+									"user",
+									"escalation",
+									"schedule"
+								],
+								"type": "string"
+							},
+							"username": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"type": "array"
+				},
+				"tags": {
+					"description": "Comma separated list of tags attached to the notifications - or a Go template that produces such a list. Sourcegraph provides some default ones if this value isn't specified.",
+					"type": "string"
+				},
+				"type": {
+					"const": "opsgenie",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type"
+			],
+			"type": "object"
+		},
+		"NotifierPagerduty": {
+			"description": "PagerDuty notifier",
+			"properties": {
+				"apiUrl": {
+					"type": "string"
+				},
+				"integrationKey": {
+					"description": "Integration key for the PagerDuty Events API v2 - see https://developer.pagerduty.com/docs/events-api-v2/overview",
+					"type": "string"
+				},
+				"severity": {
+					"description": "Severity level for PagerDuty alert",
+					"type": "string"
+				},
+				"type": {
+					"const": "pagerduty",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"integrationKey"
+			],
+			"type": "object"
+		},
+		"NotifierSlack": {
+			"description": "Slack notifier",
+			"properties": {
+				"icon_emoji": {
+					"description": "Provide an emoji to use as the icon for the bot’s message. Ex :smile:",
+					"type": "string"
+				},
+				"icon_url": {
+					"description": "Provide a URL to an image to use as the icon for the bot’s message.",
+					"type": "string"
+				},
+				"recipient": {
+					"description": "Allows you to override the Slack recipient. You must either provide a channel Slack ID, a user Slack ID, a username reference (@\u003cuser\u003e, all lowercase, no whitespace), or a channel reference (#\u003cchannel\u003e, all lowercase, no whitespace).",
+					"type": "string"
+				},
+				"type": {
+					"const": "slack",
+					"type": "string"
+				},
+				"url": {
+					"description": "Slack incoming webhook URL.",
+					"type": "string"
+				},
+				"username": {
+					"description": "Set the username for the bot’s message.",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type"
+			],
+			"type": "object"
+		},
+		"NotifierWebhook": {
+			"description": "Webhook notifier",
+			"properties": {
+				"bearerToken": {
+					"type": "string"
+				},
+				"password": {
+					"type": "string"
+				},
+				"type": {
+					"const": "webhook",
+					"type": "string"
+				},
+				"url": {
+					"type": "string"
+				},
+				"username": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"url"
+			],
+			"type": "object"
+		},
+		"OpenAICompatibleEndpoint": {
+			"description": "Endpoints to connect to. If multiple are specified, Sourcegraph will randomly distribute requests between them.",
+			"items": {
+				"minLength": 1,
+				"properties": {
+					"accessToken": {
+						"type": "string"
+					},
+					"accessTokenQuery": {
+						"$ref": "#/definitions/AccessTokenQuery",
+						"description": "Ignored when accessToken is set; this is a configuration for fetching a provider access token over HTTP."
+					},
+					"headers": {
+						"additionalProperties": {
+							"type": "string"
+						},
+						"description": "Optional static headers that should be sent with requests to this endpoint. If provided, both accessToken and accessTokenQuery will be ignored and no 'Authorization' header will be set unless configured here.",
+						"type": "object"
+					},
+					"url": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"url"
+				],
+				"type": "object"
+			},
+			"type": "array"
+		},
+		"OpenIDConnectAuthProvider": {
+			"additionalProperties": false,
+			"description": "Configures the OpenID Connect authentication provider for SSO.",
+			"properties": {
+				"allowSignup": {
+					"!go": {
+						"pointer": true
+					},
+					"description": "Allows new visitors to sign up for accounts via OpenID Connect authentication. If false, users signing in via OpenID Connect must have an existing Sourcegraph account, which will be linked to their OpenID Connect identity after sign-in.",
+					"type": "boolean"
+				},
+				"clientID": {
+					"description": "The client ID for the OpenID Connect client for this site.\n\nFor Google Apps: obtain this value from the API console (https://console.developers.google.com), as described at https://developers.google.com/identity/protocols/OpenIDConnect#getcredentials",
+					"pattern": "^[^\u003c]",
+					"type": "string"
+				},
+				"clientSecret": {
+					"description": "The client secret for the OpenID Connect client for this site.\n\nFor Google Apps: obtain this value from the API console (https://console.developers.google.com), as described at https://developers.google.com/identity/protocols/OpenIDConnect#getcredentials",
+					"pattern": "^[^\u003c]",
+					"type": "string"
+				},
+				"configID": {
+					"description": "An identifier that can be used to reference this authentication provider in other parts of the config. For example, in configuration for a code host, you may want to designate this authentication provider as the identity provider for the code host.",
+					"type": "string"
+				},
+				"displayName": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/displayName"
+				},
+				"displayPrefix": {
+					"!go": {
+						"pointer": true
+					},
+					"$ref": "#/definitions/AuthProviderCommon/properties/displayPrefix"
+				},
+				"hidden": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/hidden"
+				},
+				"issuer": {
+					"description": "The URL of the OpenID Connect issuer.\n\nFor Google Apps: https://accounts.google.com",
+					"format": "uri",
+					"pattern": "^https?://",
+					"type": "string"
+				},
+				"noSignIn": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/noSignIn"
+				},
+				"order": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/order"
+				},
+				"requireEmailDomain": {
+					"description": "Only allow users to authenticate if their email domain is equal to this value (example: mycompany.com). Do not include a leading \"@\". If not set, all users on this OpenID Connect provider can authenticate to Sourcegraph.",
+					"pattern": "^[^\u003c@]",
+					"type": "string"
+				},
+				"singleIdentityPerUser": {
+					"default": false,
+					"description": "When true, any user can connect exactly one identity from the identity provider.",
+					"type": "boolean"
+				},
+				"type": {
+					"const": "openidconnect",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"issuer",
+				"clientID",
+				"clientSecret"
+			],
+			"type": "object"
+		},
+		"ProviderOverride": {
+			"properties": {
+				"clientSideConfig": {
+					"$ref": "#/definitions/ClientSideProviderConfig"
+				},
+				"defaultModelConfig": {
+					"$ref": "#/definitions/DefaultModelConfig"
+				},
+				"displayName": {
+					"description": "display name",
+					"examples": [
+						"Anthropic",
+						"Google",
+						"ACME Corp Custom"
+					],
+					"type": "string"
+				},
+				"id": {
+					"description": "provider ID",
+					"examples": [
+						"anthropic",
+						"google",
+						"acme-corp-custom"
+					],
+					"type": "string"
+				},
+				"serverSideConfig": {
+					"$ref": "#/definitions/ServerSideProviderConfig"
+				}
+			},
+			"required": [
+				"id",
+				"displayName"
+			],
+			"type": "object"
+		},
+		"SAMLAuthProvider": {
+			"additionalProperties": false,
+			"dependencies": {
+				"serviceProviderCertificate": [
+					"serviceProviderPrivateKey"
+				],
+				"serviceProviderPrivateKey": [
+					"serviceProviderCertificate"
+				],
+				"signRequests": [
+					"serviceProviderCertificate",
+					"serviceProviderPrivateKey"
+				]
+			},
+			"description": "Configures the SAML authentication provider for SSO.\n\nNote: if you are using IdP-initiated login, you must have *at most one* SAMLAuthProvider in the `auth.providers` array.",
+			"properties": {
+				"allowGroups": {
+					"description": "Restrict login to members of these groups",
+					"items": {
+						"minLength": 1,
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"allowSignup": {
+					"!go": {
+						"pointer": true
+					},
+					"description": "Allows new visitors to sign up for accounts via SAML authentication. If false, users signing in via SAML must have an existing Sourcegraph account, which will be linked to their SAML identity after sign-in.",
+					"type": "boolean"
+				},
+				"configID": {
+					"description": "An identifier that can be used to reference this authentication provider in other parts of the config. For example, in configuration for a code host, you may want to designate this authentication provider as the identity provider for the code host.",
+					"type": "string"
+				},
+				"displayName": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/displayName"
+				},
+				"displayPrefix": {
+					"!go": {
+						"pointer": true
+					},
+					"$ref": "#/definitions/AuthProviderCommon/properties/displayPrefix"
+				},
+				"groupsAttributeName": {
+					"default": "groups",
+					"description": "Name of the SAML assertion attribute that holds group membership for allowGroups setting",
+					"type": "string"
+				},
+				"hidden": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/hidden"
+				},
+				"identityProviderMetadata": {
+					"description": "The SAML Identity Provider metadata XML contents (for static configuration of the SAML Service Provider). The value of this field should be an XML document whose root element is `\u003cEntityDescriptor\u003e` or `\u003cEntityDescriptors\u003e`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.",
+					"type": "string"
+				},
+				"identityProviderMetadataURL": {
+					"description": "The SAML Identity Provider metadata URL (for dynamic configuration of the SAML Service Provider).",
+					"format": "uri",
+					"pattern": "^https?://",
+					"type": "string"
+				},
+				"insecureSkipAssertionSignatureValidation": {
+					"default": false,
+					"description": "Whether the Service Provider should (insecurely) accept assertions from the Identity Provider without a valid signature.",
+					"type": "boolean"
+				},
+				"nameIDFormat": {
+					"default": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+					"description": "The SAML NameID format to use when performing user authentication.",
+					"examples": [
+						"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+						"urn:oasis:names:tc:SAML:1.1:nameid-format:persistent",
+						"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+						"urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName",
+						"urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName",
+						"urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress",
+						"urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos",
+						"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+						"urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+						"urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified",
+						"urn:oasis:names:tc:SAML:2.0:nameid-format:entity"
+					],
+					"pattern": "^urn:",
+					"type": "string"
+				},
+				"noSignIn": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/noSignIn"
+				},
+				"order": {
+					"$ref": "#/definitions/AuthProviderCommon/properties/order"
+				},
+				"serviceProviderCertificate": {
+					"$comment": "The pattern matches either X.509 encoding or an env var.",
+					"description": "The SAML Service Provider certificate in X.509 encoding (begins with \"-----BEGIN CERTIFICATE-----\"). This certificate is used by the Identity Provider to validate the Service Provider's AuthnRequests and LogoutRequests. It corresponds to the Service Provider's private key (`serviceProviderPrivateKey`). To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.",
+					"minLength": 1,
+					"pattern": "^(-----BEGIN CERTIFICATE-----\n|\\$)",
+					"type": "string"
+				},
+				"serviceProviderIssuer": {
+					"description": "The SAML Service Provider name, used to identify this Service Provider. This is required if the \"externalURL\" field is not set (as the SAML metadata endpoint is computed as \"\u003cexternalURL\u003e.auth/saml/metadata\"), or when using multiple SAML authentication providers.",
+					"type": "string"
+				},
+				"serviceProviderPrivateKey": {
+					"$comment": "The pattern matches either PKCS#8 encoding or an env var.",
+					"description": "The SAML Service Provider private key in PKCS#8 encoding (begins with \"-----BEGIN PRIVATE KEY-----\"). This private key is used to sign AuthnRequests and LogoutRequests. It corresponds to the Service Provider's certificate (`serviceProviderCertificate`). To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.",
+					"minLength": 1,
+					"pattern": "^(-----BEGIN PRIVATE KEY-----\n|\\$)",
+					"type": "string"
+				},
+				"signRequests": {
+					"!go": {
+						"pointer": true
+					},
+					"description": "Sign AuthnRequests and LogoutRequests sent to the Identity Provider using the Service Provider's private key (`serviceProviderPrivateKey`). It defaults to true if the `serviceProviderPrivateKey` and `serviceProviderCertificate` are set, and false otherwise.",
+					"type": "boolean"
+				},
+				"type": {
+					"const": "saml",
+					"type": "string"
+				},
+				"usernameAttributeNames": {
+					"description": "Names of the SAML assertions attributes to check for a user's username. Checked in the order the names are provided.",
+					"items": {
+						"minLength": 1,
+						"type": "string"
+					},
+					"type": "array"
+				}
+			},
+			"required": [
+				"type"
+			],
+			"type": "object"
+		},
+		"SelfHostedModel": {
+			"examples": [
+				{
+					"model": "mixtral-8x7b-instruct",
+					"override": {
+						"serverSideConfig": {
+							"apiModel": "mixtral-8x7b-instruct"
+						}
+					},
+					"provider": "mistral"
+				}
+			],
+			"properties": {
+				"apiVersion": {
+					"default": "v1",
+					"description": "API version",
+					"examples": [
+						"v1"
+					],
+					"type": "string"
+				},
+				"model": {
+					"description": "Which default model configuration to use. Sourcegraph provides default model configuration for select models. Arbitrary models can be configured in 'modelOverrides'",
+					"enum": [
+						"starcoder2-7b@v1",
+						"starcoder2-15b@v1",
+						"mistral-7b-instruct@v1",
+						"mixtral-8x7b-instruct@v1",
+						"mixtral-8x22b-instruct@v1"
+					],
+					"type": "string"
+				},
+				"override": {
+					"$ref": "#/definitions/SelfHostedModelOverride"
+				},
+				"provider": {
+					"description": "provider ID",
+					"examples": [
+						"mistral",
+						"meta",
+						"acme-corp-custom"
+					],
+					"type": "string"
+				}
+			},
+			"required": [
+				"provider"
+			],
+			"type": "object"
+		},
+		"SelfHostedModelOverride": {
+			"description": "Properties to override in the default model configuration",
+			"properties": {
+				"clientSideConfig": {
+					"$ref": "#/definitions/ClientSideModelConfigOpenAICompatible"
+				},
+				"contextWindow": {
+					"$ref": "#/definitions/ContextWindow"
+				},
+				"displayName": {
+					"description": "Display name",
+					"examples": [
+						"Claude 3 Sonnet",
+						"GPT-4 Turbo"
+					],
+					"type": "string"
+				},
+				"modelCost": {
+					"$ref": "#/definitions/ModelCost"
+				},
+				"serverSideConfig": {
+					"$ref": "#/definitions/ServerSideModelConfigOpenAICompatible"
+				}
+			},
+			"type": "object"
+		},
+		"ServerSideModelConfig": {
+			"!go": {
+				"taggedUnionType": true
+			},
+			"default": null,
+			"oneOf": [
+				{
+					"$ref": "#/definitions/ServerSideModelConfigAwsBedrockProvisionedThroughput"
+				},
+				{
+					"$ref": "#/definitions/ServerSideModelConfigAwsBedrock"
+				},
+				{
+					"$ref": "#/definitions/ServerSideModelConfigOpenAICompatible"
+				},
+				{
+					"$ref": "#/definitions/DoNotUsePhonyDiscriminantType"
+				}
+			],
+			"properties": {
+				"type": {
+					"enum": [
+						"awsBedrockProvisionedThroughput",
+						"awsBedrock",
+						"openaicompatible"
+					],
+					"type": "string"
+				}
+			},
+			"required": [
+				"type"
+			],
+			"type": "object"
+		},
+		"ServerSideModelConfigAwsBedrock": {
+			"description": "AWS Bedrock model configuration options.",
+			"properties": {
+				"arn": {
+					"description": "The 'provisioned throughput ARN' to use when sending requests to AWS Bedrock",
+					"type": "string"
+				},
+				"latencyOptimization": {
+					"description": "Configures whether to use latency-optimized inference for this model. Available options are 'standard' and 'optimized'. See: https://docs.aws.amazon.com/bedrock/latest/userguide/latency-optimized-inference.html",
+					"enum": [
+						"standard",
+						"optimized"
+					],
+					"type": "string"
+				},
+				"type": {
+					"const": "awsBedrock",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type"
+			],
+			"type": "object"
+		},
+		"ServerSideModelConfigAwsBedrockProvisionedThroughput": {
+			"properties": {
+				"arn": {
+					"description": "The 'provisioned throughput ARN' to use when sending requests to AWS Bedrock",
+					"type": "string"
+				},
+				"type": {
+					"const": "awsBedrockProvisionedThroughput",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"arn"
+			],
+			"type": "object"
+		},
+		"ServerSideModelConfigOpenAICompatible": {
+			"description": "Configuration that is only respected if the model is provided by an openaicompatible provider.",
+			"properties": {
+				"apiModel": {
+					"description": "The literal string value of the 'model' field that will be sent to the /chat/completions API, for example. If set, Sourcegraph treats this as an opaque string and sends it directly to the API, inferring no information from it. By default, the configured model name is sent.",
+					"type": "string"
+				},
+				"type": {
+					"const": "openaicompatible",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type"
+			],
+			"type": "object"
+		},
+		"ServerSideProviderConfig": {
+			"!go": {
+				"taggedUnionType": true
+			},
+			"default": null,
+			"oneOf": [
+				{
+					"$ref": "#/definitions/ServerSideProviderConfigAWSBedrock"
+				},
+				{
+					"$ref": "#/definitions/ServerSideProviderConfigAzureOpenAI"
+				},
+				{
+					"$ref": "#/definitions/ServerSideProviderConfigAnthropicProvider"
+				},
+				{
+					"$ref": "#/definitions/ServerSideProviderConfigFireworksProvider"
+				},
+				{
+					"$ref": "#/definitions/ServerSideProviderConfigGoogleProvider"
+				},
+				{
+					"$ref": "#/definitions/ServerSideProviderConfigOpenAIProvider"
+				},
+				{
+					"$ref": "#/definitions/ServerSideProviderConfigHuggingfaceTGIProvider"
+				},
+				{
+					"$ref": "#/definitions/ServerSideProviderConfigOpenAICompatibleProvider"
+				},
+				{
+					"$ref": "#/definitions/ServerSideProviderConfigSourcegraphProvider"
+				},
+				{
+					"$ref": "#/definitions/DoNotUsePhonyDiscriminantType"
+				}
+			],
+			"properties": {
+				"type": {
+					"enum": [
+						"awsBedrock",
+						"azureOpenAI",
+						"anthropic",
+						"fireworks",
+						"google",
+						"openai",
+						"huggingface-tgi",
+						"openaicompatible",
+						"sourcegraph"
+					],
+					"type": "string"
+				}
+			},
+			"required": [
+				"type"
+			],
+			"type": "object"
+		},
+		"ServerSideProviderConfigAWSBedrock": {
+			"properties": {
+				"accessToken": {
+					"description": "Leave empty to rely on instance role bindings or other AWS configurations in frontend service. \u003cACCESS_KEY_ID\u003e:\u003cSECRET_ACCESS_KEY\u003e if directly configuring the credentials, or \u003cACCESS_KEY_ID\u003e:\u003cSECRET_ACCESS_KEY\u003e:\u003cSESSION_TOKEN\u003e if a session token is also required.",
+					"type": "string"
+				},
+				"accessTokenQuery": {
+					"$ref": "#/definitions/AccessTokenQuery",
+					"description": "Ignored when accessToken is set; this is a configuration for fetching a provider access token over HTTP."
+				},
+				"authMethod": {
+					"default": "AWS",
+					"description": "Optional: the authentication method to use. If not specified or 'AWS' specified, AWS request signing will be used. If 'direct' specified, the provided accessToken will be used as a bearer token to authenticate requests to the endpoint.",
+					"enum": [
+						"AWS",
+						"direct"
+					],
+					"type": "string"
+				},
+				"endpoint": {
+					"description": "For Pay-as-you-go, set it to an AWS region code (e.g., us-west-2) when using a public Amazon Bedrock endpoint; For Provisioned Throughput, set it to the provisioned VPC endpoint for the bedrock-runtime API (e.g., 'https://vpce-0a10b2345cd67e89f-abc0defg.bedrock-runtime.us-west-2.vpce.amazonaws.com')",
+					"type": "string"
+				},
+				"region": {
+					"description": "Region to use when configuring API clients. (Since the 'frontend' binary's container won't be able to pick this up from the host OS's environment variables.)",
+					"type": "string"
+				},
+				"type": {
+					"const": "awsBedrock",
+					"type": "string"
+				},
+				"urlBuilder": {
+					"default": "AWS",
+					"description": "Optional: the URL building method to use. If not specified or 'AWS' specified, region and model will be used to build the AWS Bedrock URL. If 'direct' specified, the provided endpoint will be used as the URL.",
+					"enum": [
+						"AWS",
+						"direct"
+					],
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"endpoint",
+				"region"
+			],
+			"type": "object"
+		},
+		"ServerSideProviderConfigAnthropicProvider": {
+			"properties": {
+				"accessToken": {
+					"type": "string"
+				},
+				"accessTokenQuery": {
+					"$ref": "#/definitions/AccessTokenQuery",
+					"description": "Ignored when accessToken is set; this is a configuration for fetching a provider access token over HTTP."
+				},
+				"endpoint": {
+					"type": "string"
+				},
+				"type": {
+					"const": "anthropic",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"endpoint"
+			],
+			"type": "object"
+		},
+		"ServerSideProviderConfigAzureOpenAI": {
+			"properties": {
+				"accessToken": {
+					"description": "As of 5.2.4 the access token can be left empty and it will rely on Environmental, Workload Identity or Managed Identity credentials configured for the frontend and worker services; Set it to \u003cAPI_KEY\u003e if directly configuring the credentials using the API key specified in the Azure portal",
+					"type": "string"
+				},
+				"accessTokenQuery": {
+					"$ref": "#/definitions/AccessTokenQuery",
+					"description": "Ignored when accessToken is set; this is a configuration for fetching a provider access token over HTTP."
+				},
+				"apiVersion": {
+					"description": "The API version to use for the Azure OpenAI Service. Compatibility may be broken between versions - the only officially supported option here is to leave it unset.",
+					"type": "string"
+				},
+				"endpoint": {
+					"description": "Endpoint from the Azure OpenAI Service portal",
+					"type": "string"
+				},
+				"type": {
+					"const": "azureOpenAI",
+					"type": "string"
+				},
+				"useDeprecatedCompletionsAPI": {
+					"description": "Enables the use of the older completions API for select Azure OpenAI models. This is just an escape hatch, for backwards compatibility, because not all Azure OpenAI models are available on the 'newer' completions API.",
+					"type": "boolean"
+				},
+				"user": {
+					"description": "The user field passed along to OpenAI-provided models.",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"endpoint",
+				"user",
+				"useDeprecatedCompletionsAPI"
+			],
+			"type": "object"
+		},
+		"ServerSideProviderConfigFireworksProvider": {
+			"properties": {
+				"accessToken": {
+					"type": "string"
+				},
+				"endpoint": {
+					"type": "string"
+				},
+				"type": {
+					"const": "fireworks",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"accessToken",
+				"endpoint"
+			],
+			"type": "object"
+		},
+		"ServerSideProviderConfigGoogleProvider": {
+			"properties": {
+				"accessToken": {
+					"type": "string"
+				},
+				"endpoint": {
+					"type": "string"
+				},
+				"type": {
+					"const": "google",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"accessToken",
+				"endpoint"
+			],
+			"type": "object"
+		},
+		"ServerSideProviderConfigHuggingfaceTGIProvider": {
+			"properties": {
+				"enableVerboseLogs": {
+					"default": false,
+					"description": "Whether to enable verbose logging of requests. When enabled, grep for 'OpenAICompatible' in the frontend container logs to see the requests Cody makes to the endpoint.",
+					"type": "boolean"
+				},
+				"endpoints": {
+					"$ref": "#/definitions/OpenAICompatibleEndpoint"
+				},
+				"type": {
+					"const": "huggingface-tgi",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"endpoints"
+			],
+			"type": "object"
+		},
+		"ServerSideProviderConfigOpenAICompatibleProvider": {
+			"properties": {
+				"enableVerboseLogs": {
+					"default": false,
+					"description": "Whether to enable verbose logging of requests. When enabled, grep for 'OpenAICompatible' in the frontend container logs to see the requests Cody makes to the endpoint.",
+					"type": "boolean"
+				},
+				"endpoints": {
+					"$ref": "#/definitions/OpenAICompatibleEndpoint"
+				},
+				"type": {
+					"const": "openaicompatible",
+					"type": "string"
+				},
+				"useLegacyCompletions": {
+					"default": true,
+					"description": "If true (default), uses the /completions endpoint for autocomplete requests. If false, uses the /chat/completions endpoint for all requests, including autocomplete.",
+					"type": "boolean"
+				}
+			},
+			"required": [
+				"type",
+				"endpoints"
+			],
+			"type": "object"
+		},
+		"ServerSideProviderConfigOpenAIProvider": {
+			"properties": {
+				"accessToken": {
+					"type": "string"
+				},
+				"endpoint": {
+					"type": "string"
+				},
+				"type": {
+					"const": "openai",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"accessToken",
+				"endpoint"
+			],
+			"type": "object"
+		},
+		"ServerSideProviderConfigSourcegraphProvider": {
+			"properties": {
+				"accessToken": {
+					"type": "string"
+				},
+				"endpoint": {
+					"type": "string"
+				},
+				"type": {
+					"const": "sourcegraph",
+					"type": "string"
+				}
+			},
+			"required": [
+				"type",
+				"accessToken",
+				"endpoint"
+			],
+			"type": "object"
+		},
+		"SiteModelConfiguration": {
+			"description": "BETA FEATURE, only enable if you know what you are doing. If set, Cody will use the new model configuration system and ignore the old 'completions' site configuration entirely.",
+			"properties": {
+				"defaultModels": {
+					"$ref": "#/definitions/DefaultModels"
+				},
+				"modelOverrides": {
+					"default": [],
+					"description": "Override, or add to, the list of models Cody is aware of and how they are configured to work",
+					"items": {
+						"$ref": "#/definitions/ModelOverride"
+					},
+					"type": "array"
+				},
+				"modelOverridesRecommendedSettings": {
+					"default": [],
+					"deprecationMessage": "Deprecated; use 'selfHostedModels' instead.",
+					"description": "Override, or add to, the list of models Cody is aware of - but let Sourcegraph configure how the model should work. Only available for select models.\n\nSpecifying the same model both here and in 'modelOverrides' is not allowed.",
+					"items": {
+						"enum": [
+							"bigcode::v1::starcoder2-7b",
+							"bigcode::v1::starcoder2-15b",
+							"mistral::v1::mistral-7b-instruct",
+							"mistral::v1::mixtral-8x7b-instruct",
+							"mistral::v1::mixtral-8x22b-instruct"
+						],
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"providerOverrides": {
+					"default": [],
+					"description": "Configures model providers. Here you can override how Cody connects to model providers and e.g. bring your own API keys or self-hosted models.",
+					"items": {
+						"$ref": "#/definitions/ProviderOverride"
+					},
+					"type": "array"
+				},
+				"selfHostedModels": {
+					"default": [],
+					"description": "Add models to the list of models Cody is aware of, but let Sourcegraph provide default configuration for the model. Only available for select models, generic models can be configured in 'modelOverrides'.\n\nSpecifying the same model both here and in 'modelOverrides' is not allowed.",
+					"items": {
+						"$ref": "#/definitions/SelfHostedModel"
+					},
+					"type": "array"
+				},
+				"sourcegraph": {
+					"$ref": "#/definitions/SourcegraphModelConfig"
+				},
+				"systemPreInstruction": {
+					"description": "An optional global chat pre-instruction message to be prepended to all chat completions as a system message. This is useful for an admin to offer the LLM some global context or restrictions. This is an admin level prompt and thus will be unconditionally added, even if a client-level pre-instruction is present.",
+					"maximum": 280,
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"SourcegraphModelConfig": {
+			"description": "If null, Cody will not use Sourcegraph's servers for model discovery.",
+			"properties": {
+				"accessToken": {
+					"!go": {
+						"pointer": true
+					},
+					"default": null,
+					"description": "The Cody gateway access token to use. If null, an access token will be automatically generated based on the product license.",
+					"type": "string"
+				},
+				"endpoint": {
+					"!go": {
+						"pointer": true
+					},
+					"default": null,
+					"description": "The Cody gateway URL to use for making LLM requests. If null, the production URL for Cody gateway will be used.",
+					"type": "string"
+				},
+				"modelFilters": {
+					"$ref": "#/definitions/ModelFilters"
+				}
+			},
+			"type": [
+				"object",
+				"null"
+			]
 		}
-	],
-
-	// WARNING: This option has been removed as of 3.8.
-	"auth.public": false,
-
-	// The duration of a user session, after which it expires and the user is required to re-authenticate. The default is 90 days. There is typically no need to set this, but some users may have specific internal security requirements.
-	//
-	// The string format is that of the Duration type in the Go time package (https://golang.org/pkg/time/#ParseDuration). E.g., "720h", "43200m", "2592000s" all indicate a timespan of 30 days.
-	//
-	// Note: changing this field does not affect the expiration of existing sessions. If you would like to enforce this limit for existing sessions, you must log out currently signed-in users. You can force this by removing all keys beginning with "session_" from the Redis store:
-	//
-	// * For deployments using `sourcegraph/server`: `docker exec $CONTAINER_ID redis-cli --raw keys 'session_*' | xargs docker exec $CONTAINER_ID redis-cli del`
-	// * For cluster deployments:
-	//   ```
-	//   REDIS_POD="$(kubectl get pods -l app=redis-store -o jsonpath={.items[0].metadata.name})";
-	//   kubectl exec "$REDIS_POD" -- redis-cli --raw keys 'session_*' | xargs kubectl exec "$REDIS_POD" -- redis-cli --raw del;
-	//   ```
-	"auth.sessionExpiry": "2160h",
-	// Other example values:
-	// - "168h"
-
-	// Validity expressed in minutes of the unlock account token
-	"auth.unlockAccountLinkExpiry": 5,
-
-	// Base64-encoded HMAC signing key to sign the JWT token for account unlock URLs
-	"auth.unlockAccountLinkSigningKey": null,
-	// Other example values:
-	// - "LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KYjNCbGJuTnphQzFyWlhrdGRqRUFBQUFBQkc1dmJtVUFBQUFFYm05dVpRQUFBQUFBQUFBQkFBQUJGZ0FBQUhVQkFBQQ"
-
-//////////////////////////////////////////////////////////////
-// BatchChanges
-//////////////////////////////////////////////////////////////
-
-	// Automatically delete branches created for Batch Changes changesets when the changeset is merged or closed, for supported code hosts. Overrides any setting on the repository on the code host itself.
-	"batchChanges.autoDeleteBranch": false,
-
-	// How long changesets will be retained after they have been detached from a batch change.
-	"batchChanges.changesetsRetention": null,
-	// Other example values:
-	// - "336h"
-	// - "48h"
-	// - "5h30m40s"
-
-	// Hides Batch Changes warnings about webhooks not being configured.
-	"batchChanges.disableWebhooksWarning": false,
-
-	// Enables/disables the Batch Changes feature.
-	"batchChanges.enabled": true,
-
-	// When enabled, all branches created by batch changes will be pushed to forks of the original repository.
-	"batchChanges.enforceForks": false,
-
-	// When enabled, only site admins can create and apply batch changes.
-	"batchChanges.restrictToAdmins": false,
-
-	// Specifies specific windows, which can have associated rate limits, to be used when reconciling published changesets (creating or updating). All days and times are handled in UTC.
-	"batchChanges.rolloutWindows": null,
-	// Other example values:
-	// - {
-	//     "days": [
-	//       "saturday",
-	//       "sunday"
-	//     ],
-	//     "end": "20:00",
-	//     "rate": "10/hour",
-	//     "start": "06:00"
-	//   }
-
-//////////////////////////////////////////////////////////////
-// Code intelligence
-//////////////////////////////////////////////////////////////
-
-	// Whether auto-indexing policies may apply to all repositories on the Sourcegraph instance. Default is false. The policyRepositoryMatchLimit setting still applies to such auto-indexing policies.
-	"codeIntelAutoIndexing.allowGlobalPolicies": false,
-
-	// Enables/disables the code intel auto-indexing feature. Currently experimental.
-	"codeIntelAutoIndexing.enabled": false,
-
-	// Overrides the default Docker images used by auto-indexing.
-	"codeIntelAutoIndexing.indexerMap": null,
-	// Other example values:
-	// - {
-	//     "go": "sourcegraph/lsif-go:latest",
-	//     "java": "sourcegraph/lsif-java:latest"
-	//   }
-
-	// The maximum number of repositories to which a single auto-indexing policy can apply. Default is -1, which is unlimited.
-	"codeIntelAutoIndexing.policyRepositoryMatchLimit": -1,
-
-	// A cron expression indicating when to run the document reference counts graph reduction job.
-	"codeIntelRanking.documentReferenceCountsCronExpression": "@weekly",
-
-	// An arbitrary identifier used to group calculated rankings from SCIP data (excluding the SCIP export).
-	"codeIntelRanking.documentReferenceCountsDerivativeGraphKeyPrefix": null,
-	// Other example values:
-	// - ""
-
-	// Enables/disables the document reference counts feature. Currently experimental.
-	"codeIntelRanking.documentReferenceCountsEnabled": false,
-
-	// An arbitrary identifier used to group calculated rankings from SCIP data (including the SCIP export).
-	"codeIntelRanking.documentReferenceCountsGraphKey": null,
-	// Other example values:
-	// - "dev"
-
-	// The interval at which to run the reduce job that computes document reference counts. Default is 24hrs.
-	"codeIntelRanking.staleResultsAge": 24,
-
-//////////////////////////////////////////////////////////////
-// CodeInsights
-//////////////////////////////////////////////////////////////
-
-	// The size of the buffer for aggregations ran in-memory. A higher limit might strain memory for the frontend
-	"insights.aggregations.bufferSize": 500,
-
-	// The maximum number of results a proactive search aggregation can accept before stopping
-	"insights.aggregations.proactiveResultLimit": 50000,
-
-	// Set the number of seconds an insight series will spend backfilling before being interrupted. Series are interrupted to prevent long running insights from exhausting all of the available workers. Interrupted series will be placed back in the queue and retried based on their priority.
-	"insights.backfill.interruptAfter": 60,
-
-	// Number of repositories within the batch to backfill concurrently.
-	"insights.backfill.repositoryConcurrency": 3,
-
-	// Set the number of repositories to batch in a group during backfilling.
-	"insights.backfill.repositoryGroupSize": 10,
-
-	// Maximum number of historical Code Insights data frames that may be analyzed per second.
-	"insights.historical.worker.rateLimit": 20,
-	// Other example values:
-	// - 50
-	// - 0.5
-
-	// The allowed burst rate for the Code Insights historical worker rate limiter.
-	"insights.historical.worker.rateLimitBurst": 20,
-	// Other example values:
-	// - 10
-	// - 20
-
-	// The maximum number of data points that will be available to view for a series on a code insight. Points beyond that will be stored in a separate table and available for data export.
-	"insights.maximumSampleSize": 30,
-	// Other example values:
-	// - 12
-	// - 24
-	// - 50
-
-	// Number of concurrent executions of a code insight query on a worker node
-	"insights.query.worker.concurrency": 1,
-	// Other example values:
-	// - 10
-
-	// Maximum number of Code Insights queries initiated per second on a worker node.
-	"insights.query.worker.rateLimit": 20,
-	// Other example values:
-	// - 10
-	// - 0.5
-
-	// The allowed burst rate for the Code Insights queries per second rate limiter.
-	"insights.query.worker.rateLimitBurst": 20,
-	// Other example values:
-	// - 10
-	// - 20
-
-//////////////////////////////////////////////////////////////
-// Cody
-//////////////////////////////////////////////////////////////
-
-	// Enable or disable Cody instance-wide. When Cody is disabled, all Cody endpoints and GraphQL queries will return errors, Cody will not show up in the site-admin sidebar, and Cody in the global navbar will only show a call-to-action for site-admins to enable Cody.
-	"cody.enabled": false,
-
-	// Restrict Cody to only be enabled for users that have a feature flag labeled "cody" set to true. You must create a feature flag with this ID after enabling this setting: https://sourcegraph.com/docs/dev/how-to/use_feature_flags#create-a-feature-flag. This setting only has an effect if cody.enabled is true.
-	"cody.restrictUsersFeatureFlag": false,
-
-//////////////////////////////////////////////////////////////
-// Debug
-//////////////////////////////////////////////////////////////
-
-	// (debug) controls the amount of symbol search parallelism. Defaults to 20. It is not recommended to change this outside of debugging scenarios. This option will be removed in a future version.
-	"debug.search.symbolsParallelism": null,
-	// Other example values:
-	// - "20"
-
-	// (debug) Set a limit to the amount of captured slow GraphQL requests being stored for visualization. For defining the threshold for a slow GraphQL request, see observability.logSlowGraphQLRequests.
-	"observability.captureSlowGraphQLRequestsLimit": null,
-	// Other example values:
-	// - 2000
-
-	// (debug) logs all GraphQL requests slower than the specified number of milliseconds.
-	"observability.logSlowGraphQLRequests": null,
-	// Other example values:
-	// - 10000
-
-	// (debug) logs all search queries (issued by users, code intelligence, or API requests) slower than the specified number of milliseconds.
-	"observability.logSlowSearches": null,
-	// Other example values:
-	// - 10000
-
-//////////////////////////////////////////////////////////////
-// Email
-//////////////////////////////////////////////////////////////
-
-	// The "from" address for emails sent by this server.
-	// Please see https://sourcegraph.com/docs/admin/config/email
-	"email.address": null,
-	// Other example values:
-	// - "noreply@sourcegraph.example.com"
-
-	// The name to use in the "from" address for emails sent by this server.
-	"email.senderName": "Sourcegraph",
-	// Other example values:
-	// - "Our Company Sourcegraph"
-	// - "Example Inc Sourcegraph"
-
-	// The SMTP server used to send transactional emails.
-	// Please see https://sourcegraph.com/docs/admin/config/email
-	"email.smtp": null,
-	// Other example values:
-	// - {
-	//     "authentication": "PLAIN",
-	//     "host": "smtp.example.com",
-	//     "password": "mypassword",
-	//     "port": 465,
-	//     "username": "alice"
-	//   }
-
-	// Configurable templates for some email types sent by Sourcegraph.
-	"email.templates": null,
-	// Other example values:
-	// - {
-	//     "resetPassword": {
-	//       "body": "To reset your password on {{.Host}}, please click the link below:\n\n{{.URL}}\n\nIf you did not request a password reset, please ignore this email. Your password will not change until you click the link and set a new password.",
-	//       "subject": "Reset your password on {{.Host}}"
-	//     },
-	//     "setPassword": {
-	//       "body": "To set your password on {{.Host}} and complete your account registration, please click the link below:\n\n{{.URL}}\n\nYour username is: {{.Username}}\n\nIf you did not sign up for an account on {{.Host}}, please ignore this email.",
-	//       "subject": "Set your password on {{.Host}}"
-	//     }
-	//   }
-
-//////////////////////////////////////////////////////////////
-// Experimental
-//////////////////////////////////////////////////////////////
-
-	// Experimental features and settings.
-	"experimentalFeatures": null,
-	// Other example values:
-	// - {
-	//     "customGitFetch": [
-	//       {
-	//         "domainPath": "somecodehost.com/path/to/repo",
-	//         "fetch": "customgitbinary someflag"
-	//       },
-	//       {
-	//         "domainPath": "somecodehost.com/path/to/anotherrepo",
-	//         "fetch": "customgitbinary someflag anotherflag"
-	//       }
-	//     ]
-	//   }
-	// - {
-	//     "tls.external": {
-	//       "certificates": [
-	//         "-----BEGIN CERTIFICATE-----\n..."
-	//       ],
-	//       "insecureSkipVerify": true
-	//     }
-	//   }
-
-//////////////////////////////////////////////////////////////
-// External services
-//////////////////////////////////////////////////////////////
-
-	// Disable periodic syncs of configured code host connections (repository metadata, permissions, batch changes changesets, etc)
-	"disableAutoCodeHostSyncs": false,
-
-	// Disable periodically fetching git contents for existing repositories.
-	"disableAutoGitUpdates": false,
-
-	// DEPRECATED! Disable redirects to sourcegraph.com when visiting public repositories that can't exist on this server.
-	"disablePublicRepoRedirects": null,
-	// Other example values:
-	// - true
-
-	// JSON array of configuration that maps from Git clone URL to repository name. Sourcegraph automatically resolves remote clone URLs to their proper code host. However, there may be non-remote clone URLs (e.g., in submodule declarations) that Sourcegraph cannot automatically map to a code host. In this case, use this field to specify the mapping. The mappings are tried in the order they are specified and take precedence over automatic mappings.
-	"git.cloneURLToRepositoryName": null,
-	// Other example values:
-	// - [
-	//     {
-	//       "from": "^/admin/config(?P\u003cname\u003e\\w+)$",
-	//       "to": "github.com/user/{name}"
-	//     }
-	//   ]
-
-	// Maximum number of seconds that a long Git command (e.g. clone or remote update) is allowed to execute. The default is 3600 seconds, or 1 hour.
-	"gitLongCommandTimeout": 3600,
-
-	// Maximum number of remote code host git operations (e.g. clone or ls-remote) to be run per second per gitserver. Default is -1, which is unlimited.
-	"gitMaxCodehostRequestsPerSecond": -1,
-
-	// Maximum number of git clone processes that will be run concurrently per gitserver to update repositories. Note: the global git update scheduler respects gitMaxConcurrentClones. However, we allow each gitserver to run upto gitMaxConcurrentClones to allow for urgent fetches. Urgent fetches are used when a user is browsing a PR and we do not have the commit yet.
-	"gitMaxConcurrentClones": 5,
-
-	// JSON array of repo name patterns and update intervals. If a repo matches a pattern, the associated interval will be used. If it matches no patterns a default backoff heuristic will be used. Pattern matches are attempted in the order they are provided.
-	"gitUpdateInterval": null,
-	// Other example values:
-	// - [
-	//     {
-	//       "interval": 5,
-	//       "pattern": "^github.com/sourcegraph/.*"
-	//     },
-	//     {
-	//       "interval": 10,
-	//       "pattern": "^bitbucket.org/.*"
-	//     }
-	//   ]
-
-	// URL to fetch unreachable repository details from. Defaults to "https://sourcegraph.com"
-	"parentSourcegraph": null,
-	// Other example values:
-	// - {
-	//     "url": "https://sourcegraph.example.com"
-	//   }
-
-	// The number of concurrent external service syncers that can run.
-	"repoConcurrentExternalServiceSyncers": 3,
-
-	// Interval (in minutes) for checking code hosts (such as GitHub, Gitolite, etc.) for new repositories.
-	"repoListUpdateInterval": 1,
-
-	// Configuration for repository purge worker.
-	"repoPurgeWorker": {
-		"deletedTTLMinutes": 60,
-		"intervalMinutes": 15
 	},
-
-	// The SCIM auth token is used to authenticate SCIM requests. If not set, SCIM is disabled.
-	"scim.authToken": "",
-
-	// Identity provider used for SCIM support.  "STANDARD" should be used unless a more specific value is available
-	"scim.identityProvider": "STANDARD",
-
-//////////////////////////////////////////////////////////////
-// Misc.
-//////////////////////////////////////////////////////////////
-
-	// Disable the feedback survey
-	"disableFeedbackSurvey": false,
-
-	// DEPRECATED. Has no effect.
-	"disableNonCriticalTelemetry": false,
-
-	// HTML to inject at the bottom of the `<body>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.
-	"htmlBodyBottom": null,
-
-	// HTML to inject at the top of the `<body>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.
-	"htmlBodyTop": null,
-
-	// HTML to inject at the bottom of the `<head>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.
-	"htmlHeadBottom": null,
-
-	// HTML to inject at the top of the `<head>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.
-	"htmlHeadTop": null,
-
-	// Enables users access to the product research page in their settings.
-	"productResearchPage.enabled": true,
-
-	// The channel on which to automatically check for Sourcegraph updates.
-	"update.channel": "release",
-	// Other example values:
-	// - "none"
-
-//////////////////////////////////////////////////////////////
-// Own
-//////////////////////////////////////////////////////////////
-
-	// The max number of concurrent Own jobs that will run per worker node.
-	"own.background.repoIndexConcurrencyLimit": 5,
-
-	// The maximum per second burst of repositories for Own jobs per worker node. Generally this value should not be less than the max concurrency.
-	"own.background.repoIndexRateBurstLimit": 5,
-
-	// The maximum per second rate of repositories for Own jobs per worker node.
-	"own.background.repoIndexRateLimit": 20,
-
-	// The Own service will attempt to match a Team by the last part of its handle if it contains a slash and no match is found for its full handle.
-	"own.bestEffortTeamMatching": true,
-
-//////////////////////////////////////////////////////////////
-// Search
-//////////////////////////////////////////////////////////////
-
-	// DEPRECATED: Configure maxRepos in search.limits. The maximum number of repositories to search across. The user is prompted to narrow their query if exceeded. Any value less than or equal to zero means unlimited.
-	"maxReposToSearch": -1,
-
-	// The number of threads each indexserver should use to index shards. If not set, indexserver will use the number of available CPUs. This is exposed as a safeguard and should usually not require being set.
-	"search.index.shardConcurrency": null,
-	// Other example values:
-	// - "10"
-
-	// Whether indexed symbol search is enabled. This is contingent on the indexed search configuration, and is true by default for instances with indexed search enabled. Enabling this will cause every repository to re-index, which is a time consuming (several hours) operation. Additionally, it requires more storage and ram to accommodate the added symbols information in the search index.
-	"search.index.symbols.enabled": null,
-	// Other example values:
-	// - true
-
-	// A list of file glob patterns where matching files will be indexed and searched regardless of their size. Files still need to be valid utf-8 to be indexed. The glob pattern syntax can be found here: https://github.com/bmatcuk/doublestar#patterns.
-	"search.largeFiles": null,
-	// Other example values:
-	// - [
-	//     "go.sum",
-	//     "package-lock.json",
-	//     "**/*.thrift"
-	//   ]
-
-	// Limits that search applies for number of repositories searched and timeouts.
-	"search.limits": null,
-	// Other example values:
-	// - {
-	//     "commitDiffMaxRepos": 50,
-	//     "commitDiffWithTimeFilterMaxRepos": 5000,
-	//     "maxRepos": 200,
-	//     "maxTimeoutSeconds": 60
-	//   }
-
-//////////////////////////////////////////////////////////////
-// Security
-//////////////////////////////////////////////////////////////
-
-	// Settings for access tokens, which enable external tools to access the Sourcegraph API with the privileges of the user.
-	"auth.accessTokens": {
-		"allow": "all-users-create",
-		"expirationOptionDays": [7,14,30,60,90],
-    	"defaultExpirationDays": 90,
-		"allowNoExpiration": false,
-		"maxTokensPerUser": 25
-	},
-	// Other example values:
-	// - {"allow":"site-admin-create"}
-	// - {"allow":"none"}
-
-	// Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.
-	"corsOrigin": null,
-	// Other example values:
-	// - "https://my-phabricator.example.com https://my-bitbucket.example.com https://my-gitlab.example.com"
-
-	// Whether or not LSIF uploads will be blocked unless a valid LSIF upload token is provided.
-	"lsifEnforceAuth": false,
-
-	// Settings for Sourcegraph explicit permissions, which allow the site admin to explicitly manage repository permissions via the GraphQL API. This will mark repositories as restricted by default.
-	"permissions.userMapping": {
-		"bindID": "email",
-		"enabled": true
-	},
-	// Other example values:
-	// - {"bindID":"email"}
-	// - {"bindID":"username"}
-
-//////////////////////////////////////////////////////////////
-// Sourcegraph Enterprise license
-//////////////////////////////////////////////////////////////
-
-	// The license key associated with a Sourcegraph Enterprise subscription, which is necessary to activate Sourcegraph Enterprise functionality. To obtain this value, contact Sourcegraph to purchase a license. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
-	"licenseKey": null,
-
-//////////////////////////////////////////////////////////////
-// Sourcegraph.com
-//////////////////////////////////////////////////////////////
-
-	// Configuration options for Sourcegraph.com only.
-	"dotcom": null
-}
-```
-
-#### Known bugs
-
-The following site configuration options require the server to be restarted for the changes to take effect:
-
-```
-auth.providers
-externalURL
-insights.query.worker.concurrency
-insights.commit.indexer.interval
-permissions.syncUsersMaxConcurrency
-```
-
-## Editing your site configuration if you cannot access the web UI
-
-If you are having trouble accessing the web UI, you can make edits to your site configuration by editing the configuration directly.
-
-
-### Sourcegraph with Docker Compose and single-server Sourcegraph with Docker
-
-Set `FRONTEND_CONTAINER` to:
-
-- [Docker Compose](/admin/deploy/docker-compose/): the `sourcegraph-frontend` container
-- [Single-container](/admin/deploy/docker-single-container/): the `sourcegraph/server` container
-
-```sh
-docker exec -it --user=root $FRONTEND_CONTAINER sh -c 'apk add --no-cache && nano /home/sourcegraph/site-config.json'
-```
-
-Or if you prefer using a Vim editor:
-
-```sh
-docker exec -it $FRONTEND_CONTAINER sh -c 'vi ~/site-config.json'
-```
-
-### Sourcegraph with Kubernetes
-
-For [Kubernetes](/admin/deploy/kubernetes/) deployments:
-
-```sh
-kubectl exec -it $FRONTEND_POD -- sh -c 'apk add --no-cache nano && nano ~/site-config.json'
-```
-
-Or if you prefer using a Vim editor:
-
-```sh
-kubectl exec -it $FRONTEND_POD -- sh -c 'vi ~/site-config.json'
-```
-
-Then simply save your changes (type <kbd>ctrl+x</kbd> and <kbd>y</kbd> to exit `nano` and save your changes). Your changes will be applied immediately in the same way as if you had made them through the web UI.
-
-## If you are still encountering issues
-
-You can check the container logs to see if you have made any typos or mistakes in editing the configuration file. If you are still encountering problems, you can save the default site configuration that comes with Sourcegraph (below) or contact support@sourcegraph.com with any questions you have.
-
-```json
-{
-	// The externally accessible URL for Sourcegraph (i.e., what you type into your browser)
-	// This is required to be configured for Sourcegraph to work correctly.
-	// "externalURL": "https://sourcegraph.example.com",
-
-	// The authentication provider to use for identifying and signing in users.
-	// Only one entry is supported.
-	//
-	// The builtin auth provider with signup disallowed (shown below) means that
-	// after the initial site admin signs in, all other users must be invited.
-	//
-	// Other providers are documented at https://sourcegraph.com/docs/admin/auth.
-	"auth.providers": [
-		{
-			"type": "builtin",
-			"allowSignup": false
+	"description": "Configuration for a Sourcegraph site.",
+	"properties": {
+		"RedirectUnsupportedBrowser": {
+			"default": false,
+			"description": "Prompts user to install new browser for non es5",
+			"type": "boolean"
+		},
+		"attribution.enabled": {
+			"!go": {
+				"pointer": true
+			},
+			"description": "Enable/Disable attribution search for Cody-generated snippets",
+			"type": "boolean"
+		},
+		"attribution.gateway": {
+			"description": "Use this gateway parameters for customers that bring their own key. Otherwise gateway endpoint is used.",
+			"properties": {
+				"accessToken": {
+					"description": "Only for use to override token for attribution gateway access. If 'licenseKey' is set, a default access token is generated.",
+					"type": "string"
+				},
+				"endpoint": {
+					"description": "Endpoint where Cody gateway can be accessed for attribution.",
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"attribution.mode": {
+			"!go": {
+				"pointer": true
+			},
+			"default": "permissive",
+			"description": "Hide Cody-generated snippets that have attribution matches (\"enforced\"), or show the snippet but passively inform the user about attribution (\"permissive\", the default). Requires attribution.enabled = true.",
+			"enum": [
+				"permissive",
+				"enforced"
+			],
+			"type": "string"
+		},
+		"auth.accessRequest": {
+			"description": "The config options for access requests",
+			"examples": [
+				{
+					"enabled": true
+				},
+				{
+					"enabled": false
+				}
+			],
+			"group": "Authentication",
+			"properties": {
+				"enabled": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "Enable/disable the access request feature, which allows users to request access if built-in signup is disabled.",
+					"type": "boolean"
+				}
+			},
+			"type": "object"
+		},
+		"auth.accessTokens": {
+			"additionalProperties": false,
+			"default": {
+				"allow": "all-users-create",
+				"allowNoExpiration": false,
+				"defaultExpirationDays": 90,
+				"expirationOptionDays": [
+					7,
+					14,
+					30,
+					60,
+					90
+				]
+			},
+			"description": "Settings for access tokens, which enable external tools to access the Sourcegraph API with the privileges of the user.",
+			"examples": [
+				{
+					"allow": "site-admin-create",
+					"allowNoExpiration": true,
+					"defaultExpirationDays": 90,
+					"expirationOptionDays": [
+						7,
+						14,
+						30,
+						60,
+						90
+					]
+				},
+				{
+					"allow": "none",
+					"allowNoExpiration": false,
+					"defaultExpirationDays": 45,
+					"expirationOptionDays": [
+						7,
+						14,
+						30,
+						60,
+						90
+					]
+				}
+			],
+			"group": "Security",
+			"properties": {
+				"allow": {
+					"default": "all-users-create",
+					"description": "Allow or restrict the use of access tokens. The default is \"all-users-create\", which enables all users to create access tokens. Use \"none\" to disable access tokens entirely. Use \"site-admin-create\" to restrict creation of new tokens to admin users (existing tokens will still work until revoked).",
+					"enum": [
+						"all-users-create",
+						"site-admin-create",
+						"none"
+					],
+					"type": "string"
+				},
+				"allowNoExpiration": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "Allows new tokens to be created without specifying an expiration.",
+					"type": "boolean"
+				},
+				"defaultExpirationDays": {
+					"!go": {
+						"pointer": true
+					},
+					"default": 90,
+					"description": "The default duration selection when creating a new access token. This value will be added to the expirationOptionDays if it is not already present",
+					"maximum": 365,
+					"minimum": 1,
+					"type": "integer"
+				},
+				"expirationOptionDays": {
+					"default": [
+						7,
+						14,
+						30,
+						60,
+						90
+					],
+					"description": "Options users will see for the number of days until token expiration. The defaultExpirationDays will be added to the list if not already present.",
+					"examples": [
+						[
+							7,
+							14,
+							30,
+							60,
+							90
+						]
+					],
+					"items": {
+						"maximum": 365,
+						"minimum": 1,
+						"type": "integer"
+					},
+					"type": "array"
+				},
+				"maxTokensPerUser": {
+					"!go": {
+						"pointer": true
+					},
+					"default": 25,
+					"description": "The maximum number of active access tokens a user may have.",
+					"maximum": 100,
+					"minimum": 1,
+					"type": "integer"
+				}
+			},
+			"type": "object"
+		},
+		"auth.allowedIpAddress": {
+			"description": "IP allowlist for access to the Sourcegraph instance. If set, only requests from these IP addresses will be allowed. By default client IP is infered connected client IP address, and you may configure to use a request header to determine the user IP.",
+			"group": "Security",
+			"properties": {
+				"clientIpAddress": {
+					"description": "List of client IP addresses to allow. If empty, all IP addresses are allowed. This is useful to restrict who can open connection with the Sorcegraph instance, e.g., the request source range of the upsteam application load balancer.",
+					"examples": [
+						"100.100.100.0/25",
+						"23.34.56.21"
+					],
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"enabled": {
+					"default": false,
+					"description": "Whether to enable the IP allowlist.",
+					"type": "boolean"
+				},
+				"errorMessageTemplate": {
+					"default": "Access from your IP address is not allowed.",
+					"description": "A template to customize the error message display to users on unauthorized access.  Available template variables: `{{.Error}}`, `{{.UserIP}}`",
+					"examples": [
+						"Please reach out to your Sourcegraph instance admin at admin@acme.com to unblock your IP address: {{.UserIP}}.",
+						"{{.Error}}. Please reach out to your Sourcegraph instance admin at admin@acme.com to request access."
+					],
+					"type": "string"
+				},
+				"trustedClientIpAddress": {
+					"description": "List of trusted client IP addresses that will bypass user IP address check. If empty, nothing can be bypass. This is useful to support access from trusted internal services. It will always permit connection from `127.0.0.1`. You must include the IP range allocated for the Sourcegraph deployment services to allow inter-service communication, e.g., kubernetes pod ip range.",
+					"examples": [
+						"100.100.100.0/25",
+						"23.34.56.21"
+					],
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"userIpAddress": {
+					"description": "List of user IP addresses to allow. If empty, all IP addresses are allowed.",
+					"examples": [
+						"100.100.100.0/25",
+						"23.34.56.21"
+					],
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"userIpRequestHeaders": {
+					"description": "An optional list of case-insensitive request header names to use for resolving the callers user IP address. You must ensure that the header is coming from a trusted source. If the header contains multiple IP addresses, the right-most is used. If no IP is found from provided headers, the connected client IP address is used.",
+					"examples": [
+						"X-Forwarded-For",
+						"X-Real-IP",
+						"CF-Connecting-IP"
+					],
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				}
+			},
+			"type": "object"
+		},
+		"auth.enableUsernameChanges": {
+			"default": false,
+			"description": "Enables users to change their username after account creation. Warning: setting this to be true has security implications if you have enabled (or will at any point in the future enable) repository permissions with an option that relies on username equivalency between Sourcegraph and an external service or authentication provider. Do NOT set this to true if you are using non-built-in authentication OR rely on username equivalency for repository permissions.",
+			"group": "Authentication",
+			"type": "boolean"
+		},
+		"auth.lockout": {
+			"description": "The config options for account lockout",
+			"examples": [
+				{
+					"consecutivePeriod": 300,
+					"failedAttemptThreshold": 3,
+					"lockoutPeriod": 600
+				}
+			],
+			"group": "Authentication",
+			"properties": {
+				"consecutivePeriod": {
+					"default": 3600,
+					"description": "The number of seconds to be considered as a consecutive period",
+					"type": "integer"
+				},
+				"failedAttemptThreshold": {
+					"default": 5,
+					"description": "The threshold of failed sign-in attempts in a consecutive period",
+					"type": "integer"
+				},
+				"lockoutPeriod": {
+					"default": 1800,
+					"description": "The number of seconds for the lockout period",
+					"type": "integer"
+				}
+			},
+			"type": "object"
+		},
+		"auth.maxSessionIdleDuration": {
+			"default": "0",
+			"description": "The maximum duration a user session may be idle (not making any requests), after which it expires and the user is required to re-authenticate. Must be at least 1 hour. Defaults to no idle expiry.",
+			"examples": [
+				"2h"
+			],
+			"group": "Authentication",
+			"type": "string"
+		},
+		"auth.minPasswordLength": {
+			"default": 12,
+			"description": "The minimum number of Unicode code points that a password must contain.",
+			"group": "Authentication",
+			"type": "integer"
+		},
+		"auth.passwordPolicy": {
+			"additionalProperties": false,
+			"description": "Enables and configures password policy. This will allow admins to enforce password complexity and length requirements.",
+			"examples": [
+				{
+					"enabled": true,
+					"numberOfSpecialCharacters": 1,
+					"requireAtLeastOneNumber": true,
+					"requireUpperandLowerCase": true
+				}
+			],
+			"properties": {
+				"enabled": {
+					"default": false,
+					"description": "Enables password policy",
+					"type": "boolean"
+				},
+				"numberOfSpecialCharacters": {
+					"description": "The required number of special characters",
+					"length": 2,
+					"type": "integer"
+				},
+				"requireAtLeastOneNumber": {
+					"default": true,
+					"description": "Does the password require a number",
+					"type": "boolean"
+				},
+				"requireUpperandLowerCase": {
+					"default": true,
+					"description": "Require Mixed characters",
+					"type": "boolean"
+				}
+			},
+			"type": "object"
+		},
+		"auth.passwordResetLinkExpiry": {
+			"default": 14400,
+			"description": "The duration (in seconds) that a password reset link is considered valid.",
+			"group": "Authentication",
+			"type": "integer"
+		},
+		"auth.primaryLoginProvidersCount": {
+			"default": 3,
+			"description": "The number of auth providers that will be shown to the user on the login screen. Other providers are shown under `Other login methods` section.",
+			"group": "Authentication",
+			"type": "integer"
+		},
+		"auth.providers": {
+			"default": [
+				{
+					"allowSignup": true,
+					"type": "builtin"
+				}
+			],
+			"description": "The authentication providers to use for identifying and signing in users. See instructions below for configuring SAML, OpenID Connect (including Google Workspace), and HTTP authentication proxies. Multiple authentication providers are supported (by specifying multiple elements in this array).",
+			"group": "Authentication",
+			"items": {
+				"!go": {
+					"taggedUnionType": true
+				},
+				"oneOf": [
+					{
+						"$ref": "#/definitions/AzureDevOpsAuthProvider"
+					},
+					{
+						"$ref": "#/definitions/BitbucketCloudAuthProvider"
+					},
+					{
+						"$ref": "#/definitions/BitbucketServerAuthProvider"
+					},
+					{
+						"$ref": "#/definitions/BuiltinAuthProvider"
+					},
+					{
+						"$ref": "#/definitions/GerritAuthProvider"
+					},
+					{
+						"$ref": "#/definitions/GitHubAuthProvider"
+					},
+					{
+						"$ref": "#/definitions/GitLabAuthProvider"
+					},
+					{
+						"$ref": "#/definitions/HTTPHeaderAuthProvider"
+					},
+					{
+						"$ref": "#/definitions/OpenIDConnectAuthProvider"
+					},
+					{
+						"$ref": "#/definitions/SAMLAuthProvider"
+					}
+				],
+				"properties": {
+					"type": {
+						"enum": [
+							"azureDevOps",
+							"bitbucketcloud",
+							"bitbucketserver",
+							"builtin",
+							"gerrit",
+							"github",
+							"gitlab",
+							"http-header",
+							"openidconnect",
+							"saml"
+						],
+						"type": "string"
+					}
+				},
+				"required": [
+					"type"
+				]
+			},
+			"type": "array"
+		},
+		"auth.sessionExpiry": {
+			"default": "2160h",
+			"description": "The maximum duration of a user session, after which it expires and the user is required to re-authenticate. The default is 90 days. Must be at least 1 hour. There is typically no need to set this, but some users may have specific internal security requirements.\n\nThe string format is that of the Duration type in the Go time package (https://golang.org/pkg/time/#ParseDuration). E.g., \"720h\", \"43200m\", \"2592000s\" all indicate a timespan of 30 days.",
+			"examples": [
+				"168h"
+			],
+			"group": "Authentication",
+			"type": "string"
+		},
+		"auth.unlockAccountLinkExpiry": {
+			"default": 5,
+			"description": "Validity expressed in minutes of the unlock account token",
+			"group": "Authentication",
+			"type": "integer"
+		},
+		"auth.unlockAccountLinkSigningKey": {
+			"description": "Base64-encoded HMAC signing key to sign the JWT token for account unlock URLs",
+			"examples": [
+				"LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KYjNCbGJuTnphQzFyWlhrdGRqRUFBQUFBQkc1dmJtVUFBQUFFYm05dVpRQUFBQUFBQUFBQkFBQUJGZ0FBQUhVQkFBQQ"
+			],
+			"group": "Authentication",
+			"type": "string"
+		},
+		"auth.userOrgMap": {
+			"additionalProperties": {
+				"items": {
+					"type": "string"
+				},
+				"type": "array"
+			},
+			"description": "Ensure that matching users are members of the specified orgs (auto-joining users to the orgs if they are not already a member). Provide a JSON object of the form `{\"*\": [\"org1\", \"org2\"]}`, where org1 and org2 are orgs that all users are automatically joined to. Currently the only supported key is `\"*\"`.",
+			"examples": [
+				{
+					"*": [
+						"myorg1"
+					]
+				}
+			],
+			"hide": true,
+			"type": "object"
+		},
+		"authz.enforceForSiteAdmins": {
+			"default": false,
+			"description": "When true, site admins will only be able to see private code they have access to via our authz system.",
+			"type": "boolean"
+		},
+		"batchChanges.autoDeleteBranch": {
+			"default": false,
+			"description": "Automatically delete branches created for Batch Changes changesets when the changeset is merged or closed, for supported code hosts. Overrides any setting on the repository on the code host itself.",
+			"group": "BatchChanges",
+			"type": "boolean"
+		},
+		"batchChanges.changesetsRetention": {
+			"description": "How long changesets will be retained after they have been detached from a batch change.",
+			"examples": [
+				"336h",
+				"48h",
+				"5h30m40s"
+			],
+			"group": "BatchChanges",
+			"type": "string"
+		},
+		"batchChanges.containerRegistryAllowlist": {
+			"description": "A list of permitted container registries for use in batch changes, e.g., docker.io. If empty, all container registries are allowed. It cannot be used together with 'batchChanges.containerRegistryDenylist'",
+			"examples": [
+				"docker.io",
+				"artifactory.acme.com"
+			],
+			"items": {
+				"type": "string"
+			},
+			"type": "array"
+		},
+		"batchChanges.containerRegistryDenylist": {
+			"description": "A list of forbidden container registries for use in batch changes, e.g., docker.io. If empty, all container registries are allowed. It cannot be used together with 'batchChanges.containerRegistryAllowlist'",
+			"examples": [
+				"docker.io",
+				"artifactory.acme.com"
+			],
+			"items": {
+				"type": "string"
+			},
+			"type": "array"
+		},
+		"batchChanges.disableWebhooksWarning": {
+			"default": false,
+			"description": "Hides Batch Changes warnings about webhooks not being configured.",
+			"group": "BatchChanges",
+			"type": "boolean"
+		},
+		"batchChanges.enabled": {
+			"!go": {
+				"pointer": true
+			},
+			"default": true,
+			"description": "Enables/disables the Batch Changes feature.",
+			"group": "BatchChanges",
+			"type": "boolean"
+		},
+		"batchChanges.enforceForks": {
+			"default": false,
+			"description": "When enabled, all branches created by batch changes will be pushed to forks of the original repository.",
+			"group": "BatchChanges",
+			"type": "boolean"
+		},
+		"batchChanges.rejectUnverifiedCommit": {
+			"!go": {
+				"pointer": true
+			},
+			"default": false,
+			"description": "Reject unverified commits when creating a Batch Change",
+			"type": "boolean"
+		},
+		"batchChanges.restrictToAdmins": {
+			"!go": {
+				"pointer": true
+			},
+			"default": false,
+			"description": "When enabled, only site admins can create and apply batch changes.",
+			"group": "BatchChanges",
+			"type": "boolean"
+		},
+		"batchChanges.rolloutWindows": {
+			"!go": {
+				"pointer": true
+			},
+			"description": "Specifies specific windows, which can have associated rate limits, to be used when reconciling published changesets (creating or updating). All days and times are handled in UTC.",
+			"examples": [
+				{
+					"days": [
+						"saturday",
+						"sunday"
+					],
+					"end": "20:00",
+					"rate": "10/hour",
+					"start": "06:00"
+				}
+			],
+			"group": "BatchChanges",
+			"items": {
+				"additionalProperties": false,
+				"dependencies": {
+					"start": [
+						"end"
+					]
+				},
+				"properties": {
+					"days": {
+						"description": "Day(s) the window applies to. If omitted, this rule applies to all days of the week.",
+						"items": {
+							"pattern": "^([mM]on(day)?|[tT]ue(s|sday)?|[wW]ed(nesday)?|[tT]hu(r|rs|rsday)?|[fF]ri(day)?|[sS]at(urday)?|[sS]un(day)?)$",
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"end": {
+						"description": "Window end time. If omitted, no time window is applied to the day(s) that match this rule.",
+						"pattern": "^[0-9]?[0-9]:[0-9]{2}$",
+						"type": "string"
+					},
+					"rate": {
+						"description": "The rate changesets will be published at.",
+						"oneOf": [
+							{
+								"maximum": 0,
+								"minimum": 0,
+								"type": "number"
+							},
+							{
+								"pattern": "^(unlimited|[0-9]+/(sec|secs|second|seconds|min|mins|minute|minutes|hr|hrs|hour|hours))$",
+								"type": "string"
+							}
+						]
+					},
+					"start": {
+						"description": "Window start time. If omitted, no time window is applied to the day(s) that match this rule.",
+						"pattern": "^[0-9]?[0-9]:[0-9]{2}$",
+						"type": "string"
+					}
+				},
+				"required": [
+					"rate"
+				],
+				"title": "BatchChangeRolloutWindow",
+				"type": "object"
+			},
+			"type": "array"
+		},
+		"batchChanges.templateLibrary.displayLimit": {
+			"default": 20,
+			"description": "Maximum number of batch spec templates to display in the template library UI. Default is 20.",
+			"group": "BatchChanges",
+			"maximum": 1000,
+			"minimum": 1,
+			"type": "integer"
+		},
+		"branding": {
+			"additionalProperties": false,
+			"description": "Customize Sourcegraph homepage logo and search icon.",
+			"examples": [
+				{
+					"dark": {
+						"logo": "https://example.com/logo_dark.png",
+						"symbol": "https://example.com/search_symbol_dark_24x24.png"
+					},
+					"disableSymbolSpin": true,
+					"favicon": "https://example.com/favicon.ico",
+					"light": {
+						"logo": "https://example.com/logo_light.png",
+						"symbol": "https://example.com/search_symbol_light_24x24.png"
+					}
+				}
+			],
+			"properties": {
+				"brandName": {
+					"default": "Sourcegraph",
+					"description": "String to display everywhere the brand name should be displayed. Defaults to \"Sourcegraph\"",
+					"type": "string"
+				},
+				"dark": {
+					"$ref": "#/definitions/BrandAssets"
+				},
+				"disableSymbolSpin": {
+					"default": false,
+					"deprecationMessage": "No effect, symbol does not spin anymore.",
+					"description": "Prevents the icon in the top-left corner of the screen from spinning on hover.",
+					"type": "boolean"
+				},
+				"favicon": {
+					"description": "The URL of the favicon to be used for your instance. We recommend using the following file format: ICO",
+					"format": "uri",
+					"type": "string"
+				},
+				"light": {
+					"$ref": "#/definitions/BrandAssets"
+				}
+			},
+			"type": "object"
+		},
+		"cloneProgress.log": {
+			"default": false,
+			"description": "Whether clone progress should be logged to a file. If enabled, logs are written to files in the OS default path for temporary files.",
+			"type": "boolean"
+		},
+		"codeIntelAutoIndexing.allowGlobalPolicies": {
+			"!go": {
+				"pointer": true
+			},
+			"default": false,
+			"description": "Whether auto-indexing policies may apply to all repositories on the Sourcegraph instance. Default is false. The policyRepositoryMatchLimit setting still applies to such auto-indexing policies.",
+			"group": "Code intelligence",
+			"type": "boolean"
+		},
+		"codeIntelAutoIndexing.enabled": {
+			"!go": {
+				"pointer": true
+			},
+			"default": false,
+			"description": "Enables/disables the code intel auto-indexing feature. Currently experimental.",
+			"group": "Code intelligence",
+			"type": "boolean"
+		},
+		"codeIntelAutoIndexing.indexerMap": {
+			"additionalProperties": {
+				"type": "string"
+			},
+			"default": null,
+			"description": "Overrides the default Docker images used by auto-indexing.",
+			"examples": [
+				{
+					"go": "sourcegraph/lsif-go:latest",
+					"java": "sourcegraph/lsif-java:latest"
+				}
+			],
+			"group": "Code intelligence",
+			"type": "object"
+		},
+		"codeIntelAutoIndexing.policyRepositoryMatchLimit": {
+			"!go": {
+				"pointer": true
+			},
+			"default": -1,
+			"description": "The maximum number of repositories to which a single auto-indexing policy can apply. Default is -1, which is unlimited.",
+			"group": "Code intelligence",
+			"type": "integer"
+		},
+		"codeMonitors": {
+			"description": "Configuration options for code monitors",
+			"properties": {
+				"concurrency": {
+					"default": 4,
+					"description": "The number of code monitor jobs allowed to run concurrently. Decrease to reduce peak load.",
+					"type": "integer"
+				},
+				"maxRuntime": {
+					"default": 1,
+					"description": "The maximum runtime in minutes per code monitor jobs. Increase if jobs time out consistently",
+					"type": "integer"
+				},
+				"pollInterval": {
+					"default": "5m",
+					"description": "The interval at which a monitor checks for new changes. Increase to reduce average load.",
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"cody.contextFilters": {
+			"additionalProperties": false,
+			"description": "Rules defining the repositories that will never be shared by Cody with third-party LLM providers.",
+			"group": "Cody",
+			"minProperties": 1,
+			"properties": {
+				"exclude": {
+					"description": "List of rules specifying repositories that Cody should excluded from context in requests to third-party LLMs. These rules are applied only to repositories matching the include rules.",
+					"items": {
+						"$ref": "#/definitions/CodyContextFilterItem"
+					},
+					"minItems": 1,
+					"type": "array"
+				},
+				"include": {
+					"description": "List of rules specifying repositories that Cody may include as context in requests to third-party LLMs. If defined, only repositories matching these rules will be considered for sharing. If not defined, all repositories may be shared.",
+					"items": {
+						"$ref": "#/definitions/CodyContextFilterItem"
+					},
+					"minItems": 1,
+					"type": "array"
+				}
+			},
+			"type": "object"
+		},
+		"cody.enabled": {
+			"!go": {
+				"pointer": true
+			},
+			"default": false,
+			"description": "Enable or disable Cody instance-wide. When Cody is disabled, all Cody endpoints and GraphQL queries will return errors, Cody will not show up in the site-admin sidebar, and Cody in the global navbar will only show a call-to-action for site-admins to enable Cody.",
+			"group": "Cody",
+			"type": "boolean"
+		},
+		"cody.permissions": {
+			"!go": {
+				"pointer": true
+			},
+			"default": true,
+			"description": "Whether to enable Cody role-based access controls. Only respected if cody.restrictUsersFeatureFlag is not set. See https://sourcegraph.com/docs/admin/access_control",
+			"group": "Cody",
+			"type": "boolean"
+		},
+		"cody.restrictUsersFeatureFlag": {
+			"!go": {
+				"pointer": true
+			},
+			"default": false,
+			"description": "DEPRECATED; see cody.permissions instead. PRIOR DESCRIPTION: Cody to only be enabled for users that have a feature flag labeled \"cody\" set to true. You must create a feature flag with this ID after enabling this setting: https://www.notion.so/sourcegraph/How-to-use-feature-flags-70f42bcacd9045d4a55de22f5dd87df0?source=copy_link. This setting only has an effect if cody.enabled is true.",
+			"group": "Cody",
+			"type": "boolean"
+		},
+		"cody.serverSideContext": {
+			"description": "Configuration for Server-side context API",
+			"group": "Cody",
+			"properties": {
+				"reranker": {
+					"!go": {
+						"taggedUnionType": true
+					},
+					"description": "Reranker to use for rankContext requests",
+					"oneOf": [
+						{
+							"$ref": "#/definitions/CodyRerankerSourcegraph"
+						},
+						{
+							"$ref": "#/definitions/CodyRerankerIdentity"
+						},
+						{
+							"$ref": "#/definitions/CodyRerankerCohere"
+						},
+						{
+							"$ref": "#/definitions/CodyRerankerVoyageAI"
+						}
+					],
+					"properties": {
+						"type": {
+							"enum": [
+								"sourcegraph",
+								"identity",
+								"cohere",
+								"voyageai"
+							],
+							"type": "string"
+						}
+					},
+					"type": "object"
+				}
+			},
+			"type": "object"
+		},
+		"completions": {
+			"description": "Configuration for the completions service.",
+			"examples": [
+				{
+					"accessToken": "abc123",
+					"chatModel": "chat",
+					"completionModel": "code-completion",
+					"enabled": true,
+					"perUserDailyLimit": 100,
+					"provider": "openai"
+				}
+			],
+			"properties": {
+				"accessToken": {
+					"description": "The access token used to authenticate with the external completions provider. If using the default provider 'sourcegraph', and if 'licenseKey' is set, a default access token is generated.",
+					"type": "string"
+				},
+				"azureChatModel": {
+					"description": "Optional: Specify the Azure OpenAI model name for chat completions. This is only needed when you want to count tokens associated with your azure model",
+					"enum": [
+						"gpt-3.5-turbo",
+						"gpt-3.5-turbo-16k",
+						"gpt-3.5-turbo-instruct",
+						"gpt-3.5-turbo-0125",
+						"gpt-3.5-turbo-0301",
+						"gpt-3.5-turbo-0613",
+						"gpt-3.5-turbo-16k-0613",
+						"gpt-4-0314",
+						"gpt-4-32k-0314",
+						"gpt-4-0613",
+						"gpt-4-32k-0613",
+						"gpt-4o",
+						"gpt-4o-2024-05-13",
+						"gpt-4o-2024-08-06",
+						"gpt-4"
+					],
+					"type": "string"
+				},
+				"azureCompletionModel": {
+					"description": "Optional: Specify the Azure OpenAI model name for chat completions. This is only needed when you want to count tokens associated with your azure model",
+					"enum": [
+						"gpt-3.5-turbo",
+						"gpt-3.5-turbo-instruct",
+						"gpt-3.5-turbo-16k",
+						"gpt-3.5-turbo-0125",
+						"gpt-3.5-turbo-0301",
+						"gpt-3.5-turbo-0613",
+						"gpt-3.5-turbo-16k-0613",
+						"gpt-4-0314",
+						"gpt-4-32k-0314",
+						"gpt-4-0613",
+						"gpt-4-32k-0613",
+						"gpt-4o",
+						"gpt-4o-2024-05-13",
+						"gpt-4o-2024-08-06",
+						"gpt-4"
+					],
+					"type": "string"
+				},
+				"azureUseDeprecatedCompletionsAPIForOldModels": {
+					"default": true,
+					"description": "Enables the use of the older completions API for select Azure OpenAI models.",
+					"type": "boolean"
+				},
+				"chatModel": {
+					"description": "The model used for chat completions. If using the default provider 'sourcegraph', a reasonable default model will be set.\n NOTE: The Anthropic messages API does not support model names like claude-2 or claude-instant-1 where only the major version is specified as they are retired. We recommend using a specific model identifier as specified here https://docs.anthropic.com/claude/docs/models-overview#model-comparison ",
+					"errorMessage": "The substring 'cumber' is not allowed because it is a bad idea and may lead to unexpected issues.",
+					"not": {
+						"enum": [
+							"claude-2",
+							"claude-instant-1"
+						]
+					},
+					"type": "string"
+				},
+				"chatModelMaxTokens": {
+					"description": "The maximum number of tokens to use as client when talking to chatModel. If not set, clients need to set their own limit. If smartContextWindow is enabled, this value will be overridden by the clients.",
+					"type": "integer"
+				},
+				"completionModel": {
+					"description": "The model used for code completion. If using the default provider 'sourcegraph', a reasonable default model will be set.\n NOTE: The Anthropic messages API does not support model names like claude-2 or claude-instant-1 where only the major version is specified as they are retired. We recommend using a specific model identifier as specified here https://docs.anthropic.com/claude/docs/models-overview#model-comparison ",
+					"not": {
+						"enum": [
+							"claude-2",
+							"claude-instant-1"
+						]
+					},
+					"type": "string"
+				},
+				"completionModelMaxTokens": {
+					"description": "The maximum number of tokens to use as client when talking to completionModel. If not set, clients need to set their own limit.",
+					"type": "integer"
+				},
+				"disableClientConfigAPI": {
+					"!go": {
+						"pointer": true
+					},
+					"deprecationMessage": "This opt-out feature flag will be removed soon.",
+					"description": "Should not be set. If set to true, disables the use of the new client config API. This new API has no user-facing effect, this opt-out is provided only as an escape hatch in case of issues.",
+					"type": "boolean"
+				},
+				"enabled": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "DEPRECATED. Use cody.enabled instead to turn Cody on/off.",
+					"type": "boolean"
+				},
+				"endpoint": {
+					"description": "The endpoint under which to reach the provider. Currently only used for provider types \"sourcegraph\", \"openai\" and \"anthropic\". The default values are \"https://cody-gateway.sourcegraph.com\", \"https://api.openai.com/v1/chat/completions\", and \"https://api.anthropic.com/v1/messages\" for Sourcegraph, OpenAI, and Anthropic, respectively.",
+					"type": "string"
+				},
+				"fastChatModel": {
+					"description": "The model used for fast chat completions. \n NOTE: The Anthropic messages API does not support model names like claude-2 or claude-instant-1 where only the major version is specified as they are retired. We recommend using a specific model identifier as specified here https://docs.anthropic.com/claude/docs/models-overview#model-comparison ",
+					"not": {
+						"enum": [
+							"claude-2",
+							"claude-instant-1"
+						]
+					},
+					"type": "string"
+				},
+				"fastChatModelMaxTokens": {
+					"description": "The maximum number of tokens to use as client when talking to fastChatModel. If not set, clients need to set their own limit.",
+					"type": "integer"
+				},
+				"model": {
+					"description": "DEPRECATED. Use chatModel instead.",
+					"type": "string"
+				},
+				"perCommunityUserChatMonthlyInteractionLimit": {
+					"default": 0,
+					"description": "If \u003e 0, enables the maximum number of completions interactions allowed to be made by a single Community user in a month. This is for Cody PLG and applies to Dotcom only.",
+					"type": "integer"
+				},
+				"perCommunityUserChatMonthlyLLMRequestLimit": {
+					"default": 0,
+					"description": "If \u003e 0, limits the number of completions requests allowed for a Community user in a month. This is for Self-serve Cody and applies to Dotcom only.",
+					"type": "integer"
+				},
+				"perCommunityUserCodeCompletionsMonthlyInteractionLimit": {
+					"default": 0,
+					"description": "If \u003e 0, enables the maximum number of code completions interactions allowed to be made by a single Community user in a month.  This is for Cody PLG and applies to Dotcom only.",
+					"type": "integer"
+				},
+				"perCommunityUserCodeCompletionsMonthlyLLMRequestLimit": {
+					"default": 0,
+					"description": "If \u003e 0, limits the number of code completions requests allowed for a Community user in a month.  This is for Self-serve Cody and applies to Dotcom only.",
+					"type": "integer"
+				},
+				"perProUserChatDailyInteractionLimit": {
+					"default": 0,
+					"description": "If \u003e 0, enables the maximum number of completions interactions allowed to be made by a single Pro user in a day. This is for Cody PLG and applies to Dotcom only.",
+					"type": "integer"
+				},
+				"perProUserChatDailyLLMRequestLimit": {
+					"default": 0,
+					"description": "If \u003e 0, limits the number of completions requests allowed for a Pro user in a day. This is for Self-serve Cody and applies to Dotcom only.",
+					"type": "integer"
+				},
+				"perProUserCodeCompletionsDailyInteractionLimit": {
+					"default": 0,
+					"description": "If \u003e 0, enables the maximum number of code completions interactions allowed to be made by a single Pro user in a day. This is for Cody PLG and applies to Dotcom only.",
+					"type": "integer"
+				},
+				"perProUserCodeCompletionsDailyLLMRequestLimit": {
+					"default": 0,
+					"description": "If \u003e 0, limits the number of code completions requests allowed for a Pro user in a day. This is for Self-serve Cody and applies to Dotcom only.",
+					"type": "integer"
+				},
+				"perUserCodeCompletionsDailyLimit": {
+					"default": 0,
+					"description": "If \u003e 0, limits the number of code completions requests allowed for a user in a day. On instances that allow anonymous requests, we enforce the rate limit by IP.",
+					"type": "integer"
+				},
+				"perUserDailyLimit": {
+					"default": 0,
+					"description": "If \u003e 0, limits the number of completions requests allowed for a user in a day. On instances that allow anonymous requests, we enforce the rate limit by IP.",
+					"type": "integer"
+				},
+				"provider": {
+					"default": "sourcegraph",
+					"description": "The external completions provider. Defaults to 'sourcegraph'.",
+					"enum": [
+						"anthropic",
+						"openai",
+						"sourcegraph",
+						"azure-openai",
+						"aws-bedrock",
+						"fireworks",
+						"google"
+					],
+					"type": "string"
+				},
+				"smartContextWindow": {
+					"default": "enabled",
+					"description": "Whether the maximum number of tokens should be automatically adjusted by the client based on the name of chatModel. If enabled, it will override the value set in chatModelMaxTokens.",
+					"enum": [
+						"enabled",
+						"disabled"
+					],
+					"type": "string"
+				},
+				"user": {
+					"description": "The user field for OpenAI config for both AzureOpenAI and OpenAI",
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"configFeatures": {
+			"description": "Configuration for the completions service.",
+			"examples": [
+				{
+					"chat": true
+				}
+			],
+			"properties": {
+				"autoComplete": {
+					"description": "Enable/Disable AutoComplete for the clients",
+					"type": "boolean"
+				},
+				"chat": {
+					"description": "Enable/Disable Chat for the clients",
+					"type": "boolean"
+				},
+				"chatVision": {
+					"description": "Enable/Disable uploading images to Chat",
+					"type": "boolean"
+				},
+				"commands": {
+					"description": "Enable/Disable special commands for the clients",
+					"type": "boolean"
+				}
+			},
+			"type": "object"
+		},
+		"contributorsDataEnabled": {
+			"!go": {
+				"pointer": true
+			},
+			"default": true,
+			"description": "Enables the computation of contributor statistics per author and repository. Will all commits of each repository initially, and then work on deltas.",
+			"examples": [
+				true
+			],
+			"type": "boolean"
+		},
+		"corsOrigin": {
+			"description": "Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.",
+			"examples": [
+				"https://my-phabricator.example.com https://my-bitbucket.example.com https://my-gitlab.example.com"
+			],
+			"group": "Security",
+			"pattern": "^((https?://[\\w-.]+)( https?://[\\w-.]+)*)|\\*$",
+			"type": "string"
+		},
+		"debug.search.symbolsParallelism": {
+			"description": "(debug) controls the amount of symbol search parallelism. Defaults to 20. It is not recommended to change this outside of debugging scenarios. This option will be removed in a future version.",
+			"examples": [
+				"20"
+			],
+			"group": "Debug",
+			"type": "integer"
+		},
+		"defaultRateLimit": {
+			"!go": {
+				"pointer": true
+			},
+			"default": -1,
+			"description": "The rate limit (in requests per hour) for the default rate limiter in the rate limiters registry. By default this is disabled and the default rate limit is infinity.",
+			"type": "integer"
+		},
+		"disableAutoCodeHostSyncs": {
+			"default": false,
+			"description": "Disable periodic syncs of configured code host connections (repository metadata, permissions, batch changes changesets, etc)",
+			"group": "External services",
+			"type": "boolean"
+		},
+		"disableAutoGitUpdates": {
+			"default": false,
+			"description": "Disable periodically fetching git contents for existing repositories.",
+			"group": "External services",
+			"type": "boolean"
+		},
+		"disableFeedbackSurvey": {
+			"default": false,
+			"description": "Disable the feedback survey",
+			"group": "Misc.",
+			"type": "boolean"
+		},
+		"disableNonCriticalTelemetry": {
+			"default": false,
+			"description": "DEPRECATED. Has no effect.",
+			"group": "Misc.",
+			"type": "boolean"
+		},
+		"disablePublicRepoRedirects": {
+			"deprecationMessage": "Deprecated because it's no longer supported and hasn't been working for a while.",
+			"description": "DEPRECATED! Disable redirects to sourcegraph.com when visiting public repositories that can't exist on this server.",
+			"examples": [
+				true
+			],
+			"group": "External services",
+			"type": "boolean"
+		},
+		"dotcom": {
+			"description": "Configuration options for Sourcegraph.com only.",
+			"group": "Sourcegraph.com",
+			"properties": {
+				"codyGateway": {
+					"description": "Configuration related to the Cody Gateway service management. This should only be used on sourcegraph.com.",
+					"group": "Sourcegraph.com",
+					"properties": {
+						"bigQueryDataset": {
+							"description": "The dataset to pull BigQuery Cody Gateway related events from.",
+							"type": "string"
+						},
+						"bigQueryGoogleProjectID": {
+							"description": "The project ID to pull BigQuery Cody Gatewayrelated events from.",
+							"type": "string"
+						},
+						"bigQueryTable": {
+							"description": "The table in the dataset to pull BigQuery Cody Gateway related events from.",
+							"type": "string"
+						}
+					},
+					"type": "object"
+				},
+				"codyProConfig": {
+					"additionalProperties": false,
+					"properties": {
+						"samsBackendOrigin": {
+							"default": "",
+							"description": "Origin of the SAMS backend. (Must match the SAMS OIDC registration in auth.providers.)",
+							"examples": [
+								"https://accounts.sourcegraph.com"
+							],
+							"type": "string"
+						},
+						"sscBackendOrigin": {
+							"default": "",
+							"description": "Origin of the Self-serve Cody backend.",
+							"examples": [
+								"https://accounts.sourcegraph.com"
+							],
+							"type": "string"
+						},
+						"sscBaseUrl": {
+							"default": "https://accounts.sourcegraph.com/cody",
+							"description": "The base URL of the Self-Serve Cody site.",
+							"type": "string"
+						},
+						"stripePublishableKey": {
+							"default": null,
+							"description": "Stripe Publishable Key for use in Stripe Checkout, Stripe Elements. This is not considered a secret.",
+							"examples": [
+								"pk_test_...",
+								"pk_live_..."
+							],
+							"type": "string"
+						},
+						"useEmbeddedUI": {
+							"default": false,
+							"description": "Whether Cody Pro UI is served from sourcegraph.com. If false, users are directed to https://accounts.sourcegraph.com/cody to manage their Cody Pro subscription.",
+							"type": "boolean"
+						}
+					},
+					"type": "object"
+				},
+				"enterprisePortal.enableProxies": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "Whether to enable Enterprise Portal auth proxies for site admins.",
+					"type": "boolean"
+				},
+				"sams.clientID": {
+					"description": "The clientID for SAMS production instance.",
+					"type": "string"
+				},
+				"sams.clientSecret": {
+					"description": "The clientSecret for SAMS production instance.",
+					"type": "string"
+				},
+				"sams.server": {
+					"description": "The server URL for SAMS production instance.",
+					"type": "string"
+				},
+				"samsDev.clientID": {
+					"description": "The clientID for SAMS development instance.",
+					"type": "string"
+				},
+				"samsDev.clientSecret": {
+					"description": "The clientSecret for SAMS development instance.",
+					"type": "string"
+				},
+				"samsDev.server": {
+					"default": "https://accounts.sgdev.org",
+					"description": "The server URL for SAMS development instance.",
+					"type": "string"
+				},
+				"srcCliVersionCache": {
+					"description": "Configuration related to the src-cli version cache. This should only be used on sourcegraph.com.",
+					"group": "Sourcegraph.com",
+					"properties": {
+						"enabled": {
+							"default": false,
+							"description": "Enables the src-cli version cache API endpoint.",
+							"type": "boolean"
+						},
+						"github": {
+							"description": "GitHub configuration, both for queries and receiving release webhooks.",
+							"properties": {
+								"repository": {
+									"description": "The repository to get the latest version of.",
+									"properties": {
+										"name": {
+											"default": "src-cli",
+											"description": "The repository name.",
+											"type": "string"
+										},
+										"owner": {
+											"default": "sourcegraph",
+											"description": "The repository namespace.",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"token": {
+									"description": "The access token to use when communicating with GitHub.",
+									"type": "string"
+								},
+								"uri": {
+									"default": "https://github.com",
+									"description": "The URI of the GitHub instance.",
+									"type": "string"
+								},
+								"webhookSecret": {
+									"description": "The release webhook secret.",
+									"type": "string"
+								}
+							},
+							"required": [
+								"token",
+								"webhookSecret"
+							],
+							"type": "object"
+						},
+						"interval": {
+							"default": "1h",
+							"description": "The interval between version checks, expressed as a string that can be parsed by Go's time.ParseDuration.",
+							"type": "string"
+						}
+					},
+					"required": [
+						"enabled",
+						"github"
+					],
+					"type": "object"
+				}
+			},
+			"type": "object"
+		},
+		"email.address": {
+			"description": "The \"from\" address for emails sent by this server.\nPlease see https://sourcegraph.com/docs/admin/config/email",
+			"examples": [
+				"noreply@sourcegraph.example.com"
+			],
+			"format": "email",
+			"group": "Email",
+			"type": "string"
+		},
+		"email.senderName": {
+			"default": "Sourcegraph",
+			"description": "The name to use in the \"from\" address for emails sent by this server.",
+			"examples": [
+				"Our Company Sourcegraph",
+				"Example Inc Sourcegraph"
+			],
+			"group": "Email",
+			"type": "string"
+		},
+		"email.smtp": {
+			"additionalProperties": false,
+			"default": null,
+			"description": "The SMTP server used to send transactional emails.\nPlease see https://sourcegraph.com/docs/admin/config/email",
+			"examples": [
+				{
+					"authentication": "PLAIN",
+					"host": "smtp.example.com",
+					"password": "mypassword",
+					"port": 465,
+					"username": "alice"
+				}
+			],
+			"group": "Email",
+			"properties": {
+				"additionalHeaders": {
+					"description": "Additional headers to include on SMTP messages that cannot be configured with other 'email.smtp' fields.",
+					"items": {
+						"additionalProperties": false,
+						"examples": [
+							{
+								"key": "",
+								"value": ""
+							}
+						],
+						"properties": {
+							"key": {
+								"type": "string"
+							},
+							"sensitive": {
+								"type": "boolean"
+							},
+							"value": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"key",
+							"value"
+						],
+						"title": "Header",
+						"type": "object"
+					},
+					"type": "array"
+				},
+				"authentication": {
+					"description": "The type of authentication to use for the SMTP server.",
+					"enum": [
+						"none",
+						"PLAIN",
+						"CRAM-MD5"
+					],
+					"type": "string"
+				},
+				"domain": {
+					"description": "The HELO domain to provide to the SMTP server (if needed).",
+					"type": "string"
+				},
+				"host": {
+					"description": "The SMTP server host.",
+					"type": "string"
+				},
+				"noVerifyTLS": {
+					"description": "Disable TLS verification",
+					"type": "boolean"
+				},
+				"password": {
+					"description": "The password to use when communicating with the SMTP server.",
+					"type": "string"
+				},
+				"port": {
+					"description": "The SMTP server port.",
+					"type": "integer"
+				},
+				"username": {
+					"description": "The username to use when communicating with the SMTP server.",
+					"type": "string"
+				}
+			},
+			"required": [
+				"host",
+				"port",
+				"authentication"
+			],
+			"title": "SMTPServerConfig",
+			"type": "object"
+		},
+		"email.templates": {
+			"description": "Configurable templates for some email types sent by Sourcegraph.",
+			"examples": [
+				{
+					"resetPassword": {
+						"body": "To reset your password on {{.Host}}, please click the link below:\n\n{{.URL}}\n\nIf you did not request a password reset, please ignore this email. Your password will not change until you click the link and set a new password.",
+						"subject": "Reset your password on {{.Host}}"
+					},
+					"setPassword": {
+						"body": "To set your password on {{.Host}} and complete your account registration, please click the link below:\n\n{{.URL}}\n\nYour username is: {{.Username}}\n\nIf you did not sign up for an account on {{.Host}}, please ignore this email.",
+						"subject": "Set your password on {{.Host}}"
+					}
+				}
+			],
+			"group": "Email",
+			"properties": {
+				"resetPassword": {
+					"$ref": "#/definitions/EmailTemplate",
+					"description": "Email sent on password resets. Available template variables: {{.Host}}, {{.Username}}, {{.URL}}"
+				},
+				"setPassword": {
+					"$ref": "#/definitions/EmailTemplate",
+					"description": "Email sent on account creation, if a password reset URL is created. Available template variables: {{.Host}}, {{.Username}}, {{.URL}}"
+				}
+			},
+			"type": "object"
+		},
+		"embeddings": {
+			"deprecationMessage": "Deprecated changes to this section will not be respected.",
+			"description": "Configuration for embeddings service.",
+			"examples": [
+				{
+					"accessToken": "your-access-token",
+					"dimensions": 1536,
+					"enabled": true,
+					"excludedFilePathPatterns": [
+						"*.svg",
+						"**/__mocks__/**",
+						"**/test/**"
+					],
+					"model": "text-embedding-ada-002",
+					"url": "https://api.openai.com/v1/embeddings"
+				}
+			],
+			"properties": {
+				"accessToken": {
+					"description": "The access token used to authenticate with the external embedding API service. For provider sourcegraph, this is optional.",
+					"type": "string"
+				},
+				"dimensions": {
+					"description": "The dimensionality of the embedding vectors. Required field if not using the sourcegraph provider.",
+					"minimum": 0,
+					"type": "integer"
+				},
+				"enabled": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "Toggles whether embedding service is enabled.",
+					"type": "boolean"
+				},
+				"endpoint": {
+					"description": "The endpoint under which to reach the provider. Sensible default will be used for each provider.",
+					"format": "uri",
+					"type": "string"
+				},
+				"excludeChunkOnError": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "Whether to cancel indexing a repo if embedding a single file fails. If true, the chunk that cannot generate embeddings is not indexed and the remainder of the repository proceeds with indexing.",
+					"type": "boolean"
+				},
+				"excludedFilePathPatterns": {
+					"default": [
+						".*ignore",
+						".gitattributes",
+						".mailmap",
+						"*.csv",
+						"*.svg",
+						"*.xml",
+						"__fixtures__/",
+						"node_modules/",
+						"testdata/",
+						"mocks/",
+						"vendor/"
+					],
+					"deprecationMessage": "Deprecated in favor of fileFilers.excludedFilePathPatterns",
+					"description": "A list of glob patterns that match file paths you want to exclude from embeddings. This is useful to exclude files with low information value (e.g., SVG files, test fixtures, mocks, auto-generated files, etc.).",
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"fileFilters": {
+					"description": "Filters that allow you to specify which files in a repository should get embedded.",
+					"properties": {
+						"excludedFilePathPatterns": {
+							"default": [
+								".*ignore",
+								".gitattributes",
+								".mailmap",
+								"*.csv",
+								"*.svg",
+								"*.xml",
+								"__fixtures__/",
+								"node_modules/",
+								"testdata/",
+								"mocks/",
+								"vendor/"
+							],
+							"description": "A list of glob patterns that match file paths you want to exclude from embeddings. This is useful to exclude files with low information value (e.g., SVG files, test fixtures, mocks, auto-generated files, etc.).",
+							"items": {
+								"type": "string"
+							},
+							"type": "array"
+						},
+						"includedFilePathPatterns": {
+							"description": "A list of glob patterns that match file paths you want to include in embeddings. If specified, all files not matching these include patterns are excluded.",
+							"examples": [
+								"*.go",
+								"*.ts",
+								"*.md",
+								"src/",
+								"cmd/"
+							],
+							"items": {
+								"type": "string"
+							},
+							"type": "array"
+						},
+						"maxFileSizeBytes": {
+							"default": 1000000,
+							"description": "The maximum file size (in bytes) to include in embeddings. Must be between 0 and 100000 (1 MB).",
+							"type": "integer"
+						}
+					},
+					"type": "object"
+				},
+				"incremental": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "Whether to generate embeddings incrementally. If true, only files that have changed since the last run will be processed.",
+					"type": "boolean"
+				},
+				"maxEmbeddingsPerRepo": {
+					"description": "The maximum number of embeddings to generate per repo",
+					"minimum": 0,
+					"type": "integer"
+				},
+				"minimumInterval": {
+					"default": "24h",
+					"description": "The time to wait between runs. Valid time units are \"s\", \"m\", \"h\". Example values: \"30s\", \"5m\", \"1h\".",
+					"type": "string"
+				},
+				"model": {
+					"description": "The model used for embedding. A default model will be used for each provider, if not set.",
+					"type": "string"
+				},
+				"perCommunityUserEmbeddingsMonthlyLimit": {
+					"default": 0,
+					"description": "If \u003e 0, limits the number of tokens allowed to be embedded by a Community user in a month. This is for Self-serve Cody and applies to Dotcom only.",
+					"type": "integer"
+				},
+				"perProUserEmbeddingsMonthlyLimit": {
+					"default": 0,
+					"description": "If \u003e 0, limits the number of tokens allowed to be embedded by a Pro user in a month. This is for Self-serve Cody and applies to Dotcom only.",
+					"type": "integer"
+				},
+				"policyRepositoryMatchLimit": {
+					"!go": {
+						"pointer": true
+					},
+					"default": "5000",
+					"description": "The maximum number of repositories that can be matched by a global embeddings policy",
+					"type": "integer"
+				},
+				"provider": {
+					"description": "The provider to use for generating embeddings. Defaults to sourcegraph.",
+					"enum": [
+						"openai",
+						"azure-openai",
+						"sourcegraph"
+					],
+					"type": "string"
+				},
+				"url": {
+					"description": "The url to the external embedding API service. Deprecated, use endpoint instead.",
+					"format": "uri",
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"encryption.keys": {
+			"description": "Configuration for encryption keys used to encrypt data at rest in the database.",
+			"examples": [
+				{
+					"externalServiceKey": {
+						"filePath": "/path/to/external_service.key",
+						"type": "mounted"
+					}
+				},
+				{
+					"userExternalAccountKey": {
+						"keyname": "projects/my-project/locations/global/keyRings/my-keyring/cryptoKeys/my-key",
+						"type": "cloudkms"
+					}
+				}
+			],
+			"properties": {
+				"batchChangesCredentialKey": {
+					"$ref": "#/definitions/EncryptionKey"
+				},
+				"cacheSize": {
+					"default": 2048,
+					"description": "number of values to keep in LRU cache",
+					"type": "integer"
+				},
+				"enableCache": {
+					"default": false,
+					"description": "enable LRU cache for decryption APIs",
+					"type": "boolean"
+				},
+				"executorSecretKey": {
+					"$ref": "#/definitions/EncryptionKey"
+				},
+				"externalServiceKey": {
+					"$ref": "#/definitions/EncryptionKey"
+				},
+				"gitHubAppKey": {
+					"$ref": "#/definitions/EncryptionKey"
+				},
+				"outboundWebhookKey": {
+					"$ref": "#/definitions/EncryptionKey"
+				},
+				"userExternalAccountKey": {
+					"$ref": "#/definitions/EncryptionKey"
+				},
+				"webhookKey": {
+					"$ref": "#/definitions/EncryptionKey"
+				},
+				"webhookLogKey": {
+					"$ref": "#/definitions/EncryptionKey"
+				}
+			},
+			"type": "object"
+		},
+		"entitlements.completionCredits": {
+			"description": "Configure completion credits entitlement enablement",
+			"properties": {
+				"mode": {
+					"default": "disabled",
+					"description": "Configure completions credits consumption tracking and enforcement mode",
+					"enum": [
+						"disabled",
+						"track",
+						"trackStrict",
+						"enforce"
+					],
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"executors.accessToken": {
+			"description": "The shared secret between Sourcegraph and executors. The value must contain at least 20 characters.",
+			"examples": [
+				"my-super-secret-access-token"
+			],
+			"pattern": "^(.{20,}|REDACTED)$",
+			"type": "string"
+		},
+		"executors.batcheshelperImage": {
+			"default": "sourcegraph/batcheshelper",
+			"description": "The image to use for batch changes in executors when using native execution. Use this value to pull from a custom image registry.",
+			"type": "string"
+		},
+		"executors.batcheshelperImageTag": {
+			"description": "The tag to use for the batcheshelper image in executors when using native execution. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.",
+			"examples": [
+				"4.1.0"
+			],
+			"type": "string"
+		},
+		"executors.frontendURL": {
+			"description": "The URL where Sourcegraph executors can reach the Sourcegraph instance. If not set, defaults to externalURL. URLs with a path (other than `/`) are not allowed. For Docker executors, the special hostname `host.docker.internal` can be used to refer to the Docker container's host.",
+			"examples": [
+				"https://sourcegraph.example.com"
+			],
+			"type": "string"
+		},
+		"executors.lsifGoImage": {
+			"description": "The tag to use for the lsif-go image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.",
+			"examples": [
+				"sourcegraph/lsif-go"
+			],
+			"type": "string"
+		},
+		"executors.multiqueue": {
+			"description": "The configuration for multiqueue executors.",
+			"properties": {
+				"dequeueCacheConfig": {
+					"description": "The configuration for the dequeue cache of multiqueue executors. Each queue defines a limit of dequeues in the expiration window as well as a weight, indicating how frequently a queue is picked at random. For example, a weight of 4 for batches and 1 for codeintel means out of 5 dequeues, statistically batches will be picked 4 times and codeintel 1 time (unless one of those queues is at its limit).",
+					"properties": {
+						"batches": {
+							"description": "The configuration for the batches queue.",
+							"properties": {
+								"limit": {
+									"default": 50,
+									"description": "The maximum number of dequeues allowed within the expiration window.",
+									"type": "integer"
+								},
+								"weight": {
+									"default": 4,
+									"description": "The relative weight of this queue. Higher weights mean a higher chance of being picked at random.",
+									"type": "integer"
+								}
+							},
+							"required": [
+								"limit",
+								"weight"
+							],
+							"type": "object"
+						},
+						"codeintel": {
+							"description": "The configuration for the codeintel queue.",
+							"properties": {
+								"limit": {
+									"default": 250,
+									"description": "The maximum number of dequeues allowed within the expiration window.",
+									"type": "integer"
+								},
+								"weight": {
+									"default": 1,
+									"description": "The relative weight of this queue. Higher weights mean a higher chance of being picked at random.",
+									"type": "integer"
+								}
+							},
+							"required": [
+								"limit",
+								"weight"
+							],
+							"type": "object"
+						}
+					},
+					"type": "object"
+				}
+			},
+			"type": "object"
+		},
+		"executors.srcCLIImage": {
+			"default": "sourcegraph/src-cli",
+			"description": "The image to use for src-cli in executors. Use this value to pull from a custom image registry.",
+			"type": "string"
+		},
+		"executors.srcCLIImageTag": {
+			"description": "The tag to use for the src-cli image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.",
+			"examples": [
+				"4.1.0"
+			],
+			"type": "string"
+		},
+		"experimentalFeatures": {
+			"additionalProperties": true,
+			"description": "Experimental features and settings.",
+			"examples": [
+				{
+					"customGitFetch": [
+						{
+							"domainPath": "somecodehost.com/path/to/repo",
+							"fetch": "customgitbinary someflag"
+						},
+						{
+							"domainPath": "somecodehost.com/path/to/anotherrepo",
+							"fetch": "customgitbinary someflag anotherflag"
+						}
+					]
+				},
+				{
+					"tls.external": {
+						"certificates": [
+							"-----BEGIN CERTIFICATE-----\n..."
+						],
+						"insecureSkipVerify": true
+					}
+				}
+			],
+			"group": "Experimental",
+			"properties": {
+				"batchChanges.enableForkNameSuffix": {
+					"default": false,
+					"description": "When enabled, batch changes will append a sequence of characters to new fork names to avoid name collisions. The sequence is unique per batch change. This does not apply to existing batch changes.",
+					"group": "BatchChanges",
+					"type": "boolean"
+				},
+				"batchChanges.enablePerforce": {
+					"default": false,
+					"description": "When enabled, batch changes will be executable on Perforce depots.",
+					"group": "BatchChanges",
+					"type": "boolean"
+				},
+				"codeintelSyntacticIndexing.enabled": {
+					"default": false,
+					"description": "When enabled, syntactic indexing jobs will be scheduled for all enabled repos",
+					"type": "boolean"
+				},
+				"cody.auditLog": {
+					"description": "Configuration for the Cody Audit Log",
+					"properties": {
+						"enabled": {
+							"default": false,
+							"description": "Whether to enable the Cody Audit Log",
+							"type": "boolean"
+						}
+					},
+					"type": "object"
+				},
+				"codyContextIgnore": {
+					"!go": {
+						"pointer": true
+					},
+					"default": false,
+					"description": "Enabled filtering of remote Cody context based on repositories ./cody/ignore file",
+					"type": "boolean"
+				},
+				"commitGraphUpdates": {
+					"additionalProperties": false,
+					"description": "Customize strategy used for commit graph updates",
+					"properties": {
+						"defaultBranchOnly": {
+							"description": "Disables precise code nav on non-default branches. Specify repo names using regex syntax.",
+							"items": {
+								"examples": [
+									"github.com/myorg/huge-monorepo",
+									"github.com/other-org/.*"
+								],
+								"type": "string"
+							},
+							"type": "array"
+						}
+					},
+					"type": "object"
+				},
+				"customGitFetch": {
+					"description": "JSON array of configuration that maps from Git clone URL domain/path to custom git fetch command. To enable this feature set environment variable `ENABLE_CUSTOM_GIT_FETCH` as `true` on gitserver.",
+					"examples": [
+						[
+							{
+								"domainPath": "somecodehost.com/path/to/repo",
+								"fetch": "customgitbinary someflag"
+							},
+							{
+								"domainPath": "somecodehost.com/path/to/anotherrepo",
+								"fetch": "customgitbinary someflag anotherflag"
+							}
+						]
+					],
+					"items": {
+						"additionalProperties": false,
+						"description": "Mapping from Git clone URl domain/path to git fetch command. The `domainPath` field contains the Git clone URL domain/path part. The `fetch` field contains the custom git fetch command.",
+						"properties": {
+							"domainPath": {
+								"description": "Git clone URL domain/path",
+								"type": "string"
+							},
+							"fetch": {
+								"description": "Git fetch command",
+								"minLength": 1,
+								"type": "string"
+							}
+						},
+						"required": [
+							"domainPath",
+							"fetch"
+						],
+						"title": "CustomGitFetchMapping",
+						"type": "object"
+					},
+					"type": "array"
+				},
+				"debug.log": {
+					"additionalProperties": false,
+					"deprecationMessage": "Deprecated in favor of internal debug logging.",
+					"description": "Turns on debug logging for specific debugging scenarios.",
+					"properties": {
+						"extsvc.gitlab": {
+							"default": false,
+							"description": "Log GitLab API requests.",
+							"type": "boolean"
+						}
+					},
+					"type": "object"
+				},
+				"deepSearch.enabled": {
+					"!go": {
+						"pointer": true
+					},
+					"default": false,
+					"description": "Enable/disable the Deep Search feature",
+					"type": "boolean"
+				},
+				"deepSearch.model": {
+					"default": "anthropic::2024-10-22::claude-sonnet-4-latest",
+					"description": "The model reference to use for Deep Search.",
+					"type": "string"
+				},
+				"deepSearch.sharing.enabled": {
+					"!go": {
+						"pointer": true
+					},
+					"default": false,
+					"description": "Enable/disable sharing of Deep Search conversations via read tokens",
+					"type": "boolean"
+				},
+				"enableGithubInternalRepoVisibility": {
+					"default": false,
+					"description": "Enable support for visibility of internal Github repositories",
+					"type": "boolean"
+				},
+				"enablePermissionsWebhooks": {
+					"!go": {
+						"pointer": false
+					},
+					"default": false,
+					"description": "DEPRECATED: No longer has any effect.",
+					"type": "boolean"
+				},
+				"enableStorm": {
+					"!go": {
+						"pointer": false
+					},
+					"default": false,
+					"description": "Enables the Storm frontend architecture changes.",
+					"type": "boolean"
+				},
+				"eventLogging": {
+					"default": "enabled",
+					"description": "Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.",
+					"enum": [
+						"enabled",
+						"disabled"
+					],
+					"type": "string"
+				},
+				"gitServerPinnedRepos": {
+					"additionalProperties": {
+						"type": "string"
+					},
+					"description": "List of repositories pinned to specific gitserver instances. The specified repositories will remain at their pinned servers on scaling the cluster. If the specified pinned server differs from the current server that stores the repository, then it must be re-cloned to the specified server.",
+					"examples": [
+						{
+							"github.com/foo/bar": "gitserverHostname",
+							"github.com/foo/bar2": "gitserverHostname2"
+						}
+					],
+					"type": "object"
+				},
+				"goPackages": {
+					"default": "disabled",
+					"description": "Allow adding Go package host connections",
+					"enum": [
+						"enabled",
+						"disabled"
+					],
+					"type": "string"
+				},
+				"insightsAlternateLoadingStrategy": {
+					"default": false,
+					"description": "Use an in-memory strategy of loading Code Insights. Should only be used for benchmarking on large instances, not for customer use currently.",
+					"type": "boolean"
+				},
+				"insightsBackfillerV2": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "DEPRECATED: Setting any value to this flag has no effect.",
+					"type": "boolean"
+				},
+				"insightsDataRetention": {
+					"!go": {
+						"pointer": true
+					},
+					"default": true,
+					"description": "Code insights data points beyond the sample size defined in the site configuration will be periodically archived",
+					"type": "boolean"
+				},
+				"jvmPackages": {
+					"default": "disabled",
+					"description": "Allow adding JVM package host connections",
+					"enum": [
+						"enabled",
+						"disabled"
+					],
+					"type": "string"
+				},
+				"languageDetection": {
+					"additionalProperties": false,
+					"description": "Setting for customizing language detection behavior",
+					"properties": {
+						"graphQL": {
+							"default": "useFileContents",
+							"description": "What to take into account for computing 'languages' for the GraphQL API. This setting indirectly affects client-side code attempting to determine languages, such as search-based code navigation and the files sidebar.",
+							"enum": [
+								"useFileContents",
+								"useFileNamesOnly"
+							],
+							"type": "string"
+						}
+					},
+					"required": [
+						"graphQL"
+					],
+					"type": "object"
+				},
+				"npmPackages": {
+					"default": "disabled",
+					"description": "Allow adding npm package code host connections",
+					"enum": [
+						"enabled",
+						"disabled"
+					],
+					"type": "string"
+				},
+				"pagure": {
+					"default": "disabled",
+					"description": "Allow adding Pagure code host connections",
+					"enum": [
+						"enabled",
+						"disabled"
+					],
+					"type": "string"
+				},
+				"passwordPolicy": {
+					"additionalProperties": false,
+					"description": "DEPRECATED: this is now a standard feature see: auth.passwordPolicy",
+					"properties": {
+						"enabled": {
+							"default": true,
+							"description": "Enables password policy",
+							"type": "boolean"
+						},
+						"minimumLength": {
+							"default": 12,
+							"description": "DEPRECATED: replaced by auth.minPasswordLength",
+							"type": "integer"
+						},
+						"numberOfSpecialCharacters": {
+							"default": 2,
+							"description": "The required number of special characters",
+							"type": "integer"
+						},
+						"requireAtLeastOneNumber": {
+							"default": true,
+							"description": "Does the password require a number",
+							"type": "boolean"
+						},
+						"requireUpperandLowerCase": {
+							"default": true,
+							"description": "Require Mixed characters",
+							"type": "boolean"
+						}
+					},
+					"type": "object"
+				},
+				"perforceChangelistMapping": {
+					"default": "enabled",
+					"description": "Allow mapping of Perforce changelists to their commit SHAs in the DB",
+					"enum": [
+						"enabled",
+						"disabled"
+					],
+					"type": "string"
+				},
+				"pythonPackages": {
+					"default": "disabled",
+					"description": "Allow adding Python package code host connections",
+					"enum": [
+						"enabled",
+						"disabled"
+					],
+					"type": "string"
+				},
+				"ranking": {
+					"description": "Experimental search result ranking options.",
+					"properties": {
+						"flushWallTimeMS": {
+							"default": 500,
+							"description": "Controls the amount of time that Zoekt shards collect and rank results. Larger values give a more stable ranking, but searches can take longer to return an initial result.",
+							"group": "Search",
+							"type": "integer"
+						},
+						"maxQueueMatchCount": {
+							"!go": {
+								"pointer": true
+							},
+							"default": -1,
+							"description": "DEPRECATED: This setting has no effect.",
+							"group": "Search",
+							"type": "integer"
+						},
+						"maxQueueSizeBytes": {
+							"!go": {
+								"pointer": true
+							},
+							"default": -1,
+							"description": "The maximum number of bytes that can be buffered to sort results. The default is -1 (unbounded). Setting this to a positive integer protects frontend against OOMs.",
+							"group": "Search",
+							"type": "integer"
+						},
+						"maxReorderDurationMS": {
+							"default": 0,
+							"description": "DEPRECATED: This setting has no effect.",
+							"group": "Search",
+							"type": "integer"
+						},
+						"maxReorderQueueSize": {
+							"!go": {
+								"pointer": true
+							},
+							"default": 24,
+							"description": "DEPRECATED: This setting has no effect.",
+							"group": "Search",
+							"type": "integer"
+						},
+						"repoScores": {
+							"additionalProperties": {
+								"type": "number"
+							},
+							"default": {},
+							"description": "a map of URI directories to numeric scores for specifying search result importance, like {\"github.com\": 500, \"github.com/sourcegraph\": 300, \"github.com/sourcegraph/sourcegraph\": 100}. Would rank \"github.com/sourcegraph/sourcegraph\" as 500+300+100=900, and \"github.com/other/foo\" as 500.",
+							"group": "Search",
+							"type": "object"
+						}
+					},
+					"type": "object"
+				},
+				"rateLimitAnonymous": {
+					"default": 500,
+					"description": "DEPRECATED: this setting was targeted at a specific incident is no longer read.",
+					"type": "integer"
+				},
+				"rubyPackages": {
+					"default": "disabled",
+					"description": "Allow adding Ruby package host connections",
+					"enum": [
+						"enabled",
+						"disabled"
+					],
+					"type": "string"
+				},
+				"rustPackages": {
+					"default": "disabled",
+					"description": "Allow adding Rust package code host connections",
+					"enum": [
+						"enabled",
+						"disabled"
+					],
+					"type": "string"
+				},
+				"scipBasedAPIs": {
+					"!go": {
+						"pointer": true
+					},
+					"_comment": "Keep default above in sync with NOTE(id: scip-based-apis-feature-flag)",
+					"default": true,
+					"description": "Enable usage of new CodeGraph and usagesForSymbol APIs",
+					"type": "boolean"
+				},
+				"search.index.branches": {
+					"additionalProperties": {
+						"items": {
+							"type": "string"
+						},
+						"maxItems": 64,
+						"type": "array"
+					},
+					"description": "A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index the default branch (\"HEAD\") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.",
+					"examples": [
+						{
+							"github.com/sourcegraph/sourcegraph": [
+								"3.17",
+								"f6ca985c27486c2df5231ea3526caa4a4108ffb6",
+								"v3.17.1"
+							],
+							"name/of/repo": [
+								"develop"
+							]
+						}
+					],
+					"type": "object"
+				},
+				"search.index.query.contexts": {
+					"default": false,
+					"description": "Enables indexing of revisions of repos matching any query defined in search contexts.",
+					"type": "boolean"
+				},
+				"search.index.revisions": {
+					"description": "An array of objects describing rules for extra revisions (branch, ref, tag, commit sha, etc) to be indexed for all repositories that match them. We always index the default branch (\"HEAD\") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.",
+					"examples": [
+						[
+							{
+								"name": "^github.com/org/.*",
+								"revisions": [
+									"3.17",
+									"f6ca985c27486c2df5231ea3526caa4a4108ffb6",
+									"v3.17.1"
+								]
+							}
+						]
+					],
+					"items": {
+						"additionalProperties": false,
+						"anyOf": [
+							{
+								"required": [
+									"name"
+								]
+							}
+						],
+						"properties": {
+							"name": {
+								"description": "Regular expression which matches against the name of a repository (e.g. \"^github\\.com/owner/name$\").",
+								"format": "regex",
+								"type": "string"
+							},
+							"revisions": {
+								"description": "Revisions to index",
+								"items": {
+									"minLength": 1,
+									"type": "string"
+								},
+								"type": "array"
+							}
+						},
+						"required": [
+							"revisions"
+						],
+						"title": "SearchIndexRevisionsRule",
+						"type": "object"
+					},
+					"type": "array"
+				},
+				"search.sanitization": {
+					"description": "Allows site admins to specify a list of regular expressions representing matched content that should be omitted from search results. Also allows admins to specify the name of an organization within their Sourcegraph instance whose members are trusted and will not have their search results sanitized. Enable this feature by adding at least one valid regular expression to the value of the `sanitizePatterns` field on this object. Site admins will not have their searches sanitized.",
+					"properties": {
+						"orgName": {
+							"description": "Optionally specify the name of an organization within this Sourcegraph instance containing users whose searches should not be sanitized. Admins: ensure that ALL members of this org are trusted users. If no org exists with the given name then there will be no effect. If no org name is specified then all non-admin users will have their searches sanitized if this feature is enabled.",
+							"type": "string"
+						},
+						"sanitizePatterns": {
+							"description": "An array of regular expressions representing matched content that should be omitted from search result events. This does not prevent users from accessing file contents through other means if they have read access. Values added to this array must be valid Go regular expressions. Site admins will not have their search results sanitized.",
+							"items": {
+								"format": "regex",
+								"type": "string"
+							},
+							"type": "array"
+						}
+					},
+					"type": "object"
+				},
+				"searchJobs": {
+					"!go": {
+						"pointer": true
+					},
+					"default": false,
+					"description": "DEPRECATED. This setting is no longer read. To disable search jobs, set DISABLE_SEARCH_JOBS=true for the \"frontend\" and \"worker\" services",
+					"type": "boolean"
+				},
+				"structuralSearch": {
+					"default": "disabled",
+					"description": "Enables structural search.",
+					"enum": [
+						"enabled",
+						"disabled"
+					],
+					"type": "string"
+				},
+				"subRepoPermissions": {
+					"additionalProperties": false,
+					"if": {
+						"properties": {
+							"enforceIPRestrictions": {
+								"const": true
+							}
+						},
+						"required": [
+							"enforceIPRestrictions"
+						]
+					},
+					"properties": {
+						"allowCodeInsights": {
+							"default": false,
+							"description": "Allow Code Insights to run on repositories that use sub-repo permissions",
+							"type": "boolean"
+						},
+						"enabled": {
+							"default": false,
+							"description": "Enables sub-repo permission checking",
+							"type": "boolean"
+						},
+						"enforceIPRestrictions": {
+							"default": false,
+							"description": "Enforces IP restrictions on sub-repo permissions. If true, relies on rightmost value X-FORWARDED-FOR header to determine the client IP address. You must configure your reverse proxy to set this header securely. Also incompoitable with the perforce ignoreRulesWithHost option.",
+							"type": "boolean"
+						},
+						"ipParseCacheSize": {
+							"default": 1000,
+							"description": "The number of Perforce \"Host\" to IP addresses translations to cache",
+							"minimum": 1,
+							"type": "integer"
+						},
+						"redactInaccessibleCommits": {
+							"default": false,
+							"description": "Redacts commits in the history that the user does not have access to instead of removing them from history. DO NOT USE THIS UNLESS EXPLICITLY ASKED FOR BY THE SOURCEGRAPH TEAM.",
+							"type": "boolean"
+						},
+						"rulesInterpretationMode": {
+							"default": "unified",
+							"description": "Controls how Perforce IP-based protection rules are interpreted. 'unified' (default) applies all rules regardless of proxy-prefix. 'directOnly' only applies rules without proxy- prefix. 'proxyOnly' only applies rules with proxy- prefix. Use this to align with your Perforce deployment model.",
+							"enum": [
+								"unified",
+								"directOnly",
+								"proxyOnly"
+							],
+							"type": "string"
+						},
+						"userCacheSize": {
+							"default": 1000,
+							"description": "The number of user permissions to cache",
+							"minimum": 1,
+							"type": "integer"
+						},
+						"userCacheTTLSeconds": {
+							"default": 10,
+							"description": "The TTL in seconds for cached user permissions",
+							"minimum": 1,
+							"type": "integer"
+						}
+					},
+					"then": {
+						"properties": {
+							"enabled": {
+								"const": true
+							}
+						},
+						"required": [
+							"enabled"
+						]
+					},
+					"type": "object"
+				},
+				"tls.external": {
+					"additionalProperties": false,
+					"description": "Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.",
+					"properties": {
+						"certificates": {
+							"description": "TLS certificates to accept. This is only necessary if you are using self-signed certificates or an internal CA. Can be an internal CA certificate or a self-signed certificate. To get the certificate of a webserver run `openssl s_client -connect HOST:443 -showcerts \u003c /dev/null 2\u003e /dev/null | openssl x509 -outform PEM`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh. NOTE: System Certificate Authorities are automatically included.",
+							"items": {
+								"examples": [
+									"-----BEGIN CERTIFICATE-----\n..."
+								],
+								"pattern": "^-----BEGIN CERTIFICATE-----\n",
+								"type": "string"
+							},
+							"type": "array"
+						},
+						"insecureSkipVerify": {
+							"default": false,
+							"description": "insecureSkipVerify controls whether a client verifies the server's certificate chain and host name.\nIf InsecureSkipVerify is true, TLS accepts any certificate presented by the server and any host name in that certificate. In this mode, TLS is susceptible to man-in-the-middle attacks.",
+							"type": "boolean"
+						}
+					},
+					"type": "object"
+				}
+			},
+			"type": "object"
+		},
+		"externalURL": {
+			"description": "The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`. Only root URLs are allowed.",
+			"examples": [
+				"https://sourcegraph.example.com"
+			],
+			"type": "string"
+		},
+		"git.cloneURLToRepositoryName": {
+			"description": "JSON array of configuration that maps from Git clone URL to repository name. Sourcegraph automatically resolves remote clone URLs to their proper code host. However, there may be non-remote clone URLs (e.g., in submodule declarations) that Sourcegraph cannot automatically map to a code host. In this case, use this field to specify the mapping. The mappings are tried in the order they are specified and take precedence over automatic mappings.",
+			"examples": [
+				[
+					{
+						"from": "^../(?P\u003cname\u003e\\w+)$",
+						"to": "github.com/user/{name}"
+					}
+				]
+			],
+			"group": "External services",
+			"items": {
+				"additionalProperties": false,
+				"description": "Describes a mapping from clone URL to repository name. The `from` field contains a regular expression with named capturing groups. The `to` field contains a template string that references capturing group names. For instance, if `from` is \"^../(?P\u003cname\u003e\\w+)$\" and `to` is \"github.com/user/{name}\", the clone URL \"../myRepository\" would be mapped to the repository name \"github.com/user/myRepository\".",
+				"properties": {
+					"from": {
+						"description": "A regular expression that matches a set of clone URLs. The regular expression should use the Go regular expression syntax (https://golang.org/pkg/regexp/) and contain at least one named capturing group. The regular expression matches partially by default, so use \"^...$\" if whole-string matching is desired.",
+						"type": "string"
+					},
+					"to": {
+						"description": "The repository name output pattern. This should use `{matchGroup}` syntax to reference the capturing groups from the `from` field.",
+						"type": "string"
+					}
+				},
+				"required": [
+					"from",
+					"to"
+				],
+				"title": "CloneURLToRepositoryName",
+				"type": "object"
+			},
+			"type": "array"
+		},
+		"gitHubApp": {
+			"description": "DEPRECATED: The config options for Sourcegraph GitHub App.",
+			"examples": [
+				{
+					"appID": "1234",
+					"clientID": "client-id",
+					"clientSecret": "client-secret",
+					"privateKey": "base64-encoded-private-key",
+					"slug": "sourcegraph"
+				}
+			],
+			"properties": {
+				"appID": {
+					"description": "The app ID of the GitHub App for Sourcegraph.",
+					"type": "string"
+				},
+				"clientID": {
+					"description": "The Client ID of the GitHub App for Sourcegraph, accessible from https://github.com/settings/apps .",
+					"type": "string"
+				},
+				"clientSecret": {
+					"description": "The Client Secret of the GitHub App for Sourcegraph, accessible from https://github.com/settings/apps .",
+					"type": "string"
+				},
+				"privateKey": {
+					"description": "The base64-encoded private key of the GitHub App for Sourcegraph.",
+					"type": "string"
+				},
+				"slug": {
+					"description": "The slug of the GitHub App for Sourcegraph.",
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"gitLongCommandTimeout": {
+			"default": 7200,
+			"description": "Maximum number of seconds that a long Git command (e.g. clone or remote update) is allowed to execute. The default is 7200 seconds, or 2 hours.",
+			"group": "External services",
+			"type": "integer"
+		},
+		"gitMaxCodehostRequestsPerSecond": {
+			"!go": {
+				"pointer": true
+			},
+			"default": -1,
+			"description": "Maximum number of remote code host git operations (e.g. clone or ls-remote) to be run per second per gitserver. Default is -1, which is unlimited.",
+			"group": "External services",
+			"type": "integer"
+		},
+		"gitMaxConcurrentCleanups": {
+			"!go": {
+				"pointer": true
+			},
+			"default": 5,
+			"description": "Maximum number of git clone processes that will be run concurrently per gitserver to update repositories. \u003c= 0 means disabled.",
+			"group": "External services",
+			"type": "integer"
+		},
+		"gitMaxConcurrentClones": {
+			"default": 5,
+			"description": "Maximum number of git clone processes that will be run concurrently per gitserver to update repositories. Note: the global git update scheduler respects gitMaxConcurrentClones. However, we allow each gitserver to run upto gitMaxConcurrentClones to allow for urgent fetches. Urgent fetches are used when a user is browsing a PR and we do not have the commit yet.",
+			"group": "External services",
+			"type": "integer"
+		},
+		"gitRecorder": {
+			"description": "Record git operations that are executed on configured repositories.",
+			"examples": [
+				{
+					"ignoredGitCommands": [
+						"show",
+						"rev-parse",
+						"log",
+						"diff",
+						"ls-tree"
+					],
+					"repos": [
+						"github.com/sourcegraph/sourcegraph",
+						"github.com/gorilla/mux"
+					],
+					"size": 1000
+				}
+			],
+			"properties": {
+				"ignoredGitCommands": {
+					"default": [
+						"show",
+						"rev-parse",
+						"log",
+						"diff",
+						"ls-tree"
+					],
+					"description": "List of git commands that should be ignored and not recorded.",
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"repos": {
+					"description": "List of repositories whose git operations should be recorded. To record commands on all repositories, simply pass in an asterisk as the only item in the array.",
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"size": {
+					"default": 10000,
+					"description": "Defines how many recordings to keep. Once this size is reached, the oldest entry will be removed.",
+					"maximum": 10000,
+					"minimum": 1,
+					"type": "integer"
+				}
+			},
+			"type": "object"
+		},
+		"gitUpdateInterval": {
+			"deprecated": true,
+			"deprecationMessage": "Deprecated because it's no longer supported. Sourcegraph relies on user traffic, webhooks, and heuristics now.",
+			"description": "DEPRECATED: As of Sourcegraph 5.10, this option is no longer in use. Remove this block.",
+			"examples": [
+				[
+					{
+						"interval": 5,
+						"pattern": "^github.com/sourcegraph/.*"
+					},
+					{
+						"interval": 10,
+						"pattern": "^bitbucket.org/.*"
+					}
+				]
+			],
+			"group": "External services",
+			"items": {
+				"additionalProperties": false,
+				"properties": {
+					"interval": {
+						"description": "An integer representing the number of minutes to wait until the next update",
+						"minimum": 1,
+						"type": "integer"
+					},
+					"pattern": {
+						"description": "A regular expression matching a repo name",
+						"minLength": 1,
+						"type": "string"
+					}
+				},
+				"required": [
+					"pattern",
+					"interval"
+				],
+				"title": "UpdateIntervalRule",
+				"type": "object"
+			},
+			"type": "array"
+		},
+		"gitserver.diskUsageWarningThreshold": {
+			"!go": {
+				"pointer": true
+			},
+			"default": 90,
+			"description": "Disk usage threshold at which to display warning notification. Value is a percentage.",
+			"type": "integer"
+		},
+		"htmlBodyBottom": {
+			"description": "HTML to inject at the bottom of the `\u003cbody\u003e` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.",
+			"group": "Misc.",
+			"type": "string"
+		},
+		"htmlBodyTop": {
+			"description": "HTML to inject at the top of the `\u003cbody\u003e` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.",
+			"group": "Misc.",
+			"type": "string"
+		},
+		"htmlHeadBottom": {
+			"description": "HTML to inject at the bottom of the `\u003chead\u003e` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.",
+			"group": "Misc.",
+			"type": "string"
+		},
+		"htmlHeadTop": {
+			"description": "HTML to inject at the top of the `\u003chead\u003e` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.",
+			"group": "Misc.",
+			"type": "string"
+		},
+		"insights.aggregations.bufferSize": {
+			"default": 500,
+			"description": "The size of the buffer for aggregations ran in-memory. A higher limit might strain memory for the frontend",
+			"group": "CodeInsights",
+			"type": "integer"
+		},
+		"insights.aggregations.proactiveResultLimit": {
+			"default": 50000,
+			"description": "The maximum number of results a proactive search aggregation can accept before stopping",
+			"group": "CodeInsights",
+			"type": "integer"
+		},
+		"insights.backfill.interruptAfter": {
+			"default": 60,
+			"description": "Set the number of seconds an insight series will spend backfilling before being interrupted. Series are interrupted to prevent long running insights from exhausting all of the available workers. Interrupted series will be placed back in the queue and retried based on their priority.",
+			"group": "CodeInsights",
+			"type": "integer"
+		},
+		"insights.backfill.repositoryConcurrency": {
+			"default": 3,
+			"description": "Number of repositories within the batch to backfill concurrently.",
+			"group": "CodeInsights",
+			"maximum": 10,
+			"minimum": 1,
+			"type": "integer"
+		},
+		"insights.backfill.repositoryGroupSize": {
+			"default": 10,
+			"description": "Set the number of repositories to batch in a group during backfilling.",
+			"group": "CodeInsights",
+			"type": "integer"
+		},
+		"insights.historical.worker.rateLimit": {
+			"!go": {
+				"pointer": true
+			},
+			"default": 20,
+			"description": "Maximum number of historical Code Insights data frames that may be analyzed per second.",
+			"examples": [
+				50,
+				0.5
+			],
+			"group": "CodeInsights",
+			"type": "number"
+		},
+		"insights.historical.worker.rateLimitBurst": {
+			"default": 20,
+			"description": "The allowed burst rate for the Code Insights historical worker rate limiter.",
+			"examples": [
+				10,
+				20
+			],
+			"group": "CodeInsights",
+			"type": "integer"
+		},
+		"insights.maximumSampleSize": {
+			"default": 30,
+			"description": "The maximum number of data points that will be available to view for a series on a code insight. Points beyond that will be stored in a separate table and available for data export.",
+			"examples": [
+				12,
+				24,
+				50
+			],
+			"group": "CodeInsights",
+			"maximum": 90,
+			"type": "integer"
+		},
+		"insights.query.worker.concurrency": {
+			"default": 1,
+			"description": "Number of concurrent executions of a code insight query on a worker node",
+			"examples": [
+				10
+			],
+			"group": "CodeInsights",
+			"type": "integer"
+		},
+		"insights.query.worker.rateLimit": {
+			"!go": {
+				"pointer": true
+			},
+			"default": 20,
+			"description": "Maximum number of Code Insights queries initiated per second on a worker node.",
+			"examples": [
+				10,
+				0.5
+			],
+			"group": "CodeInsights",
+			"type": "number"
+		},
+		"insights.query.worker.rateLimitBurst": {
+			"default": 20,
+			"description": "The allowed burst rate for the Code Insights queries per second rate limiter.",
+			"examples": [
+				10,
+				20
+			],
+			"group": "CodeInsights",
+			"type": "integer"
+		},
+		"inventory": {
+			"additionalProperties": false,
+			"description": "Settings for repository language stats inventory",
+			"examples": [
+				{
+					"disableEnhancedLanguageDetection": false,
+					"gitServerConcurrency": 4,
+					"maxInventoryInMemory": 1000,
+					"redisConcurrency": 20,
+					"timeoutInMinutes": 5
+				}
+			],
+			"properties": {
+				"disableEnhancedLanguageDetection": {
+					"default": false,
+					"description": "Disable more accurate but slower language detection that uses file contents.",
+					"type": "boolean"
+				},
+				"gitServerConcurrency": {
+					"default": 4,
+					"description": "Number of concurrent requests against the gitserver for getInventory requests. Higher concurrency means faster inventory, but more strain on gitserver.",
+					"maximum": 1000,
+					"minimum": 1,
+					"type": "integer"
+				},
+				"maxInventoryInMemory": {
+					"default": 1000,
+					"description": "When computing the language stats, every nth iteration all loaded files are aggregated into the inventory to reduce the memory footprint. Increasing this value may make the computation run faster, but will require more memory.",
+					"maximum": 1000000,
+					"minimum": 100,
+					"type": "integer"
+				},
+				"redisConcurrency": {
+					"default": 20,
+					"description": "Number of concurrent requests against the redis cache for getInventory requests. Higher concurrency means faster inventory, but more strain on redis cache.",
+					"maximum": 1000,
+					"minimum": 1,
+					"type": "integer"
+				},
+				"timeoutInMinutes": {
+					"default": 5,
+					"description": "Time in minutes before cancelling getInventory requests. Raise this if your repositories are large and need a long time to process.",
+					"maximum": 1440,
+					"minimum": 1,
+					"type": "integer"
+				}
+			},
+			"type": "object"
+		},
+		"licenseKey": {
+			"description": "The license key associated with a Sourcegraph product subscription, which is necessary to activate Sourcegraph Enterprise functionality. To obtain this value, contact Sourcegraph to purchase a subscription. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.",
+			"group": "Sourcegraph Enterprise license",
+			"type": "string"
+		},
+		"log": {
+			"additionalProperties": false,
+			"description": "Configuration for logging and alerting, including to external services.",
+			"properties": {
+				"auditLog": {
+					"additionalProperties": false,
+					"description": "EXPERIMENTAL: Configuration for audit logging (specially formatted log entries for tracking sensitive events)",
+					"examples": [
+						{
+							"gitserverAccess": false,
+							"graphQL": false,
+							"internalTraffic": false
+						}
+					],
+					"properties": {
+						"gitserverAccess": {
+							"default": false,
+							"description": "Capture gitserver access logs as part of the audit log.",
+							"type": "boolean"
+						},
+						"graphQL": {
+							"default": false,
+							"description": "Capture GraphQL requests and responses as part of the audit log.",
+							"type": "boolean"
+						},
+						"internalTraffic": {
+							"default": false,
+							"description": "Capture security events performed by the internal traffic (adds significant noise).",
+							"type": "boolean"
+						},
+						"severityLevel": {
+							"deprecationMessage": "No effect, audit logs are always set to SRC_LOG_LEVEL",
+							"description": "DEPRECATED: No effect, audit logs are always set to SRC_LOG_LEVEL",
+							"enum": [
+								"DEBUG",
+								"INFO",
+								"WARN",
+								"ERROR"
+							],
+							"type": "string"
+						}
+					},
+					"required": [
+						"internalTraffic",
+						"graphQL",
+						"gitserverAccess"
+					],
+					"type": "object"
+				},
+				"sentry": {
+					"additionalProperties": false,
+					"description": "Configuration for Sentry",
+					"examples": [
+						{
+							"sentry": {
+								"backendDSN": "https://public_key@sentry.example.com/backend_project_id",
+								"codeIntelDSN": "https://public_key@sentry.example.com/codeintel_project_id",
+								"dsn": "https://public_key@sentry.example.com/project_id"
+							}
+						}
+					],
+					"properties": {
+						"backendDSN": {
+							"description": "Sentry Data Source Name (DSN) for backend errors. Per the Sentry docs (https://docs.sentry.io/quickstart/#about-the-dsn), it should match the following pattern: '{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PATH}{PROJECT_ID}'.",
+							"pattern": "^https?://",
+							"type": "string"
+						},
+						"codeIntelDSN": {
+							"description": "Sentry Data Source Name (DSN) for code intel errors. Per the Sentry docs (https://docs.sentry.io/quickstart/#about-the-dsn), it should match the following pattern: '{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PATH}{PROJECT_ID}'.",
+							"pattern": "^https?://",
+							"type": "string"
+						},
+						"dsn": {
+							"description": "Sentry Data Source Name (DSN). Per the Sentry docs (https://docs.sentry.io/quickstart/#about-the-dsn), it should match the following pattern: '{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PATH}{PROJECT_ID}'.",
+							"pattern": "^https?://",
+							"type": "string"
+						}
+					},
+					"type": "object"
+				}
+			},
+			"type": "object"
+		},
+		"lsifEnforceAuth": {
+			"default": false,
+			"description": "Whether or not LSIF uploads will be blocked unless a valid LSIF upload token is provided.",
+			"group": "Security",
+			"type": "boolean"
+		},
+		"maxReposToSearch": {
+			"default": -1,
+			"description": "DEPRECATED: Configure maxRepos in search.limits. The maximum number of repositories to search across. The user is prompted to narrow their query if exceeded. Any value less than or equal to zero means unlimited.",
+			"group": "Search",
+			"type": "integer"
+		},
+		"modelConfiguration": {
+			"$ref": "#/definitions/SiteModelConfiguration"
+		},
+		"notifications": {
+			"description": "Notifications recieved from Sourcegraph.com to display in Sourcegraph.",
+			"examples": [
+				{
+					"key": "2023-03-10-my-key",
+					"message": "This is a test notification message."
+				}
+			],
+			"items": {
+				"properties": {
+					"key": {
+						"description": "e.g. '2023-03-10-my-key'; MUST START WITH YYYY-MM-DD; a globally unique key used to track whether the message has been dismissed.",
+						"minLength": 1,
+						"type": "string"
+					},
+					"message": {
+						"description": "The Markdown message to display",
+						"minLength": 1,
+						"type": "string"
+					}
+				},
+				"required": [
+					"key",
+					"message"
+				],
+				"type": "object"
+			},
+			"type": "array"
+		},
+		"observability.alerts": {
+			"description": "Configure notifications for Sourcegraph's built-in alerts.",
+			"examples": [
+				{
+					"level": "critical",
+					"notifier": {
+						"channel": "#alerts",
+						"type": "slack",
+						"url": "https://hooks.slack.com/services/..."
+					}
+				},
+				{
+					"level": "warning",
+					"notifier": {
+						"addresses": [
+							"alerts@example.com"
+						],
+						"type": "email"
+					}
+				}
+			],
+			"items": {
+				"default": {
+					"level": "critical",
+					"notifier": {
+						"type": ""
+					}
+				},
+				"properties": {
+					"disableSendResolved": {
+						"default": false,
+						"description": "Disable notifications when alerts resolve themselves.",
+						"type": "boolean"
+					},
+					"level": {
+						"description": "Sourcegraph alert level to subscribe to notifications for.",
+						"enum": [
+							"warning",
+							"critical"
+						],
+						"type": "string"
+					},
+					"notifier": {
+						"!go": {
+							"taggedUnionType": true
+						},
+						"oneOf": [
+							{
+								"$ref": "#/definitions/NotifierSlack"
+							},
+							{
+								"$ref": "#/definitions/NotifierPagerduty"
+							},
+							{
+								"$ref": "#/definitions/NotifierWebhook"
+							},
+							{
+								"$ref": "#/definitions/NotifierEmail"
+							},
+							{
+								"$ref": "#/definitions/NotifierOpsGenie"
+							}
+						],
+						"properties": {
+							"type": {
+								"enum": [
+									"slack",
+									"pagerduty",
+									"webhook",
+									"email",
+									"opsgenie"
+								],
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"owners": {
+						"description": "Do not use. When set, only receive alerts owned by the specified teams. Used by Sourcegraph internally.",
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"level",
+					"notifier"
+				],
+				"type": "object"
+			},
+			"type": "array"
+		},
+		"observability.captureSlowGraphQLRequestsLimit": {
+			"description": "(debug) Set a limit to the amount of captured slow GraphQL requests being stored for visualization. For defining the threshold for a slow GraphQL request, see observability.logSlowGraphQLRequests.",
+			"examples": [
+				2000
+			],
+			"group": "Debug",
+			"type": "integer"
+		},
+		"observability.client": {
+			"additionalProperties": false,
+			"description": "EXPERIMENTAL: Configuration for client observability",
+			"examples": [
+				{
+					"openTelemetry": {
+						"endpoint": "/-/debug/otlp"
+					}
+				},
+				{
+					"openTelemetry": {
+						"endpoint": "https://opentelemetry.example.com"
+					}
+				}
+			],
+			"properties": {
+				"openTelemetry": {
+					"description": "Configuration for the client OpenTelemetry exporter",
+					"properties": {
+						"endpoint": {
+							"default": "/-/debug/otlp",
+							"description": "OpenTelemetry tracing collector endpoint. By default, Sourcegraph's \"/-/debug/otlp\" endpoint forwards data to the configured collector backend.",
+							"examples": [
+								"/-/debug/otlp",
+								"https://COLLECTOR_ENDPOINT"
+							],
+							"type": "string"
+						},
+						"webVitalsInstrumentation": {
+							"default": false,
+							"description": "Enable web vitals instrumentation.",
+							"type": "boolean"
+						}
+					},
+					"type": "object"
+				}
+			},
+			"type": "object"
+		},
+		"observability.logSlowGraphQLRequests": {
+			"description": "(debug) logs all GraphQL requests slower than the specified number of milliseconds.",
+			"examples": [
+				10000
+			],
+			"group": "Debug",
+			"type": "integer"
+		},
+		"observability.logSlowSearches": {
+			"description": "(debug) logs all search queries (issued by users, code intelligence, or API requests) slower than the specified number of milliseconds.",
+			"examples": [
+				10000
+			],
+			"group": "Debug",
+			"type": "integer"
+		},
+		"observability.silenceAlerts": {
+			"description": "Silence individual Sourcegraph alerts by identifier.",
+			"examples": [
+				[
+					"warning_gitserver_disk_space_remaining"
+				],
+				[
+					"critical_frontend_down",
+					"warning_high_load"
+				]
+			],
+			"items": {
+				"type": "string"
+			},
+			"type": "array"
+		},
+		"observability.tracing": {
+			"description": "Configures distributed tracing within Sourcegraph. To learn more, refer to https://sourcegraph.com/docs/admin/observability/tracing",
+			"examples": [
+				{
+					"debug": false,
+					"sampling": "selective",
+					"type": "opentelemetry",
+					"urlTemplate": "https://ui.honeycomb.io/$ORG/environments/$DATASET/trace?trace_id={{ .TraceID }}"
+				},
+				{
+					"debug": true,
+					"sampling": "all",
+					"type": "jaeger",
+					"urlTemplate": "{{ .ExternalURL }}/-/debug/jaeger/trace/{{ .TraceID }}"
+				}
+			],
+			"properties": {
+				"debug": {
+					"default": false,
+					"description": "Turns on debug logging of tracing client requests. This can be useful for debugging connectivity issues between the tracing client and tracing backend, the performance overhead of tracing, and other issues related to the use of distributed tracing. May have performance implications in production.",
+					"type": "boolean"
+				},
+				"sampling": {
+					"default": "selective",
+					"description": "Determines the conditions under which distributed traces are recorded. \"none\" turns off tracing entirely. \"selective\" (default) sends traces whenever `?trace=1` is present in the URL (though background jobs may still emit traces). \"all\" sends traces on every request. Note that this only affects the behavior of the distributed tracing client. To learn more about additional sampling and traace export configuration with the default tracing type \"opentelemetry\", refer to https://sourcegraph.com/docs/admin/observability/opentelemetry#tracing ",
+					"enum": [
+						"selective",
+						"all",
+						"none"
+					],
+					"type": "string"
+				},
+				"type": {
+					"default": "opentelemetry",
+					"description": "Determines what tracing provider to enable. For \"opentelemetry\", the required backend is an OpenTelemetry collector instance (deployed by default with Sourcegraph). For \"jaeger\", a Jaeger instance is required to be configured via Jaeger client environment variables: https://github.com/jaegertracing/jaeger-client-go#environment-variables",
+					"enum": [
+						"opentelemetry",
+						"jaeger"
+					],
+					"type": "string"
+				},
+				"urlTemplate": {
+					"description": "Template for linking to trace URLs - '{{ .TraceID }}' is replaced with the trace ID, and {{ .ExternalURL }} is replaced with the value of 'externalURL'. If none is set, no links are generated.",
+					"examples": [
+						"https://ui.honeycomb.io/$ORG/environments/$DATASET/trace?trace_id={{ .TraceID }}",
+						"https://console.cloud.google.com/traces/list?tid={{ .TraceID }}\u0026project=$PROJECT",
+						"https://$ORGANIZATION.grafana.net/explore?orgId=1\u0026left=[\"now-1h\",\"now\",\"$DATASOURCE\",{\"query\":\"{{ .TraceID }}\",\"queryType\":\"traceId\"}]",
+						"{{ .ExternalURL }}/-/debug/jaeger/trace/{{ .TraceID }}"
+					],
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"organizationInvitations": {
+			"description": "Configuration for organization invitations.",
+			"examples": [
+				{
+					"expiryTime": 48,
+					"signingKey": "your-signing-key"
+				}
+			],
+			"properties": {
+				"expiryTime": {
+					"default": 48,
+					"description": "Time before the invitation expires, in hours (experimental, not enforced at the moment).",
+					"type": "integer"
+				},
+				"signingKey": {
+					"description": "Base64 encoded HMAC Signing key to sign a JWT token, which is attached to each invitation URL.\nMore documentation here: https://pkg.go.dev/github.com/golang-jwt/jwt#SigningMethodHMAC \n\nIf not provided, will fall back to legacy invitation to an organization.\n\nThe legacy invitation will be deprecated in the future and creating an organization invitation will fail with an error if this setting is not present.",
+					"type": "string"
+				}
+			},
+			"required": [
+				"signingKey"
+			],
+			"type": "object"
+		},
+		"outboundRequestLogLimit": {
+			"default": 50,
+			"description": "The maximum number of outbound requests to retain. This is a global limit across all outbound requests. If the limit is exceeded, older items will be deleted. If the limit is 0, no outbound requests are logged.",
+			"maximum": 500,
+			"minimum": 0,
+			"type": "integer"
+		},
+		"own.background.repoIndexConcurrencyLimit": {
+			"default": 5,
+			"description": "The max number of concurrent Own jobs that will run per worker node.",
+			"group": "Own",
+			"type": "integer"
+		},
+		"own.background.repoIndexRateBurstLimit": {
+			"default": 5,
+			"description": "The maximum per second burst of repositories for Own jobs per worker node. Generally this value should not be less than the max concurrency.",
+			"group": "Own",
+			"type": "integer"
+		},
+		"own.background.repoIndexRateLimit": {
+			"default": 20,
+			"description": "The maximum per second rate of repositories for Own jobs per worker node.",
+			"group": "Own",
+			"type": "integer"
+		},
+		"own.bestEffortTeamMatching": {
+			"!go": {
+				"pointer": true
+			},
+			"default": true,
+			"description": "The Own service will attempt to match a Team by the last part of its handle if it contains a slash and no match is found for its full handle.",
+			"group": "Own",
+			"type": "boolean"
+		},
+		"parentSourcegraph": {
+			"additionalProperties": false,
+			"description": "URL to fetch unreachable repository details from. Defaults to \"https://sourcegraph.com\"",
+			"examples": [
+				{
+					"url": "https://sourcegraph.example.com"
+				}
+			],
+			"group": "External services",
+			"properties": {
+				"url": {
+					"default": "https://sourcegraph.com",
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"permissions.syncJobCleanupInterval": {
+			"default": 3600,
+			"description": "Time interval (in seconds) of how often cleanup worker should remove old jobs from permissions sync jobs table.",
+			"minimum": 1,
+			"type": "integer"
+		},
+		"permissions.syncJobsHistorySize": {
+			"!go": {
+				"pointer": true
+			},
+			"default": 5,
+			"description": "The number of last repo/user permission jobs to keep for history. Will be cleaned up occasionally to only keep the most recent N jobs.",
+			"minimum": 5,
+			"type": "integer"
+		},
+		"permissions.syncOldestRepos": {
+			"!go": {
+				"pointer": true
+			},
+			"default": 100,
+			"description": "Number of repo permissions to schedule for syncing in single scheduler iteration.",
+			"type": "integer"
+		},
+		"permissions.syncOldestUsers": {
+			"!go": {
+				"pointer": true
+			},
+			"default": 100,
+			"description": "Number of user permissions to schedule for syncing in single scheduler iteration.",
+			"type": "integer"
+		},
+		"permissions.syncReposBackoffSeconds": {
+			"default": 900,
+			"description": "Don't sync a repo's permissions if it has synced within the last n seconds.",
+			"type": "integer"
+		},
+		"permissions.syncReposMaxConcurrency": {
+			"default": 5,
+			"description": "The maximum number of repo-centric permissions syncing jobs that can be spawned concurrently. Service restart is required to take effect for changes.",
+			"type": "integer"
+		},
+		"permissions.syncScheduleInterval": {
+			"default": 60,
+			"description": "Time interval (in seconds) of how often each component picks up authorization changes in external services.",
+			"type": "integer"
+		},
+		"permissions.syncUsersBackoffSeconds": {
+			"default": 900,
+			"description": "Don't sync a user's permissions if they have synced within the last n seconds.",
+			"type": "integer"
+		},
+		"permissions.syncUsersMaxConcurrency": {
+			"default": 5,
+			"description": "The maximum number of user-centric permissions syncing jobs that can be spawned concurrently. Service restart is required to take effect for changes.",
+			"type": "integer"
+		},
+		"permissions.userMapping": {
+			"additionalProperties": false,
+			"default": {
+				"bindID": "email",
+				"enabled": true
+			},
+			"description": "Settings for Sourcegraph explicit permissions, which allow the site admin to explicitly manage repository permissions via the GraphQL API. This will mark repositories as restricted by default.",
+			"examples": [
+				{
+					"bindID": "email"
+				},
+				{
+					"bindID": "username"
+				}
+			],
+			"group": "Security",
+			"properties": {
+				"bindID": {
+					"default": "email",
+					"description": "The type of identifier to identify a user. The default is \"email\", which uses the email address to identify a user. Use \"username\" to identify a user by their username. Changing this setting will erase any permissions created for users that do not yet exist.",
+					"enum": [
+						"email",
+						"username"
+					],
+					"type": "string"
+				},
+				"enabled": {
+					"default": false,
+					"description": "Whether permissions user mapping is enabled.",
+					"type": "boolean"
+				}
+			},
+			"type": "object"
+		},
+		"productResearchPage.enabled": {
+			"!go": {
+				"pointer": true
+			},
+			"default": true,
+			"description": "Enables users access to the product research page in their settings.",
+			"group": "Misc.",
+			"type": "boolean"
+		},
+		"rateLimits": {
+			"additionalProperties": false,
+			"properties": {
+				"graphQLMaxAliases": {
+					"default": 500,
+					"description": "Maximum number of aliases allowed in a GraphQL query",
+					"type": "integer"
+				},
+				"graphQLMaxDepth": {
+					"default": 30,
+					"description": "Maximum depth of nested objects allowed for GraphQL queries. Changes to this setting require a restart.",
+					"type": "integer"
+				},
+				"graphQLMaxDuplicateFieldCount": {
+					"default": 500,
+					"description": "Maximum number of duplicate fields allowed in a GraphQL request",
+					"type": "integer"
+				},
+				"graphQLMaxFieldCount": {
+					"default": 500000,
+					"description": "Maximum number of estimated fields allowed in a GraphQL response",
+					"type": "integer"
+				},
+				"graphQLMaxUniqueFieldCount": {
+					"default": 500,
+					"description": "Maximum number of unique fields allowed in a GraphQL request",
+					"type": "integer"
+				}
+			},
+			"type": "object"
+		},
+		"redactOutboundRequestHeaders": {
+			"!go": {
+				"pointer": true
+			},
+			"description": "Enables redacting sensitive information from outbound requests. Important: We only respect this setting in development environments. In production, we always redact outbound requests.",
+			"examples": [
+				true
+			],
+			"type": "boolean"
+		},
+		"repoConcurrentExternalServiceSyncers": {
+			"default": 3,
+			"description": "The number of concurrent external service syncers that can run.",
+			"group": "External services",
+			"type": "integer"
+		},
+		"repoListUpdateInterval": {
+			"default": 1,
+			"description": "Interval (in minutes) for checking code hosts (such as GitHub, Gitolite, etc.) for new repositories.",
+			"group": "External services",
+			"type": "integer"
+		},
+		"repoPurgeWorker": {
+			"additionalProperties": false,
+			"default": {
+				"deletedTTLMinutes": 60,
+				"intervalMinutes": 15
+			},
+			"description": "Configuration for repository purge worker.",
+			"group": "External services",
+			"properties": {
+				"deletedTTLMinutes": {
+					"default": "60",
+					"description": "Repository TTL in minutes after deletion before it becomes eligible to be purged. A migration or admin could accidentally remove all or a significant number of repositories - recloning all of them is slow, so a TTL acts as a grace period so that admins can recover from accidental deletions",
+					"minimum": 0,
+					"type": "integer"
+				},
+				"intervalMinutes": {
+					"default": "15",
+					"description": "Interval in minutes at which to run purge jobs. Set to 0 to disable.",
+					"minimum": 0,
+					"type": "integer"
+				}
+			},
+			"type": "object"
+		},
+		"scim.authToken": {
+			"default": "",
+			"description": "The SCIM auth token is used to authenticate SCIM requests. If not set, SCIM is disabled.",
+			"group": "External services",
+			"type": "string"
+		},
+		"scim.identityProvider": {
+			"default": "STANDARD",
+			"description": "Identity provider used for SCIM support.  \"STANDARD\" should be used unless a more specific value is available",
+			"enum": [
+				"STANDARD",
+				"Azure AD"
+			],
+			"group": "External services",
+			"type": "string"
+		},
+		"search.index.shardConcurrency": {
+			"description": "The number of threads each indexserver should use to index shards. If not set, indexserver will use the number of available CPUs. This is exposed as a safeguard and should usually not require being set.",
+			"examples": [
+				"10"
+			],
+			"group": "Search",
+			"type": "integer"
+		},
+		"search.index.symbols.enabled": {
+			"!go": {
+				"pointer": true
+			},
+			"description": "Whether indexed symbol search is enabled. This is contingent on the indexed search configuration, and is true by default for instances with indexed search enabled. Enabling this will cause every repository to re-index, which is a time consuming (several hours) operation. Additionally, it requires more storage and ram to accommodate the added symbols information in the search index.",
+			"examples": [
+				true
+			],
+			"group": "Search",
+			"type": "boolean"
+		},
+		"search.largeFiles": {
+			"description": "A list of file glob patterns where matching files will be indexed and searched regardless of their size. Files still need to be valid utf-8 to be indexed. The glob pattern syntax can be found here: https://github.com/bmatcuk/doublestar#patterns.",
+			"examples": [
+				[
+					"go.sum",
+					"package-lock.json",
+					"**/*.thrift"
+				]
+			],
+			"group": "Search",
+			"items": {
+				"type": "string"
+			},
+			"type": "array"
+		},
+		"search.limits": {
+			"additionalProperties": false,
+			"description": "Limits that search applies for number of repositories searched and timeouts.",
+			"examples": [
+				{
+					"commitDiffMaxRepos": 50,
+					"commitDiffWithTimeFilterMaxRepos": 5000,
+					"maxRepos": 200,
+					"maxTimeoutSeconds": 60
+				}
+			],
+			"group": "Search",
+			"properties": {
+				"commitDiffMaxRepos": {
+					"default": 50,
+					"description": "The maximum number of repositories to search across when doing a \"type:diff\" or \"type:commit\". The user is prompted to narrow their query if the limit is exceeded. There is a separate limit (commitDiffWithTimeFilterMaxRepos) when \"after:\" or \"before:\" is specified because those queries are faster. Defaults to 50.",
+					"minimum": 1,
+					"type": "integer"
+				},
+				"commitDiffWithTimeFilterMaxRepos": {
+					"default": 10000,
+					"description": "The maximum number of repositories to search across when doing a \"type:diff\" or \"type:commit\" with a \"after:\" or \"before:\" filter. The user is prompted to narrow their query if the limit is exceeded. There is a separate limit (commitDiffMaxRepos) when \"after:\" or \"before:\" is not specified because those queries are slower. Defaults to 10000.",
+					"minimum": 1,
+					"type": "integer"
+				},
+				"maxRepos": {
+					"default": -1,
+					"description": "The maximum number of repositories to search across. The user is prompted to narrow their query if exceeded. Any value less than or equal to zero means unlimited.",
+					"type": "integer"
+				},
+				"maxTimeoutSeconds": {
+					"default": "60",
+					"description": "The maximum value for \"timeout:\" that search will respect. \"timeout:\" values larger than maxTimeoutSeconds are capped at maxTimeoutSeconds. Note: You need to ensure your load balancer / reverse proxy in front of Sourcegraph won't timeout the request for larger values. Note: Too many large rearch requests may harm Soucregraph for other users. Note: Experimental search jobs do not respect this limit. Defaults to 1 minute.",
+					"minimum": 1,
+					"type": "integer"
+				}
+			},
+			"type": "object"
+		},
+		"ssc.apiBaseUrl": {
+			"default": "https://accounts.sourcegraph.com/cody/api",
+			"description": "The base URL of the Self-Serve Cody API.",
+			"type": "string"
+		},
+		"ssc.samsHostName": {
+			"default": "accounts.sourcegraph.com",
+			"description": "The hostname of SAMS instance to connect.",
+			"type": "string"
+		},
+		"syntaxHighlighting": {
+			"description": "Syntax highlighting configuration",
+			"examples": [
+				{
+					"engine": {
+						"default": "tree-sitter",
+						"overrides": {
+							"go": "syntect"
+						}
+					},
+					"languages": {
+						"extensions": {
+							"go": "go",
+							"ts": "typescript"
+						},
+						"patterns": [
+							{
+								"language": "cobol",
+								"match": "cobol_.*\\.txt"
+							}
+						]
+					}
+				}
+			],
+			"properties": {
+				"engine": {
+					"properties": {
+						"default": {
+							"description": "The default syntax highlighting engine to use",
+							"enum": [
+								"tree-sitter",
+								"syntect",
+								"scip-syntax"
+							],
+							"type": "string"
+						},
+						"overrides": {
+							"additionalProperties": {
+								"enum": [
+									"tree-sitter",
+									"syntect",
+									"scip-syntax"
+								],
+								"type": "string"
+							},
+							"description": "Manually specify overrides for syntax highlighting engine per language",
+							"type": "object"
+						}
+					},
+					"title": "SyntaxHighlightingEngine",
+					"type": "object"
+				},
+				"languages": {
+					"properties": {
+						"extensions": {
+							"additionalProperties": {
+								"type": "string"
+							},
+							"description": "Map of extension to language",
+							"type": "object"
+						},
+						"patterns": {
+							"description": "Map of patterns to language. Will return after first match, if any.",
+							"items": {
+								"properties": {
+									"language": {
+										"description": "Name of the language if pattern matches",
+										"type": "string"
+									},
+									"pattern": {
+										"description": "Regular expression which matches the filepath",
+										"format": "regex",
+										"type": "string"
+									}
+								},
+								"required": [
+									"pattern",
+									"language"
+								],
+								"title": "SyntaxHighlightingLanguagePatterns",
+								"type": "object"
+							},
+							"type": "array"
+						}
+					},
+					"title": "SyntaxHighlightingLanguage",
+					"type": "object"
+				},
+				"symbols": {
+					"description": "Configure symbol generation",
+					"properties": {
+						"engine": {
+							"additionalProperties": {
+								"enum": [
+									"universal-ctags",
+									"scip-ctags",
+									"off"
+								],
+								"type": "string"
+							},
+							"description": "Manually specify overrides for symbol generation engine per language",
+							"type": "object"
+						}
+					},
+					"required": [
+						"engine"
+					],
+					"title": "SymbolConfiguration",
+					"type": "object"
+				}
+			},
+			"title": "SyntaxHighlighting",
+			"type": "object"
+		},
+		"telemetry": {
+			"additionalProperties": false,
+			"description": "Configuration for application user telemetry.",
+			"properties": {
+				"disableLocalEventLogs": {
+					"default": false,
+					"description": "Disable long-term local retention of user telemetry as 'event logs' entirely.",
+					"type": "boolean"
+				}
+			},
+			"type": "object"
+		},
+		"update.channel": {
+			"default": "release",
+			"description": "The channel on which to automatically check for Sourcegraph updates.",
+			"enum": [
+				"release",
+				"none"
+			],
+			"examples": [
+				"none"
+			],
+			"group": "Misc.",
+			"type": [
+				"string"
+			]
+		},
+		"webhook.logging": {
+			"description": "Configuration for logging incoming webhooks.",
+			"examples": [
+				{
+					"enabled": true,
+					"retention": "7d"
+				}
+			],
+			"properties": {
+				"enabled": {
+					"!go": {
+						"pointer": true
+					},
+					"description": "Whether incoming webhooks are logged. If omitted, logging is enabled on sites without encryption. If one or more encryption keys are present, this setting must be enabled manually; as webhooks may contain sensitive data, admins of encrypted sites may want to enable webhook encryption via encryption.keys.webhookLogKey.",
+					"type": "boolean"
+				},
+				"retention": {
+					"default": "72h",
+					"description": "How long incoming webhooks are retained. The string format is that of the Duration type in the Go time package (https://golang.org/pkg/time/#ParseDuration). Values lower than 1 hour will be treated as 1 hour. By default, this is \"72h\", or three days.",
+					"type": "string"
+				}
+			},
+			"type": "object"
 		}
-	],
+	},
+	"title": "Site configuration",
+	"type": "object"
 }
 ```
 {/* SCHEMA_SYNC_END: admin/config/site.schema.json */}
-
 ## Configuration Notes
 
 ### Critical Restart Requirements

--- a/docs/admin/repo/perforce.mdx
+++ b/docs/admin/repo/perforce.mdx
@@ -221,122 +221,158 @@ With this setting, Sourcegraph will ignore any rules with a host other than `*`,
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/perforce.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T19:22:31Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
-	// If non-null, enforces Perforce depot permissions.
-	"authorization": null,
-
-	// Depots can have arbitrary paths, e.g. a path to depot root or a subdirectory.
-	"depots": null,
-	// Other example values:
-	// - [
-	//     "//Sourcegraph/",
-	//     "//Engineering/Cloud/"
-	//   ]
-
-	// Configuration for the experimental p4-fusion client
-	"fusionClient": null,
-
-	// Only import at most n changes when possible (git p4 clone --max-changes).
-	"maxChanges": 1000,
-
-	// Client specified as an option for p4 CLI (P4CLIENT, also enables '--use-client-spec')
-	"p4.client": null,
-
-	// The ticket value for the user (P4PASSWD). You can get this by running `p4 login -p` or `p4 login -pa`. It should look like `6211C5E719EDE6925855039E8F5CC3D2`.
-	"p4.passwd": null,
-
-	// The Perforce Server address to be used for p4 CLI (P4PORT). It's recommended to specify the protocol prefix (e.g. tcp: or ssl:) as part of the address.
-	"p4.port": null,
-	// Other example values:
-	// - "ssl:111.222.333.444:1666"
-	// - "tcp:111.222.333.444:1666"
-
-	// The user to be authenticated for p4 CLI (P4USER).
-	"p4.user": null,
-	// Other example values:
-	// - "admin"
-
-	// The pattern used to generate the corresponding Sourcegraph repository name for a Perforce depot. In the pattern, the variable "{depot}" is replaced with the Perforce depot's path.
-	//
-	// For example, if your Perforce depot path is "//Sourcegraph/" and your Sourcegraph URL is https://src.example.com, then a repositoryPathPattern of "perforce/{depot}" would mean that the Perforce depot is available on Sourcegraph at https://src.example.com/perforce/Sourcegraph.
-	//
-	// It is important that the Sourcegraph repository name generated with this pattern be unique to this Perforce Server. If different Perforce Servers generate repository names that collide, Sourcegraph's behavior is undefined.
-	"repositoryPathPattern": "{depot}"
-}
-```
-
-## Known issues and limitations
-
-We are actively working to significantly improve Sourcegraph's Perforce support. Please [contact us](https://help.sourcegraph.com/hc/en-us/requests/new) to help us prioritize any specific improvements you'd like to see.
-
-- Sourcegraph was initially built for Git repositories only, so it stores Perforce depots as Git repositories when syncing. Perforce concepts and languages are expressed in the UI, but under the hood, Git tools are used.
-- Batch Changes does not support [file-level permissions](#file-level-permissions) (also known as sub-repo permissions)
-- Batch Changes does not handle the shelved changelist other than to query the Perforce server for its status.
-- Permalinks with Changelist Id do not work yet
-
-## Configure experimental features
-
-As of Sourcegraph 5.1, there are the following experimental features for Perforce depots. These are merely for providing feedback and have [limited support](/admin/beta_and_experimental_features#experimental-features).
-
-### Changelist ID in URLs
-
-Note: When enabling changelist IDs in URLs for the first time, Perforce depots can be unavailable for a few minutes on the Sourcegraph instance, due to the initial mapping of changelist IDs to generated commit ID happening in the background. If you have a large number of Perforce depots, we recommend proceeding with the following steps in a maintenance window in which you don't expect large amounts of traffic on your Sourcegraph instance.
-
-Add `"perforceChangelistMapping": "enabled",` to `experimentalFeatures` in the [site configuration](/admin/config/site_config):
-
-```json
-{
-  "experimentalFeatures": {
-    "perforceChangelistMapping": "enabled"
-  }
-}
-```
-
-When enabled, URLs for Perforce code hosts will use the Changelist (CL) ID instead of commit SHAs. Areas that benefit from this at the moment are:
-
-- Viewing a specific CL
-- Viewing the files of a depot at a specific CL
-- Viewing a specific file added / removed / modified in a specific CL
-- Viewing the list of CLs
-
-
-### Searching within a specific changelist
-As of Sourcegraph 5.5, you can search within a specific changelist by referring the the changelist as a reference path like `changelist/123` where 123 is the changelist id. For example, given a repo path of `Talkhouse/main` and a changelist id of `123`, you can search within that changelist by using the following query:
-```
-repo:^Talkhouse/main$@changelist/123 text to find
-```
-
-or
-```
-repo:^Talkhouse/main$ rev:changelist/123 text to find
-```
-
-#### Limitations
-
-- After a depot is cloned or fetched, Sourcegraph computes and stores mappings of CL IDs to commit SHAs. This mapping can take several minutes for large clones/fetches. When a background mapping job is running, the depot won't be serviceable as URLs referring to CL IDs may not resolve and users may see an error while interacting with the depot.
-- This experimental configuration can not be selectively enabled for a specific perforce depot.
-
-#### Mechanism
-
-To support CLs natively in the URLs, Sourcegraph performs background computation after syncing the contents of a depot. That's done by parsing each generated commit to retrieve the corresponding CL ID and store it in the `repo_commits_changelists` table. This is currently performed on only one depot at a time and we are working to support this for multiple depots in parallel in an upcoming release.
-
-Additionally, while removing a depot from a code host config will mark it as "deleted", the mapped information will **not** be deleted to prevent forced re-computation after an accidental removal of depot from a code host config. Similarly recloning a depot will **not** trigger a computation of all the CLs from the beginning of the depot's source control history. If site admins are recloning or deleting and re-adding a depot to Sourcegraph as a result of history rewrite of a depot in Perforce, they should get in [touch with us](mailto:support@sourcegraph.com) for next steps.
-
-### Batch Changes support for Perforce depots
-
-Add `"batchChanges.enablePerforce": true` to `experimentalFeatures` in the [site configuration](/admin/config/site_config):
-
-```json
-{
-  "experimentalFeatures": {
-   "batchChanges.enablePerforce": true,
-  }
+	"$id": "perforce.schema.json#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": false,
+	"allowComments": true,
+	"description": "Configuration for a connection to Perforce Server.",
+	"properties": {
+		"authorization": {
+			"description": "If non-null, enforces Perforce depot permissions.",
+			"properties": {
+				"ignoreRulesWithHost": {
+					"default": false,
+					"description": "Ignore host-based protection rules (any rule with something other than a wildcard in the Host field).",
+					"type": "boolean"
+				},
+				"subRepoPermissions": {
+					"default": false,
+					"description": "Experimental: infer sub-repository permissions from protection rules.",
+					"type": "boolean"
+				}
+			},
+			"title": "PerforceAuthorization",
+			"type": "object"
+		},
+		"depots": {
+			"description": "Depots can have arbitrary paths, e.g. a path to depot root or a subdirectory.",
+			"examples": [
+				[
+					"//Sourcegraph/",
+					"//Engineering/Cloud/"
+				]
+			],
+			"items": {
+				"pattern": "^\\/[\\/\\S]+\\/$",
+				"type": "string"
+			},
+			"type": "array"
+		},
+		"fusionClient": {
+			"additionalProperties": false,
+			"description": "Configuration for the experimental p4-fusion client",
+			"properties": {
+				"cacheLabels": {
+					"default": false,
+					"description": "Whether to cache Perforce labels on disk to avoid unnecessary roundtrips to the Perforce server.",
+					"type": "boolean"
+				},
+				"enabled": {
+					"default": false,
+					"description": "DEPRECATED. p4-fusion is always enabled.",
+					"type": "boolean"
+				},
+				"fsyncEnable": {
+					"default": false,
+					"description": " Enable fsync() while writing objects to disk to ensure they get written to permanent storage immediately instead of being cached. This is to mitigate data loss in events of hardware failure.",
+					"type": "boolean"
+				},
+				"includeBinaries": {
+					"default": false,
+					"description": "Whether to include binary files",
+					"type": "boolean"
+				},
+				"lookAhead": {
+					"default": 2000,
+					"description": "How many CLs in the future, at most, shall we keep downloaded by the time it is to commit them",
+					"minimum": 1,
+					"type": "integer"
+				},
+				"maxChanges": {
+					"default": -1,
+					"description": "How many changes to fetch during initial clone. The default of -1 will fetch all known changes",
+					"type": "integer"
+				},
+				"networkThreads": {
+					"default": 12,
+					"description": "The number of threads in the threadpool for running network calls. Defaults to the number of logical CPUs.",
+					"minimum": 1,
+					"type": "integer"
+				},
+				"networkThreadsFetch": {
+					"default": 12,
+					"description": "The number of threads in the threadpool for running network calls when performing fetches. Defaults to the number of logical CPUs.",
+					"minimum": 1,
+					"type": "integer"
+				},
+				"noConvertLabels": {
+					"default": false,
+					"description": "Disable Perforce label to git tag conversion.",
+					"type": "boolean"
+				},
+				"printBatch": {
+					"default": 100,
+					"description": "The p4 print batch size",
+					"minimum": 1,
+					"type": "integer"
+				},
+				"refresh": {
+					"default": 1000,
+					"description": "How many times a connection should be reused before it is refreshed",
+					"minimum": 1,
+					"type": "integer"
+				},
+				"retries": {
+					"default": 10,
+					"description": "How many times a command should be retried before the process exits in a failure",
+					"minimum": 1,
+					"type": "integer"
+				}
+			},
+			"type": "object"
+		},
+		"p4.client": {
+			"description": "Client specified as an option for p4 CLI (P4CLIENT, also enables '--use-client-spec')",
+			"type": "string"
+		},
+		"p4.passwd": {
+			"description": "The ticket value for the user (P4PASSWD). You can get this by running `p4 login -p` or `p4 login -pa`. It should look like `6211C5E719EDE6925855039E8F5CC3D2`.",
+			"type": "string"
+		},
+		"p4.port": {
+			"description": "The Perforce Server address to be used for p4 CLI (P4PORT). It's recommended to specify the protocol prefix (e.g. tcp: or ssl:) as part of the address.",
+			"examples": [
+				"ssl:111.222.333.444:1666",
+				"tcp:111.222.333.444:1666"
+			],
+			"type": "string"
+		},
+		"p4.user": {
+			"description": "The user to be authenticated for p4 CLI (P4USER).",
+			"examples": [
+				"admin"
+			],
+			"type": "string"
+		},
+		"repositoryPathPattern": {
+			"default": "{depot}",
+			"description": "The pattern used to generate the corresponding Sourcegraph repository name for a Perforce depot. In the pattern, the variable \"{depot}\" is replaced with the Perforce depot's path.\n\nFor example, if your Perforce depot path is \"//Sourcegraph/\" and your Sourcegraph URL is https://src.example.com, then a repositoryPathPattern of \"perforce/{depot}\" would mean that the Perforce depot is available on Sourcegraph at https://src.example.com/perforce/Sourcegraph.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this Perforce Server. If different Perforce Servers generate repository names that collide, Sourcegraph's behavior is undefined.",
+			"type": "string"
+		}
+	},
+	"required": [
+		"p4.port",
+		"p4.user",
+		"p4.passwd"
+	],
+	"title": "PerforceConnection",
+	"type": "object"
 }
 ```
 {/* SCHEMA_SYNC_END: admin/code_hosts/perforce.schema.json */}
-
 ## Configuration Notes
 
 - **p4-fusion Recommended**: Use the `fusionClient` configuration for better performance compared to `git p4`.


### PR DESCRIPTION
This PR updates the embedded JSON schemas to match the schemas from Sourcegraph v6.5.1211.

## Changes
- Updates JSON schema files referenced in MDX documentation
- Maintains version consistency between code and documentation

## Automation
This PR was created automatically by the schema sync tool during the v6.5.1211 release process.

/cc @sourcegraph/release