### PR TITLE
Update JSON schemas for v6.5.1211

### DIFF
--- a/docs/admin/code_hosts/aws_codecommit.mdx
+++ b/docs/admin/code_hosts/aws_codecommit.mdx
@@ -34,86 +34,81 @@ AWS CodeCommit connections support the following configuration options, which ar
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/aws_codecommit.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T22:00:53Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
+	// REQUIRED:
 	// The AWS access key ID to use when listing and updating repositories from AWS CodeCommit. Must have the AWSCodeCommitReadOnly IAM policy.
 	"accessKeyID": null,
 
 	// A list of repositories to never mirror from AWS CodeCommit.
-	//
 	// Supports excluding by name ({"name": "git-codecommit.us-west-1.amazonaws.com/repo-name"}) or by ARN ({"id": "arn:aws:codecommit:us-west-1:999999999999:name"}).
-	"exclude": null,
 	// Other example values:
 	// - [
-	//     {
-	//       "name": "go-monorepo"
-	//     },
-	//     {
-	//       "id": "f001337a-3450-46fd-b7d2-650c0EXAMPLE"
-	//     }
-	//   ]
+	// -   {
+	// -     "name": "go-monorepo"
+	// -   },
+	// -   {
+	// -     "id": "f001337a-3450-46fd-b7d2-650c0EXAMPLE"
+	// -   }
+	// - ]
 	// - [
-	//     {
-	//       "name": "go-monorepo"
-	//     },
-	//     {
-	//       "name": "go-client"
-	//     }
-	//   ]
+	// -   {
+	// -     "name": "go-monorepo"
+	// -   },
+	// -   {
+	// -     "name": "go-client"
+	// -   }
+	// - ]
+	"exclude": null,
 
+	// REQUIRED:
 	// The Git credentials used for authentication when cloning an AWS CodeCommit repository over HTTPS.
-	//
 	// See the AWS CodeCommit documentation on Git credentials for CodeCommit: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_ssh-keys.html#git-credentials-code-commit.
 	// For detailed instructions on how to create the credentials in IAM, see this page: https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-gc.html
-	"gitCredentials": null,
+	"gitCredentials": {
+		"password": null,
+		"username": null
+	},
+
+	// SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`.
+	"gitSSHCipher": null,
+
+	// SSH keys to use when cloning Git repo.
+	"gitSSHCredential": null,
+
+	// The ID of the SSH key created for your IAM users. It is required when using SSH to clone repositories.
+	"gitSSHKeyID": null,
+
+	// The type of Git URLs to use for cloning and fetching Git repositories.
+	// Valid options: "http", "ssh"
+	"gitURLType": "http",
 
 	// Deprecated and ignored field which will be removed entirely in the next release. AWS CodeCommit repositories can no longer be enabled or disabled explicitly. Configure which repositories should not be mirrored via "exclude" instead.
 	"initialRepositoryEnablement": false,
 
+	// The maximum number of repos that will be deleted per sync. A value of 0 or less indicates no maximum.
+	"maxDeletions": 0,
+
+	// REQUIRED:
 	// The AWS region in which to access AWS CodeCommit. See the list of supported regions at https://docs.aws.amazon.com/codecommit/latest/userguide/regions.html#regions-git.
+	// Valid options: "ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ca-central-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-west-3", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2"
 	"region": "us-east-1",
 
 	// The pattern used to generate a the corresponding Sourcegraph repository name for an AWS CodeCommit repository. In the pattern, the variable "{name}" is replaced with the repository's name.
-	//
 	// For example, if your Sourcegraph instance is at https://src.example.com, then a repositoryPathPattern of "awsrepos/{name}" would mean that a AWS CodeCommit repository named "myrepo" is available on Sourcegraph at https://src.example.com/awsrepos/myrepo.
-	//
 	// It is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.
-	"repositoryPathPattern": "{name}",
 	// Other example values:
 	// - "git-codecommit.us-west-1.amazonaws.com/{name}"
 	// - "git-codecommit.eu-central-1.amazonaws.com/{name}"
+	"repositoryPathPattern": "{name}",
 
+	// REQUIRED:
 	// The AWS secret access key (that corresponds to the AWS access key ID set in `accessKeyID`).
 	"secretAccessKey": null
 }
 ```
-
-## Setup steps for SSH connections to AWS CodeCommit repositories
-
-To add CodeCommit repositories in Docker Container:
-
-1. Generate a public/private rsa key pair that does not require passphrase as listed in the [Step 3.1 of the AWS SSH setup guide](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-ssh-unixes.html#setting-up-ssh-unixes-keys). Sourcegraph does not work with the key pair that requires passphrase.
-1. Follow the rest of the steps detailed in the [AWS SSH setup guide](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-ssh-unixes.html) to make sure you can connect to the code host locally.
-1. Confirm you have the connection by running the following ssh command locally: `ssh git-codecommit.us-west-1.amazonaws.com` (Update link with your server region)
-1. Confirm you can clone the repository locally.
-
-### Configuring SSH credentials in the Web UI
-
-```json
-{
-  "gitURLType": "ssh",
-  "gitSSHKeyID": "<SSH key ID>",
-  "gitSSHCredential": {
-    // make sure the key is base64 encoded
-    // $ cat ~/.ssh/id_rsa | base64
-    "privateKey": "<base64 encoded of the SSH private key>",
-    "passphrase": "<passphrase if applicable, omit if none is needed>"
-  }
-}
-```
 {/* SCHEMA_SYNC_END: admin/code_hosts/aws_codecommit.schema.json */}
-
 ## Configuration Notes
 
 ### Git Credentials Requirement

--- a/docs/admin/code_hosts/azuredevops.mdx
+++ b/docs/admin/code_hosts/azuredevops.mdx
@@ -67,68 +67,103 @@ Azure DevOps connections support the following configuration options, which are 
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/azuredevops.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T22:00:52Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
+	// Authentication alternatives: token OR windowsPassword
+
 {
 	// A flag to enforce Azure DevOps repository access permissions
 	"enforcePermissions": false,
 
 	// A list of repositories to never mirror from Azure DevOps Services.
-	"exclude": null,
 	// Other example values:
 	// - [
-	//     {
-	//       "name": "myorg/myproject/myrepo"
-	//     }
-	//   ]
+	// -   {
+	// -     "name": "myorg/myproject/myrepo"
+	// -   }
+	// - ]
 	// - [
-	//     {
-	//       "name": "myorg/myproject/myrepo"
-	//     },
-	//     {
-	//       "name": "myorg/myproject/myotherrepo"
-	//     },
-	//     {
-	//       "pattern": "^topsecretproject/.*"
-	//     }
-	//   ]
+	// -   {
+	// -     "name": "myorg/myproject/myrepo"
+	// -   },
+	// -   {
+	// -     "name": "myorg/myproject/myotherrepo"
+	// -   },
+	// -   {
+	// -     "pattern": "^topsecretproject/.*"
+	// -   }
+	// - ]
+	"exclude": null,
+
+	// SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`.
+	"gitSSHCipher": null,
+
+	// SSH keys to use when cloning Git repo.
+	"gitSSHCredential": null,
 
 	// The type of Git URLs to use for cloning and fetching Git repositories.
-	//
 	// If "http", Sourcegraph will access repositories using Git URLs of the form http(s)://dev.azure.com/myrepo.git.
-	//
-	// If "ssh", Sourcegraph will access repositories using Git URLs of the form git@ssh.dev.azure.com:v3/myrepo. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.
+	// If "ssh", Sourcegraph will access repositories using Git URLs of the form git@ssh.dev.azure.com:v3/myrepo. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth.
+	// Valid options: "http", "ssh"
 	"gitURLType": "http",
 
+	// The maximum number of repos that will be deleted per sync. A value of 0 or less indicates no maximum.
+	"maxDeletions": 0,
+
 	// An array of organization names identifying Azure DevOps organizations whose repositories should be mirrored on Sourcegraph.
-	"orgs": null,
 	// Other example values:
-	// - ["name"]
 	// - [
-	//     "kubernetes",
-	//     "golang",
-	//     "facebook"
-	//   ]
+	// -   "name"
+	// - ]
+	// - [
+	// -   "kubernetes",
+	// -   "golang",
+	// -   "facebook"
+	// - ]
+	"orgs": null,
 
 	// An array of projects "org/project" strings specifying which Azure DevOps projects' repositories should be mirrored on Sourcegraph.
-	"projects": null,
 	// Other example values:
-	// - ["org/project"]
+	// - [
+	// -   "org/project"
+	// - ]
+	"projects": null,
+
+	// Rate limit applied when making background API requests.
+	"rateLimit": {
+		"enabled": false,
+		"requestsPerHour": 0
+	},
+
+	// The pattern used to generate the corresponding Sourcegraph repository name for a Azure DevOps repository.
+	// - "{host}" is replaced with the Azure DevOps URL's host (such as dev.azure.com)
+	// - "{orgName}" is replaced with the repository's parent projects owning organization (or collection on DevOps server)
+	// - "{projectName}" is replaced with the repository's parent project
+	// - "{repositoryName}" is replaced with the repository's name.
+	// For example, if your Azure DevOps is https://dev.azure.com and your Sourcegraph is https://src.example.com, then a repositoryPathPattern of "{host}/{orgName}/{projectName}/{repositoryName}" would mean that a Azure DevOps repository at https://dev.azure.com/MYORG/MYPROJECT/MYREPO is available on Sourcegraph at https://src.example.com/dev.azure.com/MYORG/MYPROJECT/MYREPO.
+	// It is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.
+	// Other example values:
+	// - "{projectName}/{repositoryName}"
+	"repositoryPathPattern": "{host}/{orgName}/{projectName}/{repositoryName}",
 
 	// The Personal Access Token associated with the Azure DevOps username used for authentication.
 	"token": null,
 
+	// REQUIRED:
 	// URL for Azure DevOps Services, set to https://dev.azure.com.
-	"url": null,
 	// Other example values:
 	// - "https://dev.azure.com"
+	"url": null,
 
-	// A username for authentication with the Azure DevOps code host.
-	"username": null
+	// REQUIRED:
+	// A username for authentication with the Azure DevOps code host. Typically an email address when connect to Azure DevOps Services (cloud) and a domain\username when connecting to Azure DevOp Server (onPrem)
+	"username": null,
+
+	// Windows account password (Azure Devops Server OnPrem Only): This is needed to clone the repo, the Token will be used for REST API calls
+	"windowsPassword": null
 }
 ```
 {/* SCHEMA_SYNC_END: admin/code_hosts/azuredevops.schema.json */}
-
 ## Configuration Notes
 
 ### Token Requirements

--- a/docs/admin/code_hosts/bitbucket_cloud.mdx
+++ b/docs/admin/code_hosts/bitbucket_cloud.mdx
@@ -118,56 +118,67 @@ Bitbucket Cloud connections support the following configuration options, which a
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/bitbucket_cloud.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T22:00:51Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
+	// Authentication alternatives: username + appPassword
+
 {
 	// The workspace access token to use when authenticating with Bitbucket Cloud.
 	"accessToken": null,
 
 	// The API URL of Bitbucket Cloud, such as https://api.bitbucket.org. Generally, admin should not modify the value of this option because Bitbucket Cloud is a public hosting platform.
-	"apiURL": null,
 	// Other example values:
 	// - "https://api.bitbucket.org"
+	"apiURL": null,
 
 	// The app password to use when authenticating to the Bitbucket Cloud. Also set the corresponding "username" field.
 	"appPassword": null,
 
 	// If non-null, enforces Bitbucket Cloud repository permissions. This requires that there is an item in the [site configuration json](https://sourcegraph.com/docs/admin/config/site_config#auth-providers) `auth.providers` field, of type "bitbucketcloud" with the same `url` field as specified in this `BitbucketCloudConnection`.
-	"authorization": null,
+	"authorization": {
+		"identityProvider": null
+	},
 
 	// A list of repositories to never mirror from Bitbucket Cloud. Takes precedence over "teams" configuration.
-	//
 	// Supports excluding by name ({"name": "myorg/myrepo"}) or by UUID ({"uuid": "{fceb73c7-cef6-4abe-956d-e471281126bd}"}).
-	"exclude": null,
 	// Other example values:
 	// - [
-	//     {
-	//       "name": "myorg/myrepo"
-	//     },
-	//     {
-	//       "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bc}"
-	//     }
-	//   ]
+	// -   {
+	// -     "name": "myorg/myrepo"
+	// -   },
+	// -   {
+	// -     "uuid": "{fceb73c7-cef6-4abe-956d-e471281126bc}"
+	// -   }
+	// - ]
 	// - [
-	//     {
-	//       "name": "myorg/myrepo"
-	//     },
-	//     {
-	//       "name": "myorg/myotherrepo"
-	//     },
-	//     {
-	//       "pattern": "^topsecretproject/.*"
-	//     }
-	//   ]
+	// -   {
+	// -     "name": "myorg/myrepo"
+	// -   },
+	// -   {
+	// -     "name": "myorg/myotherrepo"
+	// -   },
+	// -   {
+	// -     "pattern": "^topsecretproject/.*"
+	// -   }
+	// - ]
+	"exclude": null,
+
+	// SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`.
+	"gitSSHCipher": null,
+
+	// SSH keys to use when cloning Git repo.
+	"gitSSHCredential": null,
 
 	// The type of Git URLs to use for cloning and fetching Git repositories on this Bitbucket Cloud.
-	//
 	// If "http", Sourcegraph will access Bitbucket Cloud repositories using Git URLs of the form https://bitbucket.org/myteam/myproject.git.
-	//
 	// If "ssh", Sourcegraph will access Bitbucket Cloud repositories using Git URLs of the form git@bitbucket.org:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.
-	"gitURLType": "http",
+	// Valid options: "http", "ssh"
 	// Other example values:
 	// - "ssh"
+	"gitURLType": "http",
+
+	// The maximum number of repos that will be deleted per sync. A value of 0 or less indicates no maximum.
+	"maxDeletions": 0,
 
 	// Rate limit applied when making background API requests to Bitbucket Cloud.
 	"rateLimit": {
@@ -175,39 +186,47 @@ Bitbucket Cloud connections support the following configuration options, which a
 		"requestsPerHour": 7200
 	},
 
+	// An array of repository "projectKey/repositorySlug" strings specifying repositories to mirror on Sourcegraph.
+	// Other example values:
+	// - [
+	// -   "myproject/myrepo",
+	// -   "myproject/myotherrepo"
+	// - ]
+	"repos": null,
+
 	// The pattern used to generate the corresponding Sourcegraph repository name for a Bitbucket Cloud repository.
-	//
-	//  - "{host}" is replaced with the Bitbucket Cloud URL's host (such as bitbucket.org),  and "{nameWithOwner}" is replaced with the Bitbucket Cloud repository's "owner/path" (such as "myorg/myrepo").
-	//
+	// - "{host}" is replaced with the Bitbucket Cloud URL's host (such as bitbucket.org),  and "{nameWithOwner}" is replaced with the Bitbucket Cloud repository's "owner/path" (such as "myorg/myrepo").
 	// For example, if your Bitbucket Cloud is https://bitbucket.org and your Sourcegraph is https://src.example.com, then a repositoryPathPattern of "{host}/{nameWithOwner}" would mean that a Bitbucket Cloud repository at https://bitbucket.org/alice/my-repo is available on Sourcegraph at https://src.example.com/bitbucket.org/alice/my-repo.
-	//
 	// It is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.
 	"repositoryPathPattern": "{host}/{nameWithOwner}",
 
 	// An array of team names identifying Bitbucket Cloud teams whose repositories should be mirrored on Sourcegraph.
-	"teams": null,
 	// Other example values:
-	// - ["name"]
 	// - [
-	//     "kubernetes",
-	//     "golang",
-	//     "facebook"
-	//   ]
+	// -   "name"
+	// - ]
+	// - [
+	// -   "kubernetes",
+	// -   "golang",
+	// -   "facebook"
+	// - ]
+	"teams": null,
 
+	// REQUIRED:
 	// URL of Bitbucket Cloud, such as https://bitbucket.org. Generally, admin should not modify the value of this option because Bitbucket Cloud is a public hosting platform.
-	"url": null,
 	// Other example values:
 	// - "https://bitbucket.org"
+	"url": null,
 
 	// The username to use when authenticating to the Bitbucket Cloud. Also set the corresponding "appPassword" field.
 	"username": null,
 
+	// ⚠️  DEPRECATED: Deprecated in favour of first class webhooks. See https://sourcegraph.com/docs/admin/config/webhooks/incoming#deprecation-notice
 	// A shared secret used to authenticate incoming webhooks (minimum 12 characters).
 	"webhookSecret": null
 }
 ```
 {/* SCHEMA_SYNC_END: admin/code_hosts/bitbucket_cloud.schema.json */}
-
 ## Configuration Notes
 
 Bitbucket Cloud connections provide streamlined configuration for cloud-hosted repositories:

--- a/docs/admin/code_hosts/bitbucket_server.mdx
+++ b/docs/admin/code_hosts/bitbucket_server.mdx
@@ -209,67 +209,90 @@ Bitbucket Server / Bitbucket Data Center connections support the following confi
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/bitbucket_server.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T22:00:50Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
+	// Authentication alternatives: token OR password
+
 {
 	// If non-null, enforces Bitbucket Server / Bitbucket Data Center repository permissions.
-	"authorization": null,
+	"authorization": {
+		"identityProvider": {
+			"type": null
+		},
+		"oauth": {
+			"consumerKey": null,
+			"signingKey": null
+		},
+		"oauth2": false
+	},
 
 	// TLS certificate of the Bitbucket Server / Bitbucket Data Center instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
-	"certificate": null,
 	// Other example values:
 	// - "-----BEGIN CERTIFICATE-----\n..."
+	"certificate": null,
 
 	// A list of repositories to never mirror from this Bitbucket Server / Bitbucket Data Center instance. Takes precedence over "repos" and "repositoryQuery".
-	//
 	// Supports excluding by name ({"name": "projectKey/repositorySlug"}) or by ID ({"id": 42}).
-	"exclude": null,
 	// Other example values:
 	// - [
-	//     {
-	//       "name": "myproject/myrepo"
-	//     },
-	//     {
-	//       "id": 42
-	//     }
-	//   ]
+	// -   {
+	// -     "name": "myproject/myrepo"
+	// -   },
+	// -   {
+	// -     "id": 42
+	// -   }
+	// - ]
 	// - [
-	//     {
-	//       "name": "myproject/myrepo"
-	//     },
-	//     {
-	//       "name": "myproject/myotherrepo"
-	//     },
-	//     {
-	//       "name": "~USER/theirrepo"
-	//     },
-	//     {
-	//       "pattern": "^topsecretproject/.*"
-	//     }
-	//   ]
+	// -   {
+	// -     "name": "myproject/myrepo"
+	// -   },
+	// -   {
+	// -     "name": "myproject/myotherrepo"
+	// -   },
+	// -   {
+	// -     "name": "~USER/theirrepo"
+	// -   },
+	// -   {
+	// -     "pattern": "^topsecretproject/.*"
+	// -   }
+	// - ]
+	"exclude": null,
 
 	// Whether or not personal repositories should be excluded or not. When true, Sourcegraph will ignore personal repositories it may have access to. See https://sourcegraph.com/docs/integration/bitbucket_server#excluding-personal-repositories for more information.
 	"excludePersonalRepositories": false,
 
+	// SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`.
+	"gitSSHCipher": null,
+
+	// SSH keys to use when cloning Git repo.
+	"gitSSHCredential": null,
+
 	// The type of Git URLs to use for cloning and fetching Git repositories on this Bitbucket Server / Bitbucket Data Center instance.
-	//
 	// If "http", Sourcegraph will access Bitbucket Server / Bitbucket Data Center repositories using Git URLs of the form http(s)://bitbucket.example.com/scm/myproject/myrepo.git (using https: if the Bitbucket Server / Bitbucket Data Center instance uses HTTPS).
-	//
-	// If "ssh", Sourcegraph will access Bitbucket Server / Bitbucket Data Center repositories using Git URLs of the form ssh://git@example.bitbucket.org/myproject/myrepo.git. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.
-	"gitURLType": "http",
+	// If "ssh", Sourcegraph will access Bitbucket Server / Bitbucket Data Center repositories using Git URLs of the form ssh://git@example.bitbucket.org/myproject/myrepo.git. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth.
+	// Valid options: "http", "ssh"
 	// Other example values:
 	// - "ssh"
+	"gitURLType": "http",
 
 	// Deprecated and ignored field which will be removed entirely in the next release. BitBucket repositories can no longer be enabled or disabled explicitly.
 	"initialRepositoryEnablement": false,
 
+	// The maximum number of repos that will be deleted per sync. A value of 0 or less indicates no maximum.
+	"maxDeletions": 0,
+
 	// The password to use when authenticating to the Bitbucket Server / Bitbucket Data Center instance. Also set the corresponding "username" field.
-	//
 	// For Bitbucket Server / Bitbucket Data Center instances that support personal access tokens (Bitbucket Server / Bitbucket Data Center version 5.5 and newer), it is recommended to provide a token instead (in the "token" field).
 	"password": null,
 
 	// Configuration for Bitbucket Server / Bitbucket Data Center Sourcegraph plugin
-	"plugin": null,
+	"plugin": {
+		"permissions": "disabled",
+		"webhooks": {
+			"disableSync": false,
+			"secret": null
+		}
+	},
 
 	// An array of project key strings that defines a collection of repositories related to their associated project keys
 	"projectKeys": null,
@@ -281,57 +304,55 @@ Bitbucket Server / Bitbucket Data Center connections support the following confi
 	},
 
 	// An array of repository "projectKey/repositorySlug" strings specifying repositories to mirror on Sourcegraph.
-	"repos": null,
 	// Other example values:
 	// - [
-	//     "myproject/myrepo",
-	//     "myproject/myotherrepo",
-	//     "~USER/theirrepo"
-	//   ]
+	// -   "myproject/myrepo",
+	// -   "myproject/myotherrepo",
+	// -   "~USER/theirrepo"
+	// - ]
+	"repos": null,
 
 	// The pattern used to generate the corresponding Sourcegraph repository name for a Bitbucket Server / Bitbucket Data Center repository.
-	//
-	//  - "{host}" is replaced with the Bitbucket Server / Bitbucket Data Center URL's host (such as bitbucket.example.com)
-	//  - "{projectKey}" is replaced with the Bitbucket repository's parent project key (such as "PRJ")
-	//  - "{repositorySlug}" is replaced with the Bitbucket repository's slug key (such as "my-repo").
-	//
+	// - "{host}" is replaced with the Bitbucket Server / Bitbucket Data Center URL's host (such as bitbucket.example.com)
+	// - "{projectKey}" is replaced with the Bitbucket repository's parent project key (such as "PRJ")
+	// - "{repositorySlug}" is replaced with the Bitbucket repository's slug key (such as "my-repo").
 	// For example, if your Bitbucket Server / Bitbucket Data Center is https://bitbucket.example.com and your Sourcegraph is https://src.example.com, then a repositoryPathPattern of "{host}/{projectKey}/{repositorySlug}" would mean that a Bitbucket Server / Bitbucket Data Center repository at https://bitbucket.example.com/projects/PRJ/repos/my-repo is available on Sourcegraph at https://src.example.com/bitbucket.example.com/PRJ/my-repo.
-	//
 	// It is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.
-	"repositoryPathPattern": "{host}/{projectKey}/{repositorySlug}",
 	// Other example values:
 	// - "{projectKey}/{repositorySlug}"
+	"repositoryPathPattern": "{host}/{projectKey}/{repositorySlug}",
 
 	// An array of strings specifying which repositories to mirror on Sourcegraph. Each string is a URL query string with parameters that filter the list of returned repos. Examples: "?name=my-repo&projectname=PROJECT&visibility=private".
-	//
 	// The special string "none" can be used as the only element to disable this feature. Repositories matched by multiple query strings are only imported once. Here's the official Bitbucket Server / Bitbucket Data Center documentation about which query string parameters are valid: https://docs.atlassian.com/bitbucket-server/rest/6.1.2/bitbucket-rest.html#idp355
+	// Other example values:
+	// - [
+	// -   "?name=my-repo\u0026projectname=PROJECT\u0026visibility=private"
+	// - ]
 	"repositoryQuery": [
 		"none"
 	],
-	// Other example values:
-	// - [
-	//     "?name=my-repo\u0026projectname=PROJECT\u0026visibility=private"
-	//   ]
 
 	// A Bitbucket Server / Bitbucket Data Center personal access token with Read permissions. When using batch changes, the token needs Write permissions. Create one at https://[your-bitbucket-hostname]/plugins/servlet/access-tokens/add. Also set the corresponding "username" field.
-	//
 	// For Bitbucket Server / Bitbucket Data Center instances that don't support personal access tokens (Bitbucket Server / Bitbucket Data Center version 5.4 and older), specify user-password credentials in the "username" and "password" fields.
 	"token": null,
 
+	// REQUIRED:
 	// URL of a Bitbucket Server / Bitbucket Data Center instance, such as https://bitbucket.example.com.
-	"url": null,
 	// Other example values:
 	// - "https://bitbucket.example.com"
+	"url": null,
 
+	// REQUIRED:
 	// The username to use when authenticating to the Bitbucket Server / Bitbucket Data Center instance. Also set the corresponding "token" or "password" field.
 	"username": null,
 
 	// DEPRECATED: Switch to "plugin.webhooks"
-	"webhooks": null
+	"webhooks": {
+		"secret": null
+	}
 }
 ```
 {/* SCHEMA_SYNC_END: admin/code_hosts/bitbucket_server.schema.json */}
-
 ## Configuration Notes
 
 Bitbucket Server/Data Center connections provide comprehensive configuration options for enterprise environments:

--- a/docs/admin/code_hosts/gerrit.mdx
+++ b/docs/admin/code_hosts/gerrit.mdx
@@ -110,51 +110,80 @@ Gerrit connections support the following configuration options, which are specif
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/gerrit.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T22:00:54Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
 	// If non-null, enforces Gerrit repository permissions. This requires that there is an item in the [site configuration json](https://sourcegraph.com/docs/admin/config/site_config#auth-providers) `auth.providers` field, of type "gerrit" with the same `url` field as specified in this `GerritConnection`.
-	"authorization": null,
+	"authorization": {
+		"identityProvider": null
+	},
 
+	// A list of repositories to never mirror from this Gerrit instance. Takes precedence over "projects" configuration.
+	// Supports excluding by name ({"name": "owner/name"})
+	// Other example values:
+	// - [
+	// -   {
+	// -     "name": "docs"
+	// -   },
+	// -   {
+	// -     "name": "php/php-src"
+	// -   }
+	// - ]
+	"exclude": null,
+
+	// SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`.
+	"gitSSHCipher": null,
+
+	// SSH keys to use when cloning Git repo.
+	"gitSSHCredential": null,
+
+	// The type of Git URLs to use for cloning and fetching Git repositories on this Gerrit instance.
+	// If "http", Sourcegraph will access Gerrit repositories using Git URLs of the form http(s)://gerrit.example.com/a/myteam/myproject.git (using https: if the Gerrit instance uses HTTPS).
+	// If "ssh", Sourcegraph will access Gerrit repositories using Git URLs of the form git@gerrit.example.com:myteam/myproject.git. The exact hostname and port will be fetched from /ssh_info. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth.
+	// Valid options: "http", "ssh"
+	"gitURLType": "http",
+
+	// REQUIRED:
 	// The password associated with the Gerrit username used for authentication.
 	"password": null,
 
+	// Any number of query parameters as supported by the Gerrit REST API: https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html
+	// Other example values:
+	// - "query=name:kubernetes"
+	// - "r=.*test"
+	"projectQuery": null,
+
 	// An array of project strings specifying which Gerrit projects to mirror on Sourcegraph. If empty, all projects will be mirrored.
+	// Other example values:
+	// - [
+	// -   "name",
+	// -   "owner/name"
+	// - ]
+	// - [
+	// -   "docs",
+	// -   "kubernetes/kubernetes",
+	// -   "golang/go",
+	// -   "facebook/react"
+	// - ]
 	"projects": null,
-	// Other example values:
-	// - ["name","owner/name"]
-	// - [
-	//     "docs",
-	//     "kubernetes/kubernetes",
-	//     "golang/go",
-	//     "facebook/react"
-	//   ]
 
-	// A list of repositories to never mirror from this Gerrit instance. Takes precedence over \"projects\" configuration.
-	//
-	// Supports excluding by name ({"name": "owner/name"})
-	"exclude": null,
-	// Other example values:
-	// - [
-	//     {
-	//       "name": "docs"
-	//     },
-	//     {
-	//       "name": "php/php-src"
-	//     }
-	//   ]
+	// The pattern used to generate the corresponding Sourcegraph repository name for a Gerrit repository. In the pattern, the variable "{host}" is replaced with the Gerrit host (such as gerrit.example.com), and "{name}" is replaced with the Gerrit repository's name (such as "myrepo").
+	// For example, if your Gerrit URL is https://gerrit.example.com and your Sourcegraph URL is https://src.example.com, then a repositoryPathPattern of "{host}/{name}" would mean that a Gerrit repository at https://gerrit.example.com/myrepo is available on Sourcegraph at https://src.example.com/gerrit.example.com/myrepo.
+	// It is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.
+	"repositoryPathPattern": "{host}/{name}",
 
+	// REQUIRED:
 	// URL of a Gerrit instance, such as https://gerrit.example.com.
-	"url": null,
 	// Other example values:
 	// - "https://gerrit.example.com"
+	"url": null,
 
-	// A username for authentication withe the Gerrit code host.
+	// REQUIRED:
+	// A username for authentication with the Gerrit code host.
 	"username": null
 }
 ```
 {/* SCHEMA_SYNC_END: admin/code_hosts/gerrit.schema.json */}
-
 ## Configuration Notes
 
 ### HTTP Credentials Setup

--- a/docs/admin/code_hosts/github.mdx
+++ b/docs/admin/code_hosts/github.mdx
@@ -447,82 +447,105 @@ GitHub connections support the following configuration options, which are specif
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/github.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T22:00:48Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
+	// Authentication alternatives: token OR gitHubAppDetails OR externalAccount OR useRandomExternalAccount
+
 {
 	// If non-null, enforces GitHub repository permissions. This requires that there is an item in the [site configuration json](https://sourcegraph.com/docs/admin/config/site_config#auth-providers) `auth.providers` field, of type "github" with the same `url` field as specified in this `GitHubConnection`.
-	"authorization": null,
+	"authorization": {
+		"groupsCacheTTL": 72,
+		"markInternalReposAsPublic": false,
+		"syncInternalRepoPermissions": false
+	},
 
 	// TLS certificate of the GitHub Enterprise instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
-	"certificate": null,
 	// Other example values:
 	// - "-----BEGIN CERTIFICATE-----\n..."
+	"certificate": null,
 
-	// Only used to override the cloud_default column from a config file specified by EXTSVC_CONFIG_FILE
-	"cloudDefault": false,
-
-	// When set to true, this external service will be chosen as our 'Global' GitHub service. Only valid on Sourcegraph.com. Only one service can have this flag set.
-	"cloudGlobal": false,
-
-	// A list of repositories to never mirror from this GitHub instance. Takes precedence over "orgs", "repos", and "repositoryQuery" configuration.
-	//
-	// Supports excluding by name ({"name": "owner/name"}) or by ID ({"id": "MDEwOlJlcG9zaXRvcnkxMTczMDM0Mg=="}).
-	//
+	// A list of repository entries that define which repositories to never mirror from this GitHub instance. Takes precedence over "orgs", "repos", and "repositoryQuery" configuration.
+	// Each entry in the list can be either a name ({"name": "owner/name"}), an ID ({"id": "MDEwOlJlcG9zaXRvcnkxMTczMDM0Mg=="}), or a set of conditions like pattern, size, stars, etc. If multiple conditions are specified within a single entry, ALL of those conditions must be met for a repository to be excluded (AND). If multiple entries exist in the exclude list, a repository matching ANY of the entries (OR) will be excluded from syncing.
 	// Note: ID is the GitHub GraphQL ID, not the GitHub database ID. eg: "curl https://api.github.com/repos/vuejs/vue | jq .node_id"
-	"exclude": null,
 	// Other example values:
-	// - [{"forks":true}]
 	// - [
-	//     {
-	//       "name": "owner/name"
-	//     },
-	//     {
-	//       "id": "MDEwOlJlcG9zaXRvcnkxMTczMDM0Mg=="
-	//     }
-	//   ]
+	// -   {
+	// -     "forks": true
+	// -   }
+	// - ]
 	// - [
-	//     {
-	//       "name": "vuejs/vue"
-	//     },
-	//     {
-	//       "name": "php/php-src"
-	//     },
-	//     {
-	//       "pattern": "^topsecretorg/.*"
-	//     }
-	//   ]
+	// -   {
+	// -     "name": "owner/name"
+	// -   },
+	// -   {
+	// -     "id": "MDEwOlJlcG9zaXRvcnkxMTczMDM0Mg=="
+	// -   }
+	// - ]
 	// - [
-	//     {
-	//       "size": "\u003e= 1GB",
-	//       "stars": "\u003c 100"
-	//     }
-	//   ]
+	// -   {
+	// -     "name": "vuejs/vue"
+	// -   },
+	// -   {
+	// -     "name": "php/php-src"
+	// -   },
+	// -   {
+	// -     "pattern": "^topsecretorg/.*"
+	// -   }
+	// - ]
+	// - [
+	// -   {
+	// -     "size": "\u003e= 1GB",
+	// -     "stars": "\u003c 100"
+	// -   }
+	// - ]
+	"exclude": null,
+
+	// GitHub external account to use for authentication.
+	"externalAccount": {
+		"accountID": null,
+		"clientID": null
+	},
 
 	// If non-null, this is a GitHub App connection with some additional properties.
-	"gitHubAppDetails": null,
+	"gitHubAppDetails": {
+		"appID": 0,
+		"baseURL": null,
+		"cloneAllRepositories": false,
+		"installationID": 0
+	},
+
+	// SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`.
+	"gitSSHCipher": null,
+
+	// SSH keys to use when cloning Git repo.
+	"gitSSHCredential": null,
 
 	// The type of Git URLs to use for cloning and fetching Git repositories on this GitHub instance.
-	//
 	// If "http", Sourcegraph will access GitHub repositories using Git URLs of the form http(s)://github.com/myteam/myproject.git (using https: if the GitHub instance uses HTTPS).
-	//
-	// If "ssh", Sourcegraph will access GitHub repositories using Git URLs of the form git@github.com:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.
+	// If "ssh", Sourcegraph will access GitHub repositories using Git URLs of the form git@github.com:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth.
+	// Valid options: "http", "ssh"
 	"gitURLType": "http",
 
 	// DEPRECATED: The installation ID of the GitHub App.
 	"githubAppInstallationID": null,
 
 	// Deprecated and ignored field which will be removed entirely in the next release. GitHub repositories can no longer be enabled or disabled explicitly. Configure repositories to be mirrored via "repos", "exclude" and "repositoryQuery" instead.
-	"initialRepositoryEnablement": null,
+	"initialRepositoryEnablement": false,
+
+	// The maximum number of repos that will be deleted per sync. A value of 0 or less indicates no maximum.
+	"maxDeletions": 0,
 
 	// An array of organization names identifying GitHub organizations whose repositories should be mirrored on Sourcegraph.
-	"orgs": null,
 	// Other example values:
-	// - ["name"]
 	// - [
-	//     "kubernetes",
-	//     "golang",
-	//     "facebook"
-	//   ]
+	// -   "name"
+	// - ]
+	// - [
+	// -   "kubernetes",
+	// -   "golang",
+	// -   "facebook"
+	// - ]
+	"orgs": null,
 
 	// Whether the code host connection is in a pending state.
 	"pending": false,
@@ -534,66 +557,63 @@ GitHub connections support the following configuration options, which are specif
 	},
 
 	// An array of repository "owner/name" strings specifying which GitHub or GitHub Enterprise repositories to mirror on Sourcegraph.
-	"repos": null,
 	// Other example values:
-	// - ["owner/name"]
 	// - [
-	//     "kubernetes/kubernetes",
-	//     "golang/go",
-	//     "facebook/react"
-	//   ]
+	// -   "owner/name"
+	// - ]
+	// - [
+	// -   "kubernetes/kubernetes",
+	// -   "golang/go",
+	// -   "facebook/react"
+	// - ]
+	"repos": null,
 
 	// The pattern used to generate the corresponding Sourcegraph repository name for a GitHub or GitHub Enterprise repository. In the pattern, the variable "{host}" is replaced with the GitHub host (such as github.example.com), and "{nameWithOwner}" is replaced with the GitHub repository's "owner/path" (such as "myorg/myrepo").
-	//
 	// For example, if your GitHub Enterprise URL is https://github.example.com and your Sourcegraph URL is https://src.example.com, then a repositoryPathPattern of "{host}/{nameWithOwner}" would mean that a GitHub repository at https://github.example.com/myorg/myrepo is available on Sourcegraph at https://src.example.com/github.example.com/myorg/myrepo.
-	//
 	// It is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.
 	"repositoryPathPattern": "{host}/{nameWithOwner}",
 
 	// An array of strings specifying which GitHub or GitHub Enterprise repositories to mirror on Sourcegraph. The valid values are:
-	//
 	// - `public` mirrors all public repositories for GitHub Enterprise and is the equivalent of `none` for GitHub
-	//
 	// - `internal` mirrors all internal repositories for GitHub Enterprise and is the equivalent of `none` for GitHub
-	//
 	// - `affiliated` mirrors all repositories affiliated with the configured token's user:
-	// 	- Private repositories with read access
-	// 	- Public repositories owned by the user or their orgs
-	// 	- Public repositories with write access
-	//
+	// - Private repositories with read access
+	// - Public repositories owned by the user or their orgs
+	// - Public repositories with write access
 	// - `none` mirrors no repositories (except those specified in the `repos` configuration property or added manually)
-	//
 	// - All other values are executed as a GitHub advanced repository search as described at https://github.com/search/advanced. Example: to sync all repositories from the "sourcegraph" organization including forks the query would be "org:sourcegraph fork:true".
-	//
 	// If multiple values are provided, their results are unioned.
-	//
 	// If you need to narrow the set of mirrored repositories further (and don't want to enumerate it with a list or query set as above), create a new bot/machine user on GitHub or GitHub Enterprise that is only affiliated with the desired repositories.
 	"repositoryQuery": [
 		"none"
 	],
 
-	// A GitHub personal access token. Create one for GitHub.com at https://github.com/settings/tokens/new?description=Sourcegraph (for GitHub Enterprise, replace github.com with your instance's hostname). See https://sourcegraph.com/docs/admin/code_host_connection/github#github-api-token-and-access for which scopes are required for which use cases.
+	// A GitHub personal access token. Create one for GitHub.com at https://github.com/settings/tokens/new?description=Sourcegraph (for GitHub Enterprise, replace github.com with your instance's hostname). See https://sourcegraph.com/docs/admin/code_hosts/github#github-api-access for which scopes are required for which use cases.
 	"token": null,
 
+	// REQUIRED:
 	// URL of a GitHub instance, such as https://github.com or https://github-enterprise.example.com.
-	"url": null,
 	// Other example values:
 	// - "https://github.com"
 	// - "https://github-enterprise.example.com"
+	"url": null,
 
+	// Use a random user external account for authentication. When set, the code host connection will only be able to add public repositories.
+	"useRandomExternalAccount": false,
+
+	// ⚠️  DEPRECATED: Deprecated in favour of first class webhooks. See https://sourcegraph.com/docs/admin/config/webhooks/incoming#deprecation-notice
 	// An array of configurations defining existing GitHub webhooks that send updates back to Sourcegraph.
-	"webhooks": null
 	// Other example values:
 	// - [
-	//     {
-	//       "org": "yourorgname",
-	//       "secret": "webhook-secret"
-	//     }
-	//   ]
+	// -   {
+	// -     "org": "yourorgname",
+	// -     "secret": "webhook-secret"
+	// -   }
+	// - ]
+	"webhooks": null
 }
 ```
 {/* SCHEMA_SYNC_END: admin/code_hosts/github.schema.json */}
-
 ## Default branch
 
 Sourcegraph displays search results from the default branch of a repository when no `revision:` [parameter](/code-search/queries#repository-revisions) is specified. If you'd like the search results to be displayed from another branch by default, you may [change a repo's default branch on the github repo settings page](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/changing-the-default-branch). If this is not an option, consider using [search contexts](/code-search/working/search_contexts) instead.

--- a/docs/admin/code_hosts/gitlab.mdx
+++ b/docs/admin/code_hosts/gitlab.mdx
@@ -187,104 +187,110 @@ See [Internal rate limits](/admin/code_hosts/rate_limits#internal-rate-limits).
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/gitlab.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T22:00:49Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
 	// If non-null, enforces GitLab repository permissions. This requires that there be an item in the `auth.providers` field of type "gitlab" with the same `url` field as specified in this `GitLabConnection`.
-	"authorization": null,
+	"authorization": {
+		"identityProvider": {
+			"type": null
+		}
+	},
 
 	// TLS certificate of the GitLab instance. This is only necessary if the certificate is self-signed or signed by an internal CA. To get the certificate run `openssl s_client -connect HOST:443 -showcerts < /dev/null 2> /dev/null | openssl x509 -outform PEM`. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
-	"certificate": null,
 	// Other example values:
 	// - "-----BEGIN CERTIFICATE-----\n..."
+	"certificate": null,
 
-	// Only used to override the cloud_default column from a config file specified by EXTSVC_CONFIG_FILE
-	"cloudDefault": false,
-
-	// When set to true, this external service will be chosen as our 'Global' GitLab service. Only valid on Sourcegraph.com. Only one service can have this flag set.
-	"cloudGlobal": false,
-
-	// A list of projects to never mirror from this GitLab instance. Takes precedence over \"projects\" and \"projectQuery\" configuration. You can exclude projects by: name ({"name": "group/name"}), ID ({"id": 42}), regular expression matching pattern ({"pattern": "^group/project-.*"}), or by excluding empty repositories ({"emptyRepos": true}).
-	"exclude": null,
+	// A list of projects to never mirror from this GitLab instance. Takes precedence over "projects" and "projectQuery" configuration. You can exclude projects by: name ({"name": "group/name"}), ID ({"id": 42}), regular expression matching pattern ({"pattern": "^group\/project-.*"}), or by excluding empty repositories ({"emptyRepos": true}).
 	// Other example values:
 	// - [
-	//     {
-	//       "name": "group/name"
-	//     },
-	//     {
-	//       "id": 42
-	//     },
-	//     {
-	//       "emptyRepos": true
-	//     }
-	//   ]
+	// -   {
+	// -     "name": "group/name"
+	// -   },
+	// -   {
+	// -     "id": 42
+	// -   },
+	// -   {
+	// -     "emptyRepos": true
+	// -   }
+	// - ]
 	// - [
-	//     {
-	//       "name": "gitlab-org/gitlab-ee"
-	//     },
-	//     {
-	//       "name": "gitlab-com/www-gitlab-com"
-	//     }
-	//   ]
+	// -   {
+	// -     "name": "gitlab-org/gitlab-ee"
+	// -   },
+	// -   {
+	// -     "name": "gitlab-com/www-gitlab-com"
+	// -   }
+	// - ]
+	"exclude": null,
+
+	// SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`.
+	"gitSSHCipher": null,
+
+	// SSH keys to use when cloning Git repo.
+	"gitSSHCredential": null,
 
 	// The type of Git URLs to use for cloning and fetching Git repositories on this GitLab instance.
-	//
 	// If "http", Sourcegraph will access GitLab repositories using Git URLs of the form http(s)://gitlab.example.com/myteam/myproject.git (using https: if the GitLab instance uses HTTPS).
-	//
 	// If "ssh", Sourcegraph will access GitLab repositories using Git URLs of the form git@example.gitlab.com:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.
+	// Valid options: "http", "ssh"
 	"gitURLType": "http",
 
 	// Deprecated and ignored field which will be removed entirely in the next release. GitLab repositories can no longer be enabled or disabled explicitly.
-	"initialRepositoryEnablement": null,
+	"initialRepositoryEnablement": false,
 
 	// If true, internal repositories will be accessible to all users on Sourcegraph as if they were public, and user permission syncs will no longer check for public repositories. This overrides repository permissions but allows easier discovery and access to internal repositories, and may be desirable if all users on the Sourcegraph instance should have access to all internal repositories anyways. Defaults to false.
 	"markInternalReposAsPublic": false,
 
+	// The maximum number of repos that will be deleted per sync. A value of 0 or less indicates no maximum.
+	"maxDeletions": 0,
+
 	// An array of transformations will apply to the repository name. Currently, only regex replacement is supported. All transformations happen after "repositoryPathPattern" is processed.
-	"nameTransformations": null,
 	// Other example values:
 	// - [
-	//     {
-	//       "regex": "\\.d/",
-	//       "replacement": "/"
-	//     },
-	//     {
-	//       "regex": "-git$",
-	//       "replacement": ""
-	//     }
-	//   ]
+	// -   {
+	// -     "regex": "\\.d/",
+	// -     "replacement": "/"
+	// -   },
+	// -   {
+	// -     "regex": "-git$",
+	// -     "replacement": ""
+	// -   }
+	// - ]
+	"nameTransformations": null,
 
+	// REQUIRED:
 	// An array of strings specifying which GitLab projects to mirror on Sourcegraph. Each string is a URL path and query that targets a GitLab API endpoint returning a list of projects. If the string only contains a query, then "projects" is used as the path. Examples: "?membership=true&search=foo", "groups/mygroup/projects".
-	//
 	// The special string "none" can be used as the only element to disable this feature. Projects matched by multiple query strings are only imported once. Here are a few endpoints that return a list of projects: https://docs.gitlab.com/ee/api/projects.html#list-all-projects, https://docs.gitlab.com/ee/api/groups.html#list-a-groups-projects, https://docs.gitlab.com/ee/api/search.html#scope-projects.
+	// Other example values:
+	// - [
+	// -   "?membership=true\u0026search=foo",
+	// -   "groups/mygroup/projects"
+	// - ]
 	"projectQuery": [
 		"none"
 	],
-	// Other example values:
-	// - [
-	//     "?membership=true\u0026search=foo",
-	//     "groups/mygroup/projects"
-	//   ]
 
 	// A list of projects to mirror from this GitLab instance. Supports including by name ({"name": "group/name"}) or by ID ({"id": 42}).
-	"projects": null,
 	// Other example values:
 	// - [
-	//     {
-	//       "name": "group/name"
-	//     },
-	//     {
-	//       "id": 42
-	//     }
-	//   ]
+	// -   {
+	// -     "name": "group/name"
+	// -   },
+	// -   {
+	// -     "id": 42
+	// -   }
+	// - ]
 	// - [
-	//     {
-	//       "name": "gnachman/iterm2"
-	//     },
-	//     {
-	//       "name": "gitlab-org/gitlab-ce"
-	//     }
-	//   ]
+	// -   {
+	// -     "name": "gnachman/iterm2"
+	// -   },
+	// -   {
+	// -     "name": "gitlab-org/gitlab-ce"
+	// -   }
+	// - ]
+	"projects": null,
 
 	// Rate limit applied when making background API requests to GitLab.
 	"rateLimit": {
@@ -293,51 +299,37 @@ See [Internal rate limits](/admin/code_hosts/rate_limits#internal-rate-limits).
 	},
 
 	// The pattern used to generate a the corresponding Sourcegraph repository name for a GitLab project. In the pattern, the variable "{host}" is replaced with the GitLab URL's host (such as gitlab.example.com), and "{pathWithNamespace}" is replaced with the GitLab project's "namespace/path" (such as "myteam/myproject").
-	//
 	// For example, if your GitLab is https://gitlab.example.com and your Sourcegraph is https://src.example.com, then a repositoryPathPattern of "{host}/{pathWithNamespace}" would mean that a GitLab project at https://gitlab.example.com/myteam/myproject is available on Sourcegraph at https://src.example.com/gitlab.example.com/myteam/myproject.
-	//
 	// It is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.
 	"repositoryPathPattern": "{host}/{pathWithNamespace}",
 
-	// A GitLab access token with "api" scope. Can be a personal access token (PAT) or an OAuth token. If you are enabling permissions with identity provider type "external", this token should also have "sudo" scope.
+	// REQUIRED:
+	// A GitLab access token with "api" scope. Can be a personal access token (PAT) or an OAuth token. If you are enabling permissions with identity provider type "username", this token should also have "sudo" scope.
 	"token": null,
 
 	// The OAuth token expiry (Unix timestamp in seconds)
-	"token.oauth.expiry": null,
+	"token.oauth.expiry": 0,
 
 	// The OAuth refresh token
 	"token.oauth.refresh": null,
 
 	// The type of the token
+	// Valid options: "pat", "oauth"
 	"token.type": "pat",
 
+	// REQUIRED:
 	// URL of a GitLab instance, such as https://gitlab.example.com or (for GitLab.com) https://gitlab.com.
-	"url": null,
 	// Other example values:
 	// - "https://gitlab.com"
 	// - "https://gitlab.example.com"
+	"url": null,
 
+	// ⚠️  DEPRECATED: Deprecated in favour of first class webhooks. See https://sourcegraph.com/docs/admin/config/webhooks/incoming#deprecation-notice
 	// An array of webhook configurations
 	"webhooks": null
 }
 ```
-
-## Native integration
-
-To provide out-of-the-box code navigation features to your users on GitLab, you will need to [configure your GitLab instance](https://docs.gitlab.com/ee/integration/sourcegraph.html). If you are using an HTTPS connection to GitLab, you will need to [configure HTTPS](/admin/http_https_configuration) for your Sourcegraph instance.
-
-The Sourcegraph instance's site admin must [update the `corsOrigin` site config property](/admin/config/site_config) to allow the GitLab instance to communicate with the Sourcegraph instance. For example:
-
-```json
-{
-  // ...
-  "corsOrigin":
-    "https://my-gitlab.example.com"
-  // ...
-}
-```
 {/* SCHEMA_SYNC_END: admin/code_hosts/gitlab.schema.json */}
-
 ## Configuration Notes
 
 GitLab connections provide flexible configuration options for different deployment scenarios:

--- a/docs/admin/code_hosts/gitolite.mdx
+++ b/docs/admin/code_hosts/gitolite.mdx
@@ -27,43 +27,54 @@ To connect Gitolite to Sourcegraph:
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/gitolite.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T22:00:54Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
 	// A list of repositories to never mirror from this Gitolite instance. Supports excluding by exact name ({"name": "foo"}).
-	"exclude": null,
 	// Other example values:
 	// - [
-	//     {
-	//       "name": "myrepo"
-	//     },
-	//     {
-	//       "pattern": ".*secret.*"
-	//     }
-	//   ]
+	// -   {
+	// -     "name": "myrepo"
+	// -   },
+	// -   {
+	// -     "pattern": ".*secret.*"
+	// -   }
+	// - ]
+	"exclude": null,
 
+	// SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`.
+	"gitSSHCipher": null,
+
+	// SSH keys to use when cloning Git repo.
+	"gitSSHCredential": null,
+
+	// REQUIRED:
 	// Gitolite host that stores the repositories (e.g., git@gitolite.example.com, ssh://git@gitolite.example.com:2222/).
-	"host": null,
 	// Other example values:
 	// - "git@gitolite.example.com"
 	// - "ssh://git@gitolite.example.com:2222/"
+	"host": null,
 
+	// ⚠️  DEPRECATED: DEPRECATED: the Phabricator integration with Gitolite code hosts is deprecated
 	// This is DEPRECATED
-	"phabricator": null,
+	"phabricator": {
+		"callsignCommand": null,
+		"url": null
+	},
 
+	// ⚠️  DEPRECATED: DEPRECATED: the Phabricator integration with Gitolite code hosts is deprecated
 	// This is DEPRECATED
 	"phabricatorMetadataCommand": null,
 
+	// REQUIRED:
 	// Repository name prefix that will map to this Gitolite host. This should likely end with a trailing slash. E.g., "gitolite.example.com/".
-	//
 	// It is important that the Sourcegraph repository name generated with this prefix be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.
-	"prefix": null
 	// Other example values:
 	// - "gitolite.example.com/"
+	"prefix": null
 }
 ```
 {/* SCHEMA_SYNC_END: admin/code_hosts/gitolite.schema.json */}
-
 ## Configuration Notes
 
 - **SSH Authentication Required**: Gitolite requires SSH key-based authentication. Ensure your Sourcegraph instance has proper SSH access to the Gitolite server.

--- a/docs/admin/code_hosts/other.mdx
+++ b/docs/admin/code_hosts/other.mdx
@@ -70,51 +70,49 @@ Repositories must be listed individually:
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/other_external_service.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T22:00:56Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
 	// A list of repositories to never mirror by name after applying repositoryPathPattern. Supports excluding by exact name ({"name": "myrepo"}) or regular expression ({"pattern": ".*secret.*"}).
-	"exclude": null,
 	// Other example values:
 	// - [
-	//     {
-	//       "name": "myrepo"
-	//     },
-	//     {
-	//       "pattern": ".*secret.*"
-	//     }
-	//   ]
+	// -   {
+	// -     "name": "myrepo"
+	// -   },
+	// -   {
+	// -     "pattern": ".*secret.*"
+	// -   }
+	// - ]
+	"exclude": null,
+
+	// SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`.
+	"gitSSHCipher": null,
+
+	// SSH keys to use when cloning Git repo.
+	"gitSSHCredential": null,
 
 	// Whether or not these repositories should be marked as public on Sourcegraph.com. Defaults to false.
 	"makeReposPublicOnDotCom": false,
 
+	// REQUIRED:
 	"repos": null,
 
 	// The pattern used to generate the corresponding Sourcegraph repository name for the repositories. In the pattern, the variable "{base}" is replaced with the Git clone base URL host and path, and "{repo}" is replaced with the repository path taken from the `repos` field.
-	//
 	// For example, if your Git clone base URL is https://git.example.com/repos and `repos` contains the value "my/repo", then a repositoryPathPattern of "{base}/{repo}" would mean that a repository at https://git.example.com/repos/my/repo is available on Sourcegraph at https://sourcegraph.example.com/git.example.com/repos/my/repo.
-	//
 	// It is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.
-	//
-	// Note: These patterns are ignored if using src-expose / src-serve / src-serve-local.
-	"repositoryPathPattern": "{base}/{repo}",
+	// Note: These patterns are ignored if using src-expose / src-serve.
 	// Other example values:
 	// - "pretty-host-name/{repo}"
+	"repositoryPathPattern": "{base}/{repo}",
 
-	// The root directory to walk for discovering local git repositories to mirror. To sync with local repositories and use this root property one must run Cody App and define the repos configuration property such as ["src-serve-local"].
-	"root": "",
-	// Other example values:
-	// - "path/to/my/repos"
-
-	"url": null
 	// Other example values:
 	// - "https://github.com/?access_token=secret"
 	// - "ssh://user@host.xz:2333/"
 	// - "git://host.xz:2333/"
+	"url": null
 }
 ```
 {/* SCHEMA_SYNC_END: admin/code_hosts/other_external_service.schema.json */}
-
 ## Configuration Notes
 
 - **Repository Path Pattern**: The `repositoryPathPattern` field controls how repository names appear in Sourcegraph. Use `{base}` for the clone URL base and `{repo}` for the repository path.

--- a/docs/admin/code_hosts/phabricator.mdx
+++ b/docs/admin/code_hosts/phabricator.mdx
@@ -79,9 +79,19 @@ The Sourcegraph instance's site admin must [update the `corsOrigin` site config 
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/phabricator.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T22:00:55Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
+	// SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`.
+	"gitSSHCipher": null,
+
+	// SSH keys to use when cloning Git repo.
+	"gitSSHCredential": null,
+
+	// The type of Git URLs to use for cloning and fetching Git repositories.
+	// Valid options: "http", "ssh"
+	"gitURLType": "http",
+
 	// The list of repositories available on Phabricator.
 	"repos": null,
 
@@ -89,13 +99,12 @@ The Sourcegraph instance's site admin must [update the `corsOrigin` site config 
 	"token": null,
 
 	// URL of a Phabricator instance, such as https://phabricator.example.com
-	"url": null
 	// Other example values:
 	// - "https://phabricator.example.com"
+	"url": null
 }
 ```
 {/* SCHEMA_SYNC_END: admin/code_hosts/phabricator.schema.json */}
-
 ## Configuration Notes
 
 - **Limited Support**: Phabricator support is limited and not expected to evolve due to Phabricator's end-of-life announcement.

--- a/docs/admin/config/settings.mdx
+++ b/docs/admin/config/settings.mdx
@@ -27,7 +27,7 @@ Settings options and their default values are shown below.
 
 {/* SCHEMA_SYNC_START: admin/config/settings.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T22:00:47Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
 	// Disables observability-related site alert banners.
@@ -40,59 +40,106 @@ Settings options and their default values are shown below.
 	"alerts.showPatchUpdates": true,
 
 	// Whether to run global searches over all repositories. On instances with many repositories, this can lead to issues such as: low quality results, slow response times, or significant load on the Sourcegraph instance. Defaults to true.
-	"basicCodeIntel.globalSearchesEnabled": null,
+	"basicCodeIntel.globalSearchesEnabled": false,
 
 	// Whether to include archived repositories in search results.
-	"basicCodeIntel.includeArchives": null,
+	"basicCodeIntel.includeArchives": false,
 
 	// Whether to include forked repositories in search results.
-	"basicCodeIntel.includeForks": null,
+	"basicCodeIntel.includeForks": false,
 
 	// Whether to use only indexed requests to the search API.
-	"basicCodeIntel.indexOnly": null,
+	"basicCodeIntel.indexOnly": false,
 
 	// The timeout (in milliseconds) for un-indexed search requests.
-	"basicCodeIntel.unindexedSearchTimeout": null,
+	"basicCodeIntel.unindexedSearchTimeout": 0,
 
 	// Whether to fetch multiple precise definitions and references on hover.
-	"codeIntel.disableRangeQueries": null,
+	"codeIntel.disableRangeQueries": false,
 
 	// Never fall back to search-based code intelligence.
-	"codeIntel.disableSearchBased": null,
+	"codeIntel.disableSearchBased": false,
 
 	// Whether to supplement precise references with search-based results.
-	"codeIntel.mixPreciseAndSearchBasedReferences": null,
+	"codeIntel.mixPreciseAndSearchBasedReferences": false,
 
 	// Whether to enable trace logging on the extension.
-	"codeIntel.traceExtension": null,
+	"codeIntel.traceExtension": false,
+
+	// Custom informational messages to display to users at Cody clients locations.
+	// Usually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that single user.
+	"cody.notices": null,
+
+	// Experimental features and settings.
+	"experimentalFeatures": {
+		"batchChangesExecution": true,
+		"boostRelevantRepositories": true,
+		"clientSearchResultRanking": "by-zoekt-ranking",
+		"codeInsightsCompute": false,
+		"codeInsightsRepoUI": "single-search-query",
+		"disableOrderBySimilarity": false,
+		"enableLazyBlobSyntaxHighlighting": true,
+		"enableLazyFileResultSyntaxHighlighting": true,
+		"enableSearchFilePrefetch": true,
+		"enableSidebarFilePrefetch": true,
+		"fuzzyFinder": false,
+		"fuzzyFinderActions": false,
+		"fuzzyFinderAll": false,
+		"fuzzyFinderCaseInsensitiveFileCountThreshold": 25000,
+		"fuzzyFinderNavbar": false,
+		"fuzzyFinderRepositories": false,
+		"fuzzyFinderSymbols": false,
+		"goCodeCheckerTemplates": false,
+		"keywordSearch": true,
+		"newSearchNavigationUI": false,
+		"newSearchResultFiltersPanel": false,
+		"newSearchResultsUI": true,
+		"proactiveSearchResultsAggregations": true,
+		"searchContextsQuery": false,
+		"searchQueryInput": "v1",
+		"searchResultsAggregations": false,
+		"showCodeMonitoringLogs": false,
+		"symbolKindTags": false
+	},
 
 	// Whether the sidebar on the repo view should be open by default.
 	"fileSidebarVisibleByDefault": true,
 
 	// Custom page size for the history tab. If set, the history tab will populate that number of commits the first time the history tab is opened and then double the number of commits progressively.
-	"history.defaultPageSize": null,
+	"history.defaultPageSize": 0,
 
 	// Show absolute timestamps in the history panel and only show relative timestamps (e.g.: "5 days ago") in tooltip when hovering.
 	"history.preferAbsoluteTimestamps": false,
 
+	// The number of seconds to execute the aggregation for when running in extended timeout mode. This value should always be less than any proxy timeout if one exists. The maximum value is equal to searchLimits.maxTimeoutSeconds
+	"insights.aggregations.extendedTimeout": 55,
+
 	// DEPRECATED: Use `notices` instead.
-	//
 	// An array (often with just one element) of messages to display at the top of all pages, including for unauthenticated users. Users may dismiss a message (and any message with the same string value will remain dismissed for the user).
-	//
 	// Markdown formatting is supported.
-	//
 	// Usually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that user. (This is useful for testing the correctness of the message's Markdown formatting.)
-	//
 	// MOTD stands for "message of the day" (which is the conventional Unix name for this type of message).
 	"motd": null,
 
 	// Custom informational messages to display to users at specific locations in the Sourcegraph user interface.
-	//
 	// Usually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that single user.
 	"notices": null,
 
 	// Group of settings related to opening files in an editor.
-	"openInEditor": null,
+	"openInEditor": {
+		"custom.urlPattern": null,
+		"editorIds": null,
+		"jetbrains.forceApi": null,
+		"projectPaths.default": null,
+		"projectPaths.linux": null,
+		"projectPaths.mac": null,
+		"projectPaths.windows": null,
+		"replacements": null,
+		"vscode.isProjectPathUNCPath": false,
+		"vscode.remoteHostForSSH": null,
+		"vscode.useInsiders": false,
+		"vscode.useSSH": false
+	},
 
 	// If enabled, all members of the org will be treated as admins (e.g. can edit, apply, delete) for all batch changes created in that org.
 	"orgs.allMembersBatchChangesAdmin": false,
@@ -109,10 +156,10 @@ Settings options and their default values are shown below.
 	// Whether query patterns are treated case sensitively. Patterns are case insensitive by default.
 	"search.defaultCaseSensitive": false,
 
-	// Defines default properties for search behavior. The default is `smart`, which provides query assistance that automatically runs alternative queries when appropriate. When `precise`, search behavior strictly searches for the precise meaning of the query.
+	// DEPRECATED: this setting is no longer read when the default 'keyword' patterntype is enabled, which always uses the 'precise' mode. Smart search will be removed in a future release.
 	"search.defaultMode": null,
 
-	// The default pattern type for search queries. Note: to disable keyword search and use the previous behavior, set "search.defaultPatternType: standard".
+	// The default pattern type that search queries will be interpreted as.
 	"search.defaultPatternType": null,
 
 	// The number of results we send down during a search. Note: this is different to the count: in the query. The search will continue once we hit displayLimit and updated filters and statistics will continue to stream down. Defaults to 1500.
@@ -127,29 +174,14 @@ Settings options and their default values are shown below.
 	// Whether searches should include searching forked repositories.
 	"search.includeForks": false,
 
-	// DEPRECATED: Saved search queries
-	"search.savedQueries": null,
-
 	// Predefined search snippets that can be appended to any search (also known as search scopes)
 	"search.scopes": null,
 
-//////////////////////////////////////////////////////////////
-// CodeInsights
-//////////////////////////////////////////////////////////////
-
-	// The number of seconds to execute the aggregation for when running in extended timeout mode. This value should always be less than any proxy timeout if one exists. The maximum value is equal to searchLimits.maxTimeoutSeconds
-	"insights.aggregations.extendedTimeout": 55,
-
-//////////////////////////////////////////////////////////////
-// Experimental
-//////////////////////////////////////////////////////////////
-
-	// Experimental features and settings.
-	"experimentalFeatures": null
+	// Enables default site wide search context. Only admins can set this. Individual users can override with their own search context.
+	"siteWideSearchContext": null
 }
 ```
 {/* SCHEMA_SYNC_END: admin/config/settings.schema.json */}
-
 ## Configuration Notes
 
 ### Settings Hierarchy and Inheritance

--- a/docs/admin/config/site_config.mdx
+++ b/docs/admin/config/site_config.mdx
@@ -21,361 +21,124 @@ All site configuration options and their default values are shown below.
 
 {/* SCHEMA_SYNC_START: admin/config/site.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T22:00:46Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
 	// Prompts user to install new browser for non es5
 	"RedirectUnsupportedBrowser": false,
 
-	// Configuration options for App only.
-	"app": null,
-	// Other example values:
-	// - {
-	//     "app": {
-	//       "dotcomAuthToken": "abc123"
-	//     }
-	//   }
+	// Enable/Disable attribution search for Cody-generated snippets
+	"attribution.enabled": false,
 
-	// Enables and configures password policy. This will allow admins to enforce password complexity and length requirements.
-	"auth.passwordPolicy": null,
-	// Other example values:
-	// - {
-	//     "enabled": true,
-	//     "numberOfSpecialCharacters": 1,
-	//     "requireAtLeastOneNumber": true,
-	//     "requireUpperandLowerCase": true
-	//   }
+	// Use this gateway parameters for customers that bring their own key. Otherwise gateway endpoint is used.
+	"attribution.gateway": {
+		"accessToken": null,
+		"endpoint": null
+	},
 
-	// When true, site admins will only be able to see private code they have access to via our authz system.
-	"authz.enforceForSiteAdmins": false,
-
-	// Time interval (in seconds) of how often each component picks up authorization changes in external services.
-	"authz.refreshInterval": 5,
-
-	// Reject unverified commits when creating a Batch Change
-	"batchChanges.rejectUnverifiedCommit": false,
-
-	// Customize Sourcegraph homepage logo and search icon.
-	//
-	// Only available in Sourcegraph Enterprise.
-	"branding": null,
-	// Other example values:
-	// - {
-	//     "dark": {
-	//       "logo": "https://example.com/logo_dark.png",
-	//       "symbol": "https://example.com/search_symbol_dark_24x24.png"
-	//     },
-	//     "disableSymbolSpin": true,
-	//     "favicon": "https://example.com/favicon.ico",
-	//     "light": {
-	//       "logo": "https://example.com/logo_light.png",
-	//       "symbol": "https://example.com/search_symbol_light_24x24.png"
-	//     }
-	//   }
-
-	// Whether clone progress should be logged to a file. If enabled, logs are written to files in the OS default path for temporary files.
-	"cloneProgress.log": false,
-
-	// Configuration for the completions service.
-	"completions": null,
-	// Other example values:
-	// - {
-	//     "accessToken": "abc123",
-	//     "chatModel": "chat",
-	//     "completionModel": "code-completion",
-	//     "enabled": true,
-	//     "perUserDailyLimit": 100,
-	//     "provider": "openai"
-	//   }
-
-	// The rate limit (in requests per hour) for the default rate limiter in the rate limiters registry. By default this is disabled and the default rate limit is infinity.
-	"defaultRateLimit": -1,
-
-	// Configuration for embeddings service.
-	"embeddings": null,
-	// Other example values:
-	// - {
-	//     "accessToken": "your-access-token",
-	//     "dimensions": 1536,
-	//     "enabled": true,
-	//     "excludedFilePathPatterns": [
-	//       "*.svg",
-	//       "**/__mocks__/**",
-	//       "**/test/**"
-	//     ],
-	//     "model": "text-embedding-ada-002",
-	//     "url": "https://api.openai.com/v1/embeddings"
-	//   }
-
-	// Configuration for encryption keys used to encrypt data at rest in the database.
-	"encryption.keys": null,
-	// Other example values:
-	// - {
-	//     "externalServiceKey": {
-	//       "filePath": "/path/to/external_service.key",
-	//       "type": "mounted"
-	//     }
-	//   }
-	// - {
-	//     "userExternalAccountKey": {
-	//       "keyname": "projects/my-project/locations/global/keyRings/my-keyring/cryptoKeys/my-key",
-	//       "type": "cloudkms"
-	//     }
-	//   }
-
-	// The shared secret between Sourcegraph and executors. The value must contain at least 20 characters.
-	"executors.accessToken": null,
-	// Other example values:
-	// - "my-super-secret-access-token"
-
-	// The image to use for batch changes in executors. Use this value to pull from a custom image registry.
-	"executors.batcheshelperImage": "sourcegraph/batcheshelper",
-
-	// The tag to use for the batcheshelper image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.
-	"executors.batcheshelperImageTag": null,
-	// Other example values:
-	// - "4.1.0"
-
-	// The URL where Sourcegraph executors can reach the Sourcegraph instance. If not set, defaults to externalURL. URLs with a path (other than `/`) are not allowed. For Docker executors, the special hostname `host.docker.internal` can be used to refer to the Docker container's host.
-	"executors.frontendURL": null,
-	// Other example values:
-	// - "https://sourcegraph.example.com"
-
-	// The tag to use for the lsif-go image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.
-	"executors.lsifGoImage": null,
-	// Other example values:
-	// - "sourcegraph/lsif-go"
-
-	// The configuration for multiqueue executors.
-	"executors.multiqueue": null,
-
-	// The image to use for src-cli in executors. Use this value to pull from a custom image registry.
-	"executors.srcCLIImage": "sourcegraph/src-cli",
-
-	// The tag to use for the src-cli image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.
-	"executors.srcCLIImageTag": null,
-	// Other example values:
-	// - "4.1.0"
-
-	"exportUsageTelemetry": null,
-	// Other example values:
-	// - {
-	//     "batchSize": 1000,
-	//     "enabled": true,
-	//     "topicName": "usage-data",
-	//     "topicProjectName": "my-project"
-	//   }
-	// - {"enabled":false}
-
-	// The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`. Only root URLs are allowed.
-	"externalURL": null,
-	// Other example values:
-	// - "https://sourcegraph.example.com"
-
-	// DEPRECATED: The config options for Sourcegraph GitHub App.
-	"gitHubApp": null,
-	// Other example values:
-	// - {
-	//     "appID": "1234",
-	//     "clientID": "client-id",
-	//     "clientSecret": "client-secret",
-	//     "privateKey": "base64-encoded-private-key",
-	//     "slug": "sourcegraph"
-	//   }
-
-	// Record git operations that are executed on configured repositories.
-	"gitRecorder": null,
-	// Other example values:
-	// - {
-	//     "ignoredGitCommands": [
-	//       "show",
-	//       "rev-parse",
-	//       "log",
-	//       "diff",
-	//       "ls-tree"
-	//     ],
-	//     "repos": [
-	//       "github.com/sourcegraph/sourcegraph",
-	//       "github.com/gorilla/mux"
-	//     ],
-	//     "size": 1000
-	//   }
-
-	// Disk usage threshold at which to display warning notification. Value is a percentage.
-	"gitserver.diskUsageWarningThreshold": 90,
-
-	// Configuration for logging and alerting, including to external services.
-	"log": null,
-
-	// Notifications recieved from Sourcegraph.com to display in Sourcegraph.
-	"notifications": null,
-	// Other example values:
-	// - {
-	//     "key": "2023-03-10-my-key",
-	//     "message": "This is a test notification message."
-	//   }
-
-	// Configure notifications for Sourcegraph's built-in alerts. Not configurable for Sourcegraph Cloud instances.
-	"observability.alerts": null,
-	// Other example values:
-	// - {
-	//     "level": "critical",
-	//     "notifier": {
-	//       "channel": "#alerts",
-	//       "type": "slack",
-	//       "url": "https://hooks.slack.com/services/..."
-	//     }
-	//   }
-	// - {
-	//     "level": "warning",
-	//     "notifier": {
-	//       "address": "alerts@example.com",
-	//       "type": "email"
-	//     }
-	//   }
-
-	// EXPERIMENTAL: Configuration for client observability
-	"observability.client": null,
-	// Other example values:
-	// - {
-	//     "openTelemetry": {
-	//       "endpoint": "/-/debug/otlp"
-	//     }
-	//   }
-	// - {
-	//     "openTelemetry": {
-	//       "endpoint": "https://opentelemetry.example.com"
-	//     }
-	//   }
-
-	// Silence individual Sourcegraph alerts by identifier.
-	"observability.silenceAlerts": null,
-	// Other example values:
-	// - [
-	//     "warning_gitserver_disk_space_remaining"
-	//   ]
-	// - [
-	//     "critical_frontend_down",
-	//     "warning_high_load"
-	//   ]
-
-	// Configures distributed tracing within Sourcegraph. To learn more, refer to https://sourcegraph.com/docs/admin/observability/tracing
-	"observability.tracing": null,
-	// Other example values:
-	// - {
-	//     "debug": false,
-	//     "sampling": "selective",
-	//     "type": "opentelemetry",
-	//     "urlTemplate": "https://ui.honeycomb.io/$ORG/environments/$DATASET/trace?trace_id={{ .TraceID }}"
-	//   }
-	// - {
-	//     "debug": true,
-	//     "sampling": "all",
-	//     "type": "opentelemetry", // Jaeger now uses the OpenTelemetry format, the old jaeger format is deprecated
-	//     "urlTemplate": "{{ .ExternalURL }}/-/debug/jaeger/trace/{{ .TraceID }}"
-	//   }
-
-	// Configuration for organization invitations.
-	"organizationInvitations": null,
-	// Other example values:
-	// - {
-	//     "expiryTime": 48,
-	//     "signingKey": "your-signing-key"
-	//   }
-
-	// The maximum number of outbound requests to retain. This is a global limit across all outbound requests. If the limit is exceeded, older items will be deleted. If the limit is 0, no outbound requests are logged.
-	"outboundRequestLogLimit": 50,
-
-	// Time interval (in seconds) of how often cleanup worker should remove old jobs from permissions sync jobs table.
-	"permissions.syncJobCleanupInterval": 60,
-
-	// The number of last repo/user permission jobs to keep for history.
-	"permissions.syncJobsHistorySize": 5,
-
-	// Number of repo permissions to schedule for syncing in single scheduler iteration.
-	"permissions.syncOldestRepos": 10,
-
-	// Number of user permissions to schedule for syncing in single scheduler iteration.
-	"permissions.syncOldestUsers": 10,
-
-	// Don't sync a repo's permissions if it has synced within the last n seconds.
-	"permissions.syncReposBackoffSeconds": 60,
-
-	// Time interval (in seconds) of how often each component picks up authorization changes in external services.
-	"permissions.syncScheduleInterval": 15,
-
-	// Don't sync a user's permissions if they have synced within the last n seconds.
-	"permissions.syncUsersBackoffSeconds": 60,
-
-	// The maximum number of user-centric permissions syncing jobs that can be spawned concurrently. Server restart is required for changes to take effect.
-	"permissions.syncUsersMaxConcurrency": 1,
-
-	// The maximum number of repo-centric permissions syncing jobs that can be spawned concurrently. Server restart is required for changes to take effect.
-	"permissions.syncReposMaxConcurrency": 5,
-
-	"rateLimits": null,
-
-	// Enables redacting sensitive information from outbound requests. Important: We only respect this setting in development environments. In production, we always redact outbound requests.
-	"redactOutboundRequestHeaders": null,
-	// Other example values:
-	// - true
-
-	// Syntax highlighting configuration
-	"syntaxHighlighting": null,
-	// Other example values:
-	// - {
-	//     "engine": {
-	//       "default": "tree-sitter",
-	//       "overrides": {
-	//         "go": "syntect"
-	//       }
-	//     },
-	//     "languages": {
-	//       "extensions": {
-	//         "go": "go",
-	//         "ts": "typescript"
-	//       },
-	//       "patterns": [
-	//         {
-	//           "language": "cobol",
-	//           "match": "cobol_.*\\.txt"
-	//         }
-	//       ]
-	//     }
-	//   }
-
-	// Configuration for logging incoming webhooks.
-	"webhook.logging": null,
-	// Other example values:
-	// - {
-	//     "enabled": true,
-	//     "retention": "7d"
-	//   }
-
-//////////////////////////////////////////////////////////////
-// Authentication
-//////////////////////////////////////////////////////////////
+	// Hide Cody-generated snippets that have attribution matches ("enforced"), or show the snippet but passively inform the user about attribution ("permissive", the default). Requires attribution.enabled = true.
+	// Valid options: "permissive", "enforced"
+	"attribution.mode": "permissive",
 
 	// The config options for access requests
-	"auth.accessRequest": null,
 	// Other example values:
-	// - {"enabled":true}
-	// - {"enabled":false}
+	// - {
+	// -   "enabled": true
+	// - }
+	// - {
+	// -   "enabled": false
+	// - }
+	"auth.accessRequest": {
+		"enabled": true
+	},
+
+	// Settings for access tokens, which enable external tools to access the Sourcegraph API with the privileges of the user.
+	// Other example values:
+	// - {
+	// -   "allow": "site-admin-create",
+	// -   "allowNoExpiration": true,
+	// -   "defaultExpirationDays": 90,
+	// -   "expirationOptionDays": [
+	// -     7,
+	// -     14,
+	// -     30,
+	// -     60,
+	// -     90
+	// -   ]
+	// - }
+	// - {
+	// -   "allow": "none",
+	// -   "allowNoExpiration": false,
+	// -   "defaultExpirationDays": 45,
+	// -   "expirationOptionDays": [
+	// -     7,
+	// -     14,
+	// -     30,
+	// -     60,
+	// -     90
+	// -   ]
+	// - }
+	"auth.accessTokens": {
+		"allow": "all-users-create",
+		"allowNoExpiration": false,
+		"defaultExpirationDays": 90,
+		"expirationOptionDays": [
+			7,
+			14,
+			30,
+			60,
+			90
+		]
+	},
+
+	// IP allowlist for access to the Sourcegraph instance. If set, only requests from these IP addresses will be allowed. By default client IP is infered connected client IP address, and you may configure to use a request header to determine the user IP.
+	"auth.allowedIpAddress": {
+		"clientIpAddress": null,
+		"enabled": false,
+		"errorMessageTemplate": "Access from your IP address is not allowed.",
+		"trustedClientIpAddress": null,
+		"userIpAddress": null,
+		"userIpRequestHeaders": null
+	},
 
 	// Enables users to change their username after account creation. Warning: setting this to be true has security implications if you have enabled (or will at any point in the future enable) repository permissions with an option that relies on username equivalency between Sourcegraph and an external service or authentication provider. Do NOT set this to true if you are using non-built-in authentication OR rely on username equivalency for repository permissions.
 	"auth.enableUsernameChanges": false,
 
 	// The config options for account lockout
-	"auth.lockout": null,
 	// Other example values:
 	// - {
-	//     "consecutivePeriod": 300,
-	//     "failedAttemptThreshold": 3,
-	//     "lockoutPeriod": 600
-	//   }
+	// -   "consecutivePeriod": 300,
+	// -   "failedAttemptThreshold": 3,
+	// -   "lockoutPeriod": 600
+	// - }
+	"auth.lockout": {
+		"consecutivePeriod": 3600,
+		"failedAttemptThreshold": 5,
+		"lockoutPeriod": 1800
+	},
+
+	// The maximum duration a user session may be idle (not making any requests), after which it expires and the user is required to re-authenticate. Must be at least 1 hour. Defaults to no idle expiry.
+	// Other example values:
+	// - "2h"
+	"auth.maxSessionIdleDuration": "0",
 
 	// The minimum number of Unicode code points that a password must contain.
 	"auth.minPasswordLength": 12,
+
+	// Enables and configures password policy. This will allow admins to enforce password complexity and length requirements.
+	// Other example values:
+	// - {
+	// -   "enabled": true,
+	// -   "numberOfSpecialCharacters": 1,
+	// -   "requireAtLeastOneNumber": true,
+	// -   "requireUpperandLowerCase": true
+	// - }
+	"auth.passwordPolicy": {
+		"enabled": false,
+		"numberOfSpecialCharacters": 0,
+		"requireAtLeastOneNumber": true,
+		"requireUpperandLowerCase": true
+	},
 
 	// The duration (in seconds) that a password reset link is considered valid.
 	"auth.passwordResetLinkExpiry": 14400,
@@ -391,46 +154,53 @@ All site configuration options and their default values are shown below.
 		}
 	],
 
-	// WARNING: This option has been removed as of 3.8.
-	"auth.public": false,
-
-	// The duration of a user session, after which it expires and the user is required to re-authenticate. The default is 90 days. There is typically no need to set this, but some users may have specific internal security requirements.
-	//
+	// The maximum duration of a user session, after which it expires and the user is required to re-authenticate. The default is 90 days. Must be at least 1 hour. There is typically no need to set this, but some users may have specific internal security requirements.
 	// The string format is that of the Duration type in the Go time package (https://golang.org/pkg/time/#ParseDuration). E.g., "720h", "43200m", "2592000s" all indicate a timespan of 30 days.
-	//
-	// Note: changing this field does not affect the expiration of existing sessions. If you would like to enforce this limit for existing sessions, you must log out currently signed-in users. You can force this by removing all keys beginning with "session_" from the Redis store:
-	//
-	// * For deployments using `sourcegraph/server`: `docker exec $CONTAINER_ID redis-cli --raw keys 'session_*' | xargs docker exec $CONTAINER_ID redis-cli del`
-	// * For cluster deployments:
-	//   ```
-	//   REDIS_POD="$(kubectl get pods -l app=redis-store -o jsonpath={.items[0].metadata.name})";
-	//   kubectl exec "$REDIS_POD" -- redis-cli --raw keys 'session_*' | xargs kubectl exec "$REDIS_POD" -- redis-cli --raw del;
-	//   ```
-	"auth.sessionExpiry": "2160h",
 	// Other example values:
 	// - "168h"
+	"auth.sessionExpiry": "2160h",
 
 	// Validity expressed in minutes of the unlock account token
 	"auth.unlockAccountLinkExpiry": 5,
 
 	// Base64-encoded HMAC signing key to sign the JWT token for account unlock URLs
-	"auth.unlockAccountLinkSigningKey": null,
 	// Other example values:
 	// - "LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KYjNCbGJuTnphQzFyWlhrdGRqRUFBQUFBQkc1dmJtVUFBQUFFYm05dVpRQUFBQUFBQUFBQkFBQUJGZ0FBQUhVQkFBQQ"
+	"auth.unlockAccountLinkSigningKey": null,
 
-//////////////////////////////////////////////////////////////
-// BatchChanges
-//////////////////////////////////////////////////////////////
+	// Ensure that matching users are members of the specified orgs (auto-joining users to the orgs if they are not already a member). Provide a JSON object of the form `{"*": ["org1", "org2"]}`, where org1 and org2 are orgs that all users are automatically joined to. Currently the only supported key is `"*"`.
+	// Other example values:
+	// - {
+	// -   "*": [
+	// -     "myorg1"
+	// -   ]
+	// - }
+	"auth.userOrgMap": null,
+
+	// When true, site admins will only be able to see private code they have access to via our authz system.
+	"authz.enforceForSiteAdmins": false,
 
 	// Automatically delete branches created for Batch Changes changesets when the changeset is merged or closed, for supported code hosts. Overrides any setting on the repository on the code host itself.
 	"batchChanges.autoDeleteBranch": false,
 
 	// How long changesets will be retained after they have been detached from a batch change.
-	"batchChanges.changesetsRetention": null,
 	// Other example values:
 	// - "336h"
 	// - "48h"
 	// - "5h30m40s"
+	"batchChanges.changesetsRetention": null,
+
+	// A list of permitted container registries for use in batch changes, e.g., docker.io. If empty, all container registries are allowed. It cannot be used together with 'batchChanges.containerRegistryDenylist'
+	// Other example values:
+	// - "docker.io"
+	// - "artifactory.acme.com"
+	"batchChanges.containerRegistryAllowlist": null,
+
+	// A list of forbidden container registries for use in batch changes, e.g., docker.io. If empty, all container registries are allowed. It cannot be used together with 'batchChanges.containerRegistryAllowlist'
+	// Other example values:
+	// - "docker.io"
+	// - "artifactory.acme.com"
+	"batchChanges.containerRegistryDenylist": null,
 
 	// Hides Batch Changes warnings about webhooks not being configured.
 	"batchChanges.disableWebhooksWarning": false,
@@ -441,25 +211,52 @@ All site configuration options and their default values are shown below.
 	// When enabled, all branches created by batch changes will be pushed to forks of the original repository.
 	"batchChanges.enforceForks": false,
 
+	// Reject unverified commits when creating a Batch Change
+	"batchChanges.rejectUnverifiedCommit": false,
+
 	// When enabled, only site admins can create and apply batch changes.
 	"batchChanges.restrictToAdmins": false,
 
 	// Specifies specific windows, which can have associated rate limits, to be used when reconciling published changesets (creating or updating). All days and times are handled in UTC.
-	"batchChanges.rolloutWindows": null,
 	// Other example values:
 	// - {
-	//     "days": [
-	//       "saturday",
-	//       "sunday"
-	//     ],
-	//     "end": "20:00",
-	//     "rate": "10/hour",
-	//     "start": "06:00"
-	//   }
+	// -   "days": [
+	// -     "saturday",
+	// -     "sunday"
+	// -   ],
+	// -   "end": "20:00",
+	// -   "rate": "10/hour",
+	// -   "start": "06:00"
+	// - }
+	"batchChanges.rolloutWindows": null,
 
-//////////////////////////////////////////////////////////////
-// Code intelligence
-//////////////////////////////////////////////////////////////
+	// Maximum number of batch spec templates to display in the template library UI. Default is 20.
+	"batchChanges.templateLibrary.displayLimit": 20,
+
+	// Customize Sourcegraph homepage logo and search icon.
+	// Other example values:
+	// - {
+	// -   "dark": {
+	// -     "logo": "https://example.com/logo_dark.png",
+	// -     "symbol": "https://example.com/search_symbol_dark_24x24.png"
+	// -   },
+	// -   "disableSymbolSpin": true,
+	// -   "favicon": "https://example.com/favicon.ico",
+	// -   "light": {
+	// -     "logo": "https://example.com/logo_light.png",
+	// -     "symbol": "https://example.com/search_symbol_light_24x24.png"
+	// -   }
+	// - }
+	"branding": {
+		"brandName": "Sourcegraph",
+		"dark": null,
+		"disableSymbolSpin": false,
+		"favicon": null,
+		"light": null
+	},
+
+	// Whether clone progress should be logged to a file. If enabled, logs are written to files in the OS default path for temporary files.
+	"cloneProgress.log": false,
 
 	// Whether auto-indexing policies may apply to all repositories on the Sourcegraph instance. Default is false. The policyRepositoryMatchLimit setting still applies to such auto-indexing policies.
 	"codeIntelAutoIndexing.allowGlobalPolicies": false,
@@ -468,38 +265,551 @@ All site configuration options and their default values are shown below.
 	"codeIntelAutoIndexing.enabled": false,
 
 	// Overrides the default Docker images used by auto-indexing.
-	"codeIntelAutoIndexing.indexerMap": null,
 	// Other example values:
 	// - {
-	//     "go": "sourcegraph/lsif-go:latest",
-	//     "java": "sourcegraph/lsif-java:latest"
-	//   }
+	// -   "go": "sourcegraph/lsif-go:latest",
+	// -   "java": "sourcegraph/lsif-java:latest"
+	// - }
+	"codeIntelAutoIndexing.indexerMap": null,
 
 	// The maximum number of repositories to which a single auto-indexing policy can apply. Default is -1, which is unlimited.
 	"codeIntelAutoIndexing.policyRepositoryMatchLimit": -1,
 
-	// A cron expression indicating when to run the document reference counts graph reduction job.
-	"codeIntelRanking.documentReferenceCountsCronExpression": "@weekly",
+	// Configuration options for code monitors
+	"codeMonitors": {
+		"concurrency": 4,
+		"maxRuntime": 1,
+		"pollInterval": "5m"
+	},
 
-	// An arbitrary identifier used to group calculated rankings from SCIP data (excluding the SCIP export).
-	"codeIntelRanking.documentReferenceCountsDerivativeGraphKeyPrefix": null,
+	// Rules defining the repositories that will never be shared by Cody with third-party LLM providers.
+	"cody.contextFilters": {
+		"exclude": null,
+		"include": null
+	},
+
+	// Enable or disable Cody instance-wide. When Cody is disabled, all Cody endpoints and GraphQL queries will return errors, Cody will not show up in the site-admin sidebar, and Cody in the global navbar will only show a call-to-action for site-admins to enable Cody.
+	"cody.enabled": false,
+
+	// Whether to enable Cody role-based access controls. Only respected if cody.restrictUsersFeatureFlag is not set. See https://sourcegraph.com/docs/admin/access_control
+	"cody.permissions": true,
+
+	// DEPRECATED; see cody.permissions instead. PRIOR DESCRIPTION: Cody to only be enabled for users that have a feature flag labeled "cody" set to true. You must create a feature flag with this ID after enabling this setting: https://www.notion.so/sourcegraph/How-to-use-feature-flags-70f42bcacd9045d4a55de22f5dd87df0?source=copy_link. This setting only has an effect if cody.enabled is true.
+	"cody.restrictUsersFeatureFlag": false,
+
+	// Configuration for Server-side context API
+	"cody.serverSideContext": {
+		"reranker": {
+			"type": null
+		}
+	},
+
+	// Configuration for the completions service.
 	// Other example values:
-	// - ""
+	// - {
+	// -   "accessToken": "abc123",
+	// -   "chatModel": "chat",
+	// -   "completionModel": "code-completion",
+	// -   "enabled": true,
+	// -   "perUserDailyLimit": 100,
+	// -   "provider": "openai"
+	// - }
+	"completions": {
+		"accessToken": null,
+		"azureChatModel": null,
+		"azureCompletionModel": null,
+		"azureUseDeprecatedCompletionsAPIForOldModels": true,
+		"chatModel": null,
+		"chatModelMaxTokens": 0,
+		"completionModel": null,
+		"completionModelMaxTokens": 0,
+		"disableClientConfigAPI": false,
+		"enabled": true,
+		"endpoint": null,
+		"fastChatModel": null,
+		"fastChatModelMaxTokens": 0,
+		"model": null,
+		"perCommunityUserChatMonthlyInteractionLimit": 0,
+		"perCommunityUserChatMonthlyLLMRequestLimit": 0,
+		"perCommunityUserCodeCompletionsMonthlyInteractionLimit": 0,
+		"perCommunityUserCodeCompletionsMonthlyLLMRequestLimit": 0,
+		"perProUserChatDailyInteractionLimit": 0,
+		"perProUserChatDailyLLMRequestLimit": 0,
+		"perProUserCodeCompletionsDailyInteractionLimit": 0,
+		"perProUserCodeCompletionsDailyLLMRequestLimit": 0,
+		"perUserCodeCompletionsDailyLimit": 0,
+		"perUserDailyLimit": 0,
+		"provider": "sourcegraph",
+		"smartContextWindow": "enabled",
+		"user": null
+	},
 
-	// Enables/disables the document reference counts feature. Currently experimental.
-	"codeIntelRanking.documentReferenceCountsEnabled": false,
-
-	// An arbitrary identifier used to group calculated rankings from SCIP data (including the SCIP export).
-	"codeIntelRanking.documentReferenceCountsGraphKey": null,
+	// Configuration for the completions service.
 	// Other example values:
-	// - "dev"
+	// - {
+	// -   "chat": true
+	// - }
+	"configFeatures": {
+		"autoComplete": false,
+		"chat": false,
+		"chatVision": false,
+		"commands": false
+	},
 
-	// The interval at which to run the reduce job that computes document reference counts. Default is 24hrs.
-	"codeIntelRanking.staleResultsAge": 24,
+	// Enables the computation of contributor statistics per author and repository. Will all commits of each repository initially, and then work on deltas.
+	// Other example values:
+	// - true
+	"contributorsDataEnabled": true,
 
-//////////////////////////////////////////////////////////////
-// CodeInsights
-//////////////////////////////////////////////////////////////
+	// Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.
+	// Other example values:
+	// - "https://my-phabricator.example.com https://my-bitbucket.example.com https://my-gitlab.example.com"
+	"corsOrigin": null,
+
+	// (debug) controls the amount of symbol search parallelism. Defaults to 20. It is not recommended to change this outside of debugging scenarios. This option will be removed in a future version.
+	// Other example values:
+	// - "20"
+	"debug.search.symbolsParallelism": 0,
+
+	// The rate limit (in requests per hour) for the default rate limiter in the rate limiters registry. By default this is disabled and the default rate limit is infinity.
+	"defaultRateLimit": -1,
+
+	// Disable periodic syncs of configured code host connections (repository metadata, permissions, batch changes changesets, etc)
+	"disableAutoCodeHostSyncs": false,
+
+	// Disable periodically fetching git contents for existing repositories.
+	"disableAutoGitUpdates": false,
+
+	// Disable the feedback survey
+	"disableFeedbackSurvey": false,
+
+	// DEPRECATED. Has no effect.
+	"disableNonCriticalTelemetry": false,
+
+	// ⚠️  DEPRECATED: Deprecated because it's no longer supported and hasn't been working for a while.
+	// DEPRECATED! Disable redirects to sourcegraph.com when visiting public repositories that can't exist on this server.
+	// Other example values:
+	// - true
+	"disablePublicRepoRedirects": false,
+
+	// Configuration options for Sourcegraph.com only.
+	"dotcom": {
+		"codyGateway": {
+			"bigQueryDataset": null,
+			"bigQueryGoogleProjectID": null,
+			"bigQueryTable": null
+		},
+		"codyProConfig": {
+			"samsBackendOrigin": "",
+			"sscBackendOrigin": "",
+			"sscBaseUrl": "https://accounts.sourcegraph.com/cody",
+			"stripePublishableKey": null,
+			"useEmbeddedUI": false
+		},
+		"enterprisePortal.enableProxies": true,
+		"sams.clientID": null,
+		"sams.clientSecret": null,
+		"sams.server": null,
+		"samsDev.clientID": null,
+		"samsDev.clientSecret": null,
+		"samsDev.server": "https://accounts.sgdev.org",
+		"srcCliVersionCache": {
+			"enabled": false,
+			"github": {
+				"repository": {
+					"name": "src-cli",
+					"owner": "sourcegraph"
+				},
+				"token": null,
+				"uri": "https://github.com",
+				"webhookSecret": null
+			},
+			"interval": "1h"
+		}
+	},
+
+	// The "from" address for emails sent by this server.
+	// Please see https://sourcegraph.com/docs/admin/config/email
+	// Other example values:
+	// - "noreply@sourcegraph.example.com"
+	"email.address": null,
+
+	// The name to use in the "from" address for emails sent by this server.
+	// Other example values:
+	// - "Our Company Sourcegraph"
+	// - "Example Inc Sourcegraph"
+	"email.senderName": "Sourcegraph",
+
+	// The SMTP server used to send transactional emails.
+	// Please see https://sourcegraph.com/docs/admin/config/email
+	// Other example values:
+	// - {
+	// -   "authentication": "PLAIN",
+	// -   "host": "smtp.example.com",
+	// -   "password": "mypassword",
+	// -   "port": 465,
+	// -   "username": "alice"
+	// - }
+	"email.smtp": null,
+
+	// Configurable templates for some email types sent by Sourcegraph.
+	// Other example values:
+	// - {
+	// -   "resetPassword": {
+	// -     "body": "To reset your password on {{.Host}}, please click the link below:\n\n{{.URL}}\n\nIf you did not request a password reset, please ignore this email. Your password will not change until you click the link and set a new password.",
+	// -     "subject": "Reset your password on {{.Host}}"
+	// -   },
+	// -   "setPassword": {
+	// -     "body": "To set your password on {{.Host}} and complete your account registration, please click the link below:\n\n{{.URL}}\n\nYour username is: {{.Username}}\n\nIf you did not sign up for an account on {{.Host}}, please ignore this email.",
+	// -     "subject": "Set your password on {{.Host}}"
+	// -   }
+	// - }
+	"email.templates": {
+		"resetPassword": null,
+		"setPassword": null
+	},
+
+	// ⚠️  DEPRECATED: Deprecated changes to this section will not be respected.
+	// Configuration for embeddings service.
+	// Other example values:
+	// - {
+	// -   "accessToken": "your-access-token",
+	// -   "dimensions": 1536,
+	// -   "enabled": true,
+	// -   "excludedFilePathPatterns": [
+	// -     "*.svg",
+	// -     "**/__mocks__/**",
+	// -     "**/test/**"
+	// -   ],
+	// -   "model": "text-embedding-ada-002",
+	// -   "url": "https://api.openai.com/v1/embeddings"
+	// - }
+	"embeddings": {
+		"accessToken": null,
+		"dimensions": 0,
+		"enabled": true,
+		"endpoint": null,
+		"excludeChunkOnError": true,
+		"excludedFilePathPatterns": [
+			".*ignore",
+			".gitattributes",
+			".mailmap",
+			"*.csv",
+			"*.svg",
+			"*.xml",
+			"__fixtures__/",
+			"node_modules/",
+			"testdata/",
+			"mocks/",
+			"vendor/"
+		],
+		"fileFilters": {
+			"excludedFilePathPatterns": [
+				".*ignore",
+				".gitattributes",
+				".mailmap",
+				"*.csv",
+				"*.svg",
+				"*.xml",
+				"__fixtures__/",
+				"node_modules/",
+				"testdata/",
+				"mocks/",
+				"vendor/"
+			],
+			"includedFilePathPatterns": null,
+			"maxFileSizeBytes": 1000000
+		},
+		"incremental": true,
+		"maxEmbeddingsPerRepo": 0,
+		"minimumInterval": "24h",
+		"model": null,
+		"perCommunityUserEmbeddingsMonthlyLimit": 0,
+		"perProUserEmbeddingsMonthlyLimit": 0,
+		"policyRepositoryMatchLimit": "5000",
+		"provider": null,
+		"url": null
+	},
+
+	// Configuration for encryption keys used to encrypt data at rest in the database.
+	// Other example values:
+	// - {
+	// -   "externalServiceKey": {
+	// -     "filePath": "/path/to/external_service.key",
+	// -     "type": "mounted"
+	// -   }
+	// - }
+	// - {
+	// -   "userExternalAccountKey": {
+	// -     "keyname": "projects/my-project/locations/global/keyRings/my-keyring/cryptoKeys/my-key",
+	// -     "type": "cloudkms"
+	// -   }
+	// - }
+	"encryption.keys": {
+		"batchChangesCredentialKey": null,
+		"cacheSize": 2048,
+		"enableCache": false,
+		"executorSecretKey": null,
+		"externalServiceKey": null,
+		"gitHubAppKey": null,
+		"outboundWebhookKey": null,
+		"userExternalAccountKey": null,
+		"webhookKey": null,
+		"webhookLogKey": null
+	},
+
+	// Configure completion credits entitlement enablement
+	"entitlements.completionCredits": {
+		"mode": "disabled"
+	},
+
+	// The shared secret between Sourcegraph and executors. The value must contain at least 20 characters.
+	// Other example values:
+	// - "my-super-secret-access-token"
+	"executors.accessToken": null,
+
+	// The image to use for batch changes in executors when using native execution. Use this value to pull from a custom image registry.
+	"executors.batcheshelperImage": "sourcegraph/batcheshelper",
+
+	// The tag to use for the batcheshelper image in executors when using native execution. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.
+	// Other example values:
+	// - "4.1.0"
+	"executors.batcheshelperImageTag": null,
+
+	// The URL where Sourcegraph executors can reach the Sourcegraph instance. If not set, defaults to externalURL. URLs with a path (other than `/`) are not allowed. For Docker executors, the special hostname `host.docker.internal` can be used to refer to the Docker container's host.
+	// Other example values:
+	// - "https://sourcegraph.example.com"
+	"executors.frontendURL": null,
+
+	// The tag to use for the lsif-go image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.
+	// Other example values:
+	// - "sourcegraph/lsif-go"
+	"executors.lsifGoImage": null,
+
+	// The configuration for multiqueue executors.
+	"executors.multiqueue": {
+		"dequeueCacheConfig": {
+			"batches": {
+				"limit": 50,
+				"weight": 4
+			},
+			"codeintel": {
+				"limit": 250,
+				"weight": 1
+			}
+		}
+	},
+
+	// The image to use for src-cli in executors. Use this value to pull from a custom image registry.
+	"executors.srcCLIImage": "sourcegraph/src-cli",
+
+	// The tag to use for the src-cli image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.
+	// Other example values:
+	// - "4.1.0"
+	"executors.srcCLIImageTag": null,
+
+	// Experimental features and settings.
+	// Other example values:
+	// - {
+	// -   "customGitFetch": [
+	// -     {
+	// -       "domainPath": "somecodehost.com/path/to/repo",
+	// -       "fetch": "customgitbinary someflag"
+	// -     },
+	// -     {
+	// -       "domainPath": "somecodehost.com/path/to/anotherrepo",
+	// -       "fetch": "customgitbinary someflag anotherflag"
+	// -     }
+	// -   ]
+	// - }
+	// - {
+	// -   "tls.external": {
+	// -     "certificates": [
+	// -       "-----BEGIN CERTIFICATE-----\n..."
+	// -     ],
+	// -     "insecureSkipVerify": true
+	// -   }
+	// - }
+	"experimentalFeatures": {
+		"batchChanges.enableForkNameSuffix": false,
+		"batchChanges.enablePerforce": false,
+		"codeintelSyntacticIndexing.enabled": false,
+		"cody.auditLog": {
+			"enabled": false
+		},
+		"codyContextIgnore": false,
+		"commitGraphUpdates": {
+			"defaultBranchOnly": null
+		},
+		"customGitFetch": null,
+		"debug.log": {
+			"extsvc.gitlab": false
+		},
+		"deepSearch.enabled": false,
+		"deepSearch.model": "anthropic::2024-10-22::claude-sonnet-4-latest",
+		"deepSearch.sharing.enabled": false,
+		"enableGithubInternalRepoVisibility": false,
+		"enablePermissionsWebhooks": false,
+		"enableStorm": false,
+		"eventLogging": "enabled",
+		"gitServerPinnedRepos": null,
+		"goPackages": "disabled",
+		"insightsAlternateLoadingStrategy": false,
+		"insightsBackfillerV2": true,
+		"insightsDataRetention": true,
+		"jvmPackages": "disabled",
+		"languageDetection": {
+			"graphQL": "useFileContents"
+		},
+		"npmPackages": "disabled",
+		"pagure": "disabled",
+		"passwordPolicy": {
+			"enabled": true,
+			"minimumLength": 12,
+			"numberOfSpecialCharacters": 2,
+			"requireAtLeastOneNumber": true,
+			"requireUpperandLowerCase": true
+		},
+		"perforceChangelistMapping": "enabled",
+		"pythonPackages": "disabled",
+		"ranking": {
+			"flushWallTimeMS": 500,
+			"maxQueueMatchCount": -1,
+			"maxQueueSizeBytes": -1,
+			"maxReorderDurationMS": 0,
+			"maxReorderQueueSize": 24,
+			"repoScores": {}
+		},
+		"rateLimitAnonymous": 500,
+		"rubyPackages": "disabled",
+		"rustPackages": "disabled",
+		"scipBasedAPIs": true,
+		"search.index.branches": null,
+		"search.index.query.contexts": false,
+		"search.index.revisions": null,
+		"search.sanitization": {
+			"orgName": null,
+			"sanitizePatterns": null
+		},
+		"searchJobs": false,
+		"structuralSearch": "disabled",
+		"subRepoPermissions": {
+			"allowCodeInsights": false,
+			"enabled": false,
+			"enforceIPRestrictions": false,
+			"ipParseCacheSize": 1000,
+			"redactInaccessibleCommits": false,
+			"rulesInterpretationMode": "unified",
+			"userCacheSize": 1000,
+			"userCacheTTLSeconds": 10
+		},
+		"tls.external": {
+			"certificates": null,
+			"insecureSkipVerify": false
+		}
+	},
+
+	// The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`. Only root URLs are allowed.
+	// Other example values:
+	// - "https://sourcegraph.example.com"
+	"externalURL": null,
+
+	// JSON array of configuration that maps from Git clone URL to repository name. Sourcegraph automatically resolves remote clone URLs to their proper code host. However, there may be non-remote clone URLs (e.g., in submodule declarations) that Sourcegraph cannot automatically map to a code host. In this case, use this field to specify the mapping. The mappings are tried in the order they are specified and take precedence over automatic mappings.
+	// Other example values:
+	// - [
+	// -   {
+	// -     "from": "^../(?P\u003cname\u003e\\w+)$",
+	// -     "to": "github.com/user/{name}"
+	// -   }
+	// - ]
+	"git.cloneURLToRepositoryName": null,
+
+	// DEPRECATED: The config options for Sourcegraph GitHub App.
+	// Other example values:
+	// - {
+	// -   "appID": "1234",
+	// -   "clientID": "client-id",
+	// -   "clientSecret": "client-secret",
+	// -   "privateKey": "base64-encoded-private-key",
+	// -   "slug": "sourcegraph"
+	// - }
+	"gitHubApp": {
+		"appID": null,
+		"clientID": null,
+		"clientSecret": null,
+		"privateKey": null,
+		"slug": null
+	},
+
+	// Maximum number of seconds that a long Git command (e.g. clone or remote update) is allowed to execute. The default is 7200 seconds, or 2 hours.
+	"gitLongCommandTimeout": 7200,
+
+	// Maximum number of remote code host git operations (e.g. clone or ls-remote) to be run per second per gitserver. Default is -1, which is unlimited.
+	"gitMaxCodehostRequestsPerSecond": -1,
+
+	// Maximum number of git clone processes that will be run concurrently per gitserver to update repositories. <= 0 means disabled.
+	"gitMaxConcurrentCleanups": 5,
+
+	// Maximum number of git clone processes that will be run concurrently per gitserver to update repositories. Note: the global git update scheduler respects gitMaxConcurrentClones. However, we allow each gitserver to run upto gitMaxConcurrentClones to allow for urgent fetches. Urgent fetches are used when a user is browsing a PR and we do not have the commit yet.
+	"gitMaxConcurrentClones": 5,
+
+	// Record git operations that are executed on configured repositories.
+	// Other example values:
+	// - {
+	// -   "ignoredGitCommands": [
+	// -     "show",
+	// -     "rev-parse",
+	// -     "log",
+	// -     "diff",
+	// -     "ls-tree"
+	// -   ],
+	// -   "repos": [
+	// -     "github.com/sourcegraph/sourcegraph",
+	// -     "github.com/gorilla/mux"
+	// -   ],
+	// -   "size": 1000
+	// - }
+	"gitRecorder": {
+		"ignoredGitCommands": [
+			"show",
+			"rev-parse",
+			"log",
+			"diff",
+			"ls-tree"
+		],
+		"repos": null,
+		"size": 10000
+	},
+
+	// ⚠️  DEPRECATED: Deprecated because it's no longer supported. Sourcegraph relies on user traffic, webhooks, and heuristics now.
+	// DEPRECATED: As of Sourcegraph 5.10, this option is no longer in use. Remove this block.
+	// Other example values:
+	// - [
+	// -   {
+	// -     "interval": 5,
+	// -     "pattern": "^github.com/sourcegraph/.*"
+	// -   },
+	// -   {
+	// -     "interval": 10,
+	// -     "pattern": "^bitbucket.org/.*"
+	// -   }
+	// - ]
+	"gitUpdateInterval": null,
+
+	// Disk usage threshold at which to display warning notification. Value is a percentage.
+	"gitserver.diskUsageWarningThreshold": 90,
+
+	// HTML to inject at the bottom of the `<body>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.
+	"htmlBodyBottom": null,
+
+	// HTML to inject at the top of the `<body>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.
+	"htmlBodyTop": null,
+
+	// HTML to inject at the bottom of the `<head>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.
+	"htmlHeadBottom": null,
+
+	// HTML to inject at the top of the `<head>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.
+	"htmlHeadTop": null,
 
 	// The size of the buffer for aggregations ran in-memory. A higher limit might strain memory for the frontend
 	"insights.aggregations.bufferSize": 500,
@@ -517,199 +827,269 @@ All site configuration options and their default values are shown below.
 	"insights.backfill.repositoryGroupSize": 10,
 
 	// Maximum number of historical Code Insights data frames that may be analyzed per second.
-	"insights.historical.worker.rateLimit": 20,
 	// Other example values:
 	// - 50
 	// - 0.5
+	"insights.historical.worker.rateLimit": 20,
 
 	// The allowed burst rate for the Code Insights historical worker rate limiter.
-	"insights.historical.worker.rateLimitBurst": 20,
 	// Other example values:
 	// - 10
 	// - 20
+	"insights.historical.worker.rateLimitBurst": 20,
 
 	// The maximum number of data points that will be available to view for a series on a code insight. Points beyond that will be stored in a separate table and available for data export.
-	"insights.maximumSampleSize": 30,
 	// Other example values:
 	// - 12
 	// - 24
 	// - 50
+	"insights.maximumSampleSize": 30,
 
 	// Number of concurrent executions of a code insight query on a worker node
-	"insights.query.worker.concurrency": 1,
 	// Other example values:
 	// - 10
+	"insights.query.worker.concurrency": 1,
 
 	// Maximum number of Code Insights queries initiated per second on a worker node.
-	"insights.query.worker.rateLimit": 20,
 	// Other example values:
 	// - 10
 	// - 0.5
+	"insights.query.worker.rateLimit": 20,
 
 	// The allowed burst rate for the Code Insights queries per second rate limiter.
-	"insights.query.worker.rateLimitBurst": 20,
 	// Other example values:
 	// - 10
 	// - 20
+	"insights.query.worker.rateLimitBurst": 20,
 
-//////////////////////////////////////////////////////////////
-// Cody
-//////////////////////////////////////////////////////////////
-
-	// Enable or disable Cody instance-wide. When Cody is disabled, all Cody endpoints and GraphQL queries will return errors, Cody will not show up in the site-admin sidebar, and Cody in the global navbar will only show a call-to-action for site-admins to enable Cody.
-	"cody.enabled": false,
-
-	// Restrict Cody to only be enabled for users that have a feature flag labeled "cody" set to true. You must create a feature flag with this ID after enabling this setting: https://sourcegraph.com/docs/dev/how-to/use_feature_flags#create-a-feature-flag. This setting only has an effect if cody.enabled is true.
-	"cody.restrictUsersFeatureFlag": false,
-
-//////////////////////////////////////////////////////////////
-// Debug
-//////////////////////////////////////////////////////////////
-
-	// (debug) controls the amount of symbol search parallelism. Defaults to 20. It is not recommended to change this outside of debugging scenarios. This option will be removed in a future version.
-	"debug.search.symbolsParallelism": null,
+	// Settings for repository language stats inventory
 	// Other example values:
-	// - "20"
+	// - {
+	// -   "disableEnhancedLanguageDetection": false,
+	// -   "gitServerConcurrency": 4,
+	// -   "maxInventoryInMemory": 1000,
+	// -   "redisConcurrency": 20,
+	// -   "timeoutInMinutes": 5
+	// - }
+	"inventory": {
+		"disableEnhancedLanguageDetection": false,
+		"gitServerConcurrency": 4,
+		"maxInventoryInMemory": 1000,
+		"redisConcurrency": 20,
+		"timeoutInMinutes": 5
+	},
+
+	// The license key associated with a Sourcegraph product subscription, which is necessary to activate Sourcegraph Enterprise functionality. To obtain this value, contact Sourcegraph to purchase a subscription. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
+	"licenseKey": null,
+
+	// Configuration for logging and alerting, including to external services.
+	"log": {
+		"auditLog": {
+			"gitserverAccess": false,
+			"graphQL": false,
+			"internalTraffic": false,
+			"severityLevel": null
+		},
+		"sentry": {
+			"backendDSN": null,
+			"codeIntelDSN": null,
+			"dsn": null
+		}
+	},
+
+	// Whether or not LSIF uploads will be blocked unless a valid LSIF upload token is provided.
+	"lsifEnforceAuth": false,
+
+	// DEPRECATED: Configure maxRepos in search.limits. The maximum number of repositories to search across. The user is prompted to narrow their query if exceeded. Any value less than or equal to zero means unlimited.
+	"maxReposToSearch": -1,
+
+	"modelConfiguration": null,
+
+	// Notifications recieved from Sourcegraph.com to display in Sourcegraph.
+	// Other example values:
+	// - {
+	// -   "key": "2023-03-10-my-key",
+	// -   "message": "This is a test notification message."
+	// - }
+	"notifications": null,
+
+	// Configure notifications for Sourcegraph's built-in alerts.
+	// Other example values:
+	// - {
+	// -   "level": "critical",
+	// -   "notifier": {
+	// -     "channel": "#alerts",
+	// -     "type": "slack",
+	// -     "url": "https://hooks.slack.com/services/..."
+	// -   }
+	// - }
+	// - {
+	// -   "level": "warning",
+	// -   "notifier": {
+	// -     "addresses": [
+	// -       "alerts@example.com"
+	// -     ],
+	// -     "type": "email"
+	// -   }
+	// - }
+	"observability.alerts": null,
 
 	// (debug) Set a limit to the amount of captured slow GraphQL requests being stored for visualization. For defining the threshold for a slow GraphQL request, see observability.logSlowGraphQLRequests.
-	"observability.captureSlowGraphQLRequestsLimit": null,
 	// Other example values:
 	// - 2000
+	"observability.captureSlowGraphQLRequestsLimit": 0,
+
+	// EXPERIMENTAL: Configuration for client observability
+	// Other example values:
+	// - {
+	// -   "openTelemetry": {
+	// -     "endpoint": "/-/debug/otlp"
+	// -   }
+	// - }
+	// - {
+	// -   "openTelemetry": {
+	// -     "endpoint": "https://opentelemetry.example.com"
+	// -   }
+	// - }
+	"observability.client": {
+		"openTelemetry": {
+			"endpoint": "/-/debug/otlp",
+			"webVitalsInstrumentation": false
+		}
+	},
 
 	// (debug) logs all GraphQL requests slower than the specified number of milliseconds.
-	"observability.logSlowGraphQLRequests": null,
 	// Other example values:
 	// - 10000
+	"observability.logSlowGraphQLRequests": 0,
 
 	// (debug) logs all search queries (issued by users, code intelligence, or API requests) slower than the specified number of milliseconds.
-	"observability.logSlowSearches": null,
 	// Other example values:
 	// - 10000
+	"observability.logSlowSearches": 0,
 
-//////////////////////////////////////////////////////////////
-// Email
-//////////////////////////////////////////////////////////////
-
-	// The "from" address for emails sent by this server.
-	// Please see https://sourcegraph.com/docs/admin/config/email
-	"email.address": null,
-	// Other example values:
-	// - "noreply@sourcegraph.example.com"
-
-	// The name to use in the "from" address for emails sent by this server.
-	"email.senderName": "Sourcegraph",
-	// Other example values:
-	// - "Our Company Sourcegraph"
-	// - "Example Inc Sourcegraph"
-
-	// The SMTP server used to send transactional emails.
-	// Please see https://sourcegraph.com/docs/admin/config/email
-	"email.smtp": null,
-	// Other example values:
-	// - {
-	//     "authentication": "PLAIN",
-	//     "host": "smtp.example.com",
-	//     "password": "mypassword",
-	//     "port": 465,
-	//     "username": "alice"
-	//   }
-
-	// Configurable templates for some email types sent by Sourcegraph.
-	"email.templates": null,
-	// Other example values:
-	// - {
-	//     "resetPassword": {
-	//       "body": "To reset your password on {{.Host}}, please click the link below:\n\n{{.URL}}\n\nIf you did not request a password reset, please ignore this email. Your password will not change until you click the link and set a new password.",
-	//       "subject": "Reset your password on {{.Host}}"
-	//     },
-	//     "setPassword": {
-	//       "body": "To set your password on {{.Host}} and complete your account registration, please click the link below:\n\n{{.URL}}\n\nYour username is: {{.Username}}\n\nIf you did not sign up for an account on {{.Host}}, please ignore this email.",
-	//       "subject": "Set your password on {{.Host}}"
-	//     }
-	//   }
-
-//////////////////////////////////////////////////////////////
-// Experimental
-//////////////////////////////////////////////////////////////
-
-	// Experimental features and settings.
-	"experimentalFeatures": null,
-	// Other example values:
-	// - {
-	//     "customGitFetch": [
-	//       {
-	//         "domainPath": "somecodehost.com/path/to/repo",
-	//         "fetch": "customgitbinary someflag"
-	//       },
-	//       {
-	//         "domainPath": "somecodehost.com/path/to/anotherrepo",
-	//         "fetch": "customgitbinary someflag anotherflag"
-	//       }
-	//     ]
-	//   }
-	// - {
-	//     "tls.external": {
-	//       "certificates": [
-	//         "-----BEGIN CERTIFICATE-----\n..."
-	//       ],
-	//       "insecureSkipVerify": true
-	//     }
-	//   }
-
-//////////////////////////////////////////////////////////////
-// External services
-//////////////////////////////////////////////////////////////
-
-	// Disable periodic syncs of configured code host connections (repository metadata, permissions, batch changes changesets, etc)
-	"disableAutoCodeHostSyncs": false,
-
-	// Disable periodically fetching git contents for existing repositories.
-	"disableAutoGitUpdates": false,
-
-	// DEPRECATED! Disable redirects to sourcegraph.com when visiting public repositories that can't exist on this server.
-	"disablePublicRepoRedirects": null,
-	// Other example values:
-	// - true
-
-	// JSON array of configuration that maps from Git clone URL to repository name. Sourcegraph automatically resolves remote clone URLs to their proper code host. However, there may be non-remote clone URLs (e.g., in submodule declarations) that Sourcegraph cannot automatically map to a code host. In this case, use this field to specify the mapping. The mappings are tried in the order they are specified and take precedence over automatic mappings.
-	"git.cloneURLToRepositoryName": null,
+	// Silence individual Sourcegraph alerts by identifier.
 	// Other example values:
 	// - [
-	//     {
-	//       "from": "^/admin/config(?P\u003cname\u003e\\w+)$",
-	//       "to": "github.com/user/{name}"
-	//     }
-	//   ]
-
-	// Maximum number of seconds that a long Git command (e.g. clone or remote update) is allowed to execute. The default is 3600 seconds, or 1 hour.
-	"gitLongCommandTimeout": 3600,
-
-	// Maximum number of remote code host git operations (e.g. clone or ls-remote) to be run per second per gitserver. Default is -1, which is unlimited.
-	"gitMaxCodehostRequestsPerSecond": -1,
-
-	// Maximum number of git clone processes that will be run concurrently per gitserver to update repositories. Note: the global git update scheduler respects gitMaxConcurrentClones. However, we allow each gitserver to run upto gitMaxConcurrentClones to allow for urgent fetches. Urgent fetches are used when a user is browsing a PR and we do not have the commit yet.
-	"gitMaxConcurrentClones": 5,
-
-	// JSON array of repo name patterns and update intervals. If a repo matches a pattern, the associated interval will be used. If it matches no patterns a default backoff heuristic will be used. Pattern matches are attempted in the order they are provided.
-	"gitUpdateInterval": null,
-	// Other example values:
+	// -   "warning_gitserver_disk_space_remaining"
+	// - ]
 	// - [
-	//     {
-	//       "interval": 5,
-	//       "pattern": "^github.com/sourcegraph/.*"
-	//     },
-	//     {
-	//       "interval": 10,
-	//       "pattern": "^bitbucket.org/.*"
-	//     }
-	//   ]
+	// -   "critical_frontend_down",
+	// -   "warning_high_load"
+	// - ]
+	"observability.silenceAlerts": null,
+
+	// Configures distributed tracing within Sourcegraph. To learn more, refer to https://sourcegraph.com/docs/admin/observability/tracing
+	// Other example values:
+	// - {
+	// -   "debug": false,
+	// -   "sampling": "selective",
+	// -   "type": "opentelemetry",
+	// -   "urlTemplate": "https://ui.honeycomb.io/$ORG/environments/$DATASET/trace?trace_id={{ .TraceID }}"
+	// - }
+	// - {
+	// -   "debug": true,
+	// -   "sampling": "all",
+	// -   "type": "jaeger",
+	// -   "urlTemplate": "{{ .ExternalURL }}/-/debug/jaeger/trace/{{ .TraceID }}"
+	// - }
+	"observability.tracing": {
+		"debug": false,
+		"sampling": "selective",
+		"type": "opentelemetry",
+		"urlTemplate": null
+	},
+
+	// Configuration for organization invitations.
+	// Other example values:
+	// - {
+	// -   "expiryTime": 48,
+	// -   "signingKey": "your-signing-key"
+	// - }
+	"organizationInvitations": {
+		"expiryTime": 48,
+		"signingKey": null
+	},
+
+	// The maximum number of outbound requests to retain. This is a global limit across all outbound requests. If the limit is exceeded, older items will be deleted. If the limit is 0, no outbound requests are logged.
+	"outboundRequestLogLimit": 50,
+
+	// The max number of concurrent Own jobs that will run per worker node.
+	"own.background.repoIndexConcurrencyLimit": 5,
+
+	// The maximum per second burst of repositories for Own jobs per worker node. Generally this value should not be less than the max concurrency.
+	"own.background.repoIndexRateBurstLimit": 5,
+
+	// The maximum per second rate of repositories for Own jobs per worker node.
+	"own.background.repoIndexRateLimit": 20,
+
+	// The Own service will attempt to match a Team by the last part of its handle if it contains a slash and no match is found for its full handle.
+	"own.bestEffortTeamMatching": true,
 
 	// URL to fetch unreachable repository details from. Defaults to "https://sourcegraph.com"
-	"parentSourcegraph": null,
 	// Other example values:
 	// - {
-	//     "url": "https://sourcegraph.example.com"
-	//   }
+	// -   "url": "https://sourcegraph.example.com"
+	// - }
+	"parentSourcegraph": {
+		"url": "https://sourcegraph.com"
+	},
+
+	// Time interval (in seconds) of how often cleanup worker should remove old jobs from permissions sync jobs table.
+	"permissions.syncJobCleanupInterval": 3600,
+
+	// The number of last repo/user permission jobs to keep for history. Will be cleaned up occasionally to only keep the most recent N jobs.
+	"permissions.syncJobsHistorySize": 5,
+
+	// Number of repo permissions to schedule for syncing in single scheduler iteration.
+	"permissions.syncOldestRepos": 100,
+
+	// Number of user permissions to schedule for syncing in single scheduler iteration.
+	"permissions.syncOldestUsers": 100,
+
+	// Don't sync a repo's permissions if it has synced within the last n seconds.
+	"permissions.syncReposBackoffSeconds": 900,
+
+	// The maximum number of repo-centric permissions syncing jobs that can be spawned concurrently. Service restart is required to take effect for changes.
+	"permissions.syncReposMaxConcurrency": 5,
+
+	// Time interval (in seconds) of how often each component picks up authorization changes in external services.
+	"permissions.syncScheduleInterval": 60,
+
+	// Don't sync a user's permissions if they have synced within the last n seconds.
+	"permissions.syncUsersBackoffSeconds": 900,
+
+	// The maximum number of user-centric permissions syncing jobs that can be spawned concurrently. Service restart is required to take effect for changes.
+	"permissions.syncUsersMaxConcurrency": 5,
+
+	// Settings for Sourcegraph explicit permissions, which allow the site admin to explicitly manage repository permissions via the GraphQL API. This will mark repositories as restricted by default.
+	// Other example values:
+	// - {
+	// -   "bindID": "email"
+	// - }
+	// - {
+	// -   "bindID": "username"
+	// - }
+	"permissions.userMapping": {
+		"bindID": "email",
+		"enabled": true
+	},
+
+	// Enables users access to the product research page in their settings.
+	"productResearchPage.enabled": true,
+
+	"rateLimits": {
+		"graphQLMaxAliases": 500,
+		"graphQLMaxDepth": 30,
+		"graphQLMaxDuplicateFieldCount": 500,
+		"graphQLMaxFieldCount": 500000,
+		"graphQLMaxUniqueFieldCount": 500
+	},
+
+	// Enables redacting sensitive information from outbound requests. Important: We only respect this setting in development environments. In production, we always redact outbound requests.
+	// Other example values:
+	// - true
+	"redactOutboundRequestHeaders": false,
 
 	// The number of concurrent external service syncers that can run.
 	"repoConcurrentExternalServiceSyncers": 3,
@@ -727,216 +1107,109 @@ All site configuration options and their default values are shown below.
 	"scim.authToken": "",
 
 	// Identity provider used for SCIM support.  "STANDARD" should be used unless a more specific value is available
+	// Valid options: "STANDARD", "Azure AD"
 	"scim.identityProvider": "STANDARD",
 
-//////////////////////////////////////////////////////////////
-// Misc.
-//////////////////////////////////////////////////////////////
-
-	// Disable the feedback survey
-	"disableFeedbackSurvey": false,
-
-	// DEPRECATED. Has no effect.
-	"disableNonCriticalTelemetry": false,
-
-	// HTML to inject at the bottom of the `<body>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.
-	"htmlBodyBottom": null,
-
-	// HTML to inject at the top of the `<body>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.
-	"htmlBodyTop": null,
-
-	// HTML to inject at the bottom of the `<head>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.
-	"htmlHeadBottom": null,
-
-	// HTML to inject at the top of the `<head>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.
-	"htmlHeadTop": null,
-
-	// Enables users access to the product research page in their settings.
-	"productResearchPage.enabled": true,
-
-	// The channel on which to automatically check for Sourcegraph updates.
-	"update.channel": "release",
-	// Other example values:
-	// - "none"
-
-//////////////////////////////////////////////////////////////
-// Own
-//////////////////////////////////////////////////////////////
-
-	// The max number of concurrent Own jobs that will run per worker node.
-	"own.background.repoIndexConcurrencyLimit": 5,
-
-	// The maximum per second burst of repositories for Own jobs per worker node. Generally this value should not be less than the max concurrency.
-	"own.background.repoIndexRateBurstLimit": 5,
-
-	// The maximum per second rate of repositories for Own jobs per worker node.
-	"own.background.repoIndexRateLimit": 20,
-
-	// The Own service will attempt to match a Team by the last part of its handle if it contains a slash and no match is found for its full handle.
-	"own.bestEffortTeamMatching": true,
-
-//////////////////////////////////////////////////////////////
-// Search
-//////////////////////////////////////////////////////////////
-
-	// DEPRECATED: Configure maxRepos in search.limits. The maximum number of repositories to search across. The user is prompted to narrow their query if exceeded. Any value less than or equal to zero means unlimited.
-	"maxReposToSearch": -1,
-
 	// The number of threads each indexserver should use to index shards. If not set, indexserver will use the number of available CPUs. This is exposed as a safeguard and should usually not require being set.
-	"search.index.shardConcurrency": null,
 	// Other example values:
 	// - "10"
+	"search.index.shardConcurrency": 0,
 
 	// Whether indexed symbol search is enabled. This is contingent on the indexed search configuration, and is true by default for instances with indexed search enabled. Enabling this will cause every repository to re-index, which is a time consuming (several hours) operation. Additionally, it requires more storage and ram to accommodate the added symbols information in the search index.
-	"search.index.symbols.enabled": null,
 	// Other example values:
 	// - true
+	"search.index.symbols.enabled": false,
 
 	// A list of file glob patterns where matching files will be indexed and searched regardless of their size. Files still need to be valid utf-8 to be indexed. The glob pattern syntax can be found here: https://github.com/bmatcuk/doublestar#patterns.
-	"search.largeFiles": null,
 	// Other example values:
 	// - [
-	//     "go.sum",
-	//     "package-lock.json",
-	//     "**/*.thrift"
-	//   ]
+	// -   "go.sum",
+	// -   "package-lock.json",
+	// -   "**/*.thrift"
+	// - ]
+	"search.largeFiles": null,
 
 	// Limits that search applies for number of repositories searched and timeouts.
-	"search.limits": null,
 	// Other example values:
 	// - {
-	//     "commitDiffMaxRepos": 50,
-	//     "commitDiffWithTimeFilterMaxRepos": 5000,
-	//     "maxRepos": 200,
-	//     "maxTimeoutSeconds": 60
-	//   }
-
-//////////////////////////////////////////////////////////////
-// Security
-//////////////////////////////////////////////////////////////
-
-	// Settings for access tokens, which enable external tools to access the Sourcegraph API with the privileges of the user.
-	"auth.accessTokens": {
-		"allow": "all-users-create",
-		"expirationOptionDays": [7,14,30,60,90],
-    	"defaultExpirationDays": 90,
-		"allowNoExpiration": false,
-		"maxTokensPerUser": 25
+	// -   "commitDiffMaxRepos": 50,
+	// -   "commitDiffWithTimeFilterMaxRepos": 5000,
+	// -   "maxRepos": 200,
+	// -   "maxTimeoutSeconds": 60
+	// - }
+	"search.limits": {
+		"commitDiffMaxRepos": 50,
+		"commitDiffWithTimeFilterMaxRepos": 10000,
+		"maxRepos": -1,
+		"maxTimeoutSeconds": "60"
 	},
+
+	// The base URL of the Self-Serve Cody API.
+	"ssc.apiBaseUrl": "https://accounts.sourcegraph.com/cody/api",
+
+	// The hostname of SAMS instance to connect.
+	"ssc.samsHostName": "accounts.sourcegraph.com",
+
+	// Syntax highlighting configuration
 	// Other example values:
-	// - {"allow":"site-admin-create"}
-	// - {"allow":"none"}
-
-	// Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.
-	"corsOrigin": null,
-	// Other example values:
-	// - "https://my-phabricator.example.com https://my-bitbucket.example.com https://my-gitlab.example.com"
-
-	// Whether or not LSIF uploads will be blocked unless a valid LSIF upload token is provided.
-	"lsifEnforceAuth": false,
-
-	// Settings for Sourcegraph explicit permissions, which allow the site admin to explicitly manage repository permissions via the GraphQL API. This will mark repositories as restricted by default.
-	"permissions.userMapping": {
-		"bindID": "email",
-		"enabled": true
-	},
-	// Other example values:
-	// - {"bindID":"email"}
-	// - {"bindID":"username"}
-
-//////////////////////////////////////////////////////////////
-// Sourcegraph Enterprise license
-//////////////////////////////////////////////////////////////
-
-	// The license key associated with a Sourcegraph Enterprise subscription, which is necessary to activate Sourcegraph Enterprise functionality. To obtain this value, contact Sourcegraph to purchase a license. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
-	"licenseKey": null,
-
-//////////////////////////////////////////////////////////////
-// Sourcegraph.com
-//////////////////////////////////////////////////////////////
-
-	// Configuration options for Sourcegraph.com only.
-	"dotcom": null
-}
-```
-
-#### Known bugs
-
-The following site configuration options require the server to be restarted for the changes to take effect:
-
-```
-auth.providers
-externalURL
-insights.query.worker.concurrency
-insights.commit.indexer.interval
-permissions.syncUsersMaxConcurrency
-```
-
-## Editing your site configuration if you cannot access the web UI
-
-If you are having trouble accessing the web UI, you can make edits to your site configuration by editing the configuration directly.
-
-
-### Sourcegraph with Docker Compose and single-server Sourcegraph with Docker
-
-Set `FRONTEND_CONTAINER` to:
-
-- [Docker Compose](/admin/deploy/docker-compose/): the `sourcegraph-frontend` container
-- [Single-container](/admin/deploy/docker-single-container/): the `sourcegraph/server` container
-
-```sh
-docker exec -it --user=root $FRONTEND_CONTAINER sh -c 'apk add --no-cache && nano /home/sourcegraph/site-config.json'
-```
-
-Or if you prefer using a Vim editor:
-
-```sh
-docker exec -it $FRONTEND_CONTAINER sh -c 'vi ~/site-config.json'
-```
-
-### Sourcegraph with Kubernetes
-
-For [Kubernetes](/admin/deploy/kubernetes/) deployments:
-
-```sh
-kubectl exec -it $FRONTEND_POD -- sh -c 'apk add --no-cache nano && nano ~/site-config.json'
-```
-
-Or if you prefer using a Vim editor:
-
-```sh
-kubectl exec -it $FRONTEND_POD -- sh -c 'vi ~/site-config.json'
-```
-
-Then simply save your changes (type <kbd>ctrl+x</kbd> and <kbd>y</kbd> to exit `nano` and save your changes). Your changes will be applied immediately in the same way as if you had made them through the web UI.
-
-## If you are still encountering issues
-
-You can check the container logs to see if you have made any typos or mistakes in editing the configuration file. If you are still encountering problems, you can save the default site configuration that comes with Sourcegraph (below) or contact support@sourcegraph.com with any questions you have.
-
-```json
-{
-	// The externally accessible URL for Sourcegraph (i.e., what you type into your browser)
-	// This is required to be configured for Sourcegraph to work correctly.
-	// "externalURL": "https://sourcegraph.example.com",
-
-	// The authentication provider to use for identifying and signing in users.
-	// Only one entry is supported.
-	//
-	// The builtin auth provider with signup disallowed (shown below) means that
-	// after the initial site admin signs in, all other users must be invited.
-	//
-	// Other providers are documented at https://sourcegraph.com/docs/admin/auth.
-	"auth.providers": [
-		{
-			"type": "builtin",
-			"allowSignup": false
+	// - {
+	// -   "engine": {
+	// -     "default": "tree-sitter",
+	// -     "overrides": {
+	// -       "go": "syntect"
+	// -     }
+	// -   },
+	// -   "languages": {
+	// -     "extensions": {
+	// -       "go": "go",
+	// -       "ts": "typescript"
+	// -     },
+	// -     "patterns": [
+	// -       {
+	// -         "language": "cobol",
+	// -         "match": "cobol_.*\\.txt"
+	// -       }
+	// -     ]
+	// -   }
+	// - }
+	"syntaxHighlighting": {
+		"engine": {
+			"default": null,
+			"overrides": null
+		},
+		"languages": {
+			"extensions": null,
+			"patterns": null
+		},
+		"symbols": {
+			"engine": null
 		}
-	],
+	},
+
+	// Configuration for application user telemetry.
+	"telemetry": {
+		"disableLocalEventLogs": false
+	},
+
+	// The channel on which to automatically check for Sourcegraph updates.
+	// Valid options: "release", "none"
+	// Other example values:
+	// - "none"
+	"update.channel": "release",
+
+	// Configuration for logging incoming webhooks.
+	// Other example values:
+	// - {
+	// -   "enabled": true,
+	// -   "retention": "7d"
+	// - }
+	"webhook.logging": {
+		"enabled": false,
+		"retention": "72h"
+	}
 }
 ```
 {/* SCHEMA_SYNC_END: admin/config/site.schema.json */}
-
 ## Configuration Notes
 
 ### Critical Restart Requirements

--- a/docs/admin/repo/perforce.mdx
+++ b/docs/admin/repo/perforce.mdx
@@ -221,122 +221,66 @@ With this setting, Sourcegraph will ignore any rules with a host other than `*`,
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/perforce.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: Manual setup - will be automated via sourcegraph/sourcegraph releases */}
+{/* Last updated: 2025-07-01T22:00:57Z via sourcegraph/sourcegraph@v6.5.1211 */}
 ```json
 {
 	// If non-null, enforces Perforce depot permissions.
-	"authorization": null,
+	"authorization": {
+		"ignoreRulesWithHost": false,
+		"subRepoPermissions": false
+	},
 
 	// Depots can have arbitrary paths, e.g. a path to depot root or a subdirectory.
-	"depots": null,
 	// Other example values:
 	// - [
-	//     "//Sourcegraph/",
-	//     "//Engineering/Cloud/"
-	//   ]
+	// -   "//Sourcegraph/",
+	// -   "//Engineering/Cloud/"
+	// - ]
+	"depots": null,
 
 	// Configuration for the experimental p4-fusion client
-	"fusionClient": null,
-
-	// Only import at most n changes when possible (git p4 clone --max-changes).
-	"maxChanges": 1000,
+	"fusionClient": {
+		"cacheLabels": false,
+		"enabled": false,
+		"fsyncEnable": false,
+		"includeBinaries": false,
+		"lookAhead": 2000,
+		"maxChanges": -1,
+		"networkThreads": 12,
+		"networkThreadsFetch": 12,
+		"noConvertLabels": false,
+		"printBatch": 100,
+		"refresh": 1000,
+		"retries": 10
+	},
 
 	// Client specified as an option for p4 CLI (P4CLIENT, also enables '--use-client-spec')
 	"p4.client": null,
 
+	// REQUIRED:
 	// The ticket value for the user (P4PASSWD). You can get this by running `p4 login -p` or `p4 login -pa`. It should look like `6211C5E719EDE6925855039E8F5CC3D2`.
 	"p4.passwd": null,
 
+	// REQUIRED:
 	// The Perforce Server address to be used for p4 CLI (P4PORT). It's recommended to specify the protocol prefix (e.g. tcp: or ssl:) as part of the address.
-	"p4.port": null,
 	// Other example values:
 	// - "ssl:111.222.333.444:1666"
 	// - "tcp:111.222.333.444:1666"
+	"p4.port": null,
 
+	// REQUIRED:
 	// The user to be authenticated for p4 CLI (P4USER).
-	"p4.user": null,
 	// Other example values:
 	// - "admin"
+	"p4.user": null,
 
 	// The pattern used to generate the corresponding Sourcegraph repository name for a Perforce depot. In the pattern, the variable "{depot}" is replaced with the Perforce depot's path.
-	//
 	// For example, if your Perforce depot path is "//Sourcegraph/" and your Sourcegraph URL is https://src.example.com, then a repositoryPathPattern of "perforce/{depot}" would mean that the Perforce depot is available on Sourcegraph at https://src.example.com/perforce/Sourcegraph.
-	//
 	// It is important that the Sourcegraph repository name generated with this pattern be unique to this Perforce Server. If different Perforce Servers generate repository names that collide, Sourcegraph's behavior is undefined.
 	"repositoryPathPattern": "{depot}"
 }
 ```
-
-## Known issues and limitations
-
-We are actively working to significantly improve Sourcegraph's Perforce support. Please [contact us](https://help.sourcegraph.com/hc/en-us/requests/new) to help us prioritize any specific improvements you'd like to see.
-
-- Sourcegraph was initially built for Git repositories only, so it stores Perforce depots as Git repositories when syncing. Perforce concepts and languages are expressed in the UI, but under the hood, Git tools are used.
-- Batch Changes does not support [file-level permissions](#file-level-permissions) (also known as sub-repo permissions)
-- Batch Changes does not handle the shelved changelist other than to query the Perforce server for its status.
-- Permalinks with Changelist Id do not work yet
-
-## Configure experimental features
-
-As of Sourcegraph 5.1, there are the following experimental features for Perforce depots. These are merely for providing feedback and have [limited support](/admin/beta_and_experimental_features#experimental-features).
-
-### Changelist ID in URLs
-
-Note: When enabling changelist IDs in URLs for the first time, Perforce depots can be unavailable for a few minutes on the Sourcegraph instance, due to the initial mapping of changelist IDs to generated commit ID happening in the background. If you have a large number of Perforce depots, we recommend proceeding with the following steps in a maintenance window in which you don't expect large amounts of traffic on your Sourcegraph instance.
-
-Add `"perforceChangelistMapping": "enabled",` to `experimentalFeatures` in the [site configuration](/admin/config/site_config):
-
-```json
-{
-  "experimentalFeatures": {
-    "perforceChangelistMapping": "enabled"
-  }
-}
-```
-
-When enabled, URLs for Perforce code hosts will use the Changelist (CL) ID instead of commit SHAs. Areas that benefit from this at the moment are:
-
-- Viewing a specific CL
-- Viewing the files of a depot at a specific CL
-- Viewing a specific file added / removed / modified in a specific CL
-- Viewing the list of CLs
-
-
-### Searching within a specific changelist
-As of Sourcegraph 5.5, you can search within a specific changelist by referring the the changelist as a reference path like `changelist/123` where 123 is the changelist id. For example, given a repo path of `Talkhouse/main` and a changelist id of `123`, you can search within that changelist by using the following query:
-```
-repo:^Talkhouse/main$@changelist/123 text to find
-```
-
-or
-```
-repo:^Talkhouse/main$ rev:changelist/123 text to find
-```
-
-#### Limitations
-
-- After a depot is cloned or fetched, Sourcegraph computes and stores mappings of CL IDs to commit SHAs. This mapping can take several minutes for large clones/fetches. When a background mapping job is running, the depot won't be serviceable as URLs referring to CL IDs may not resolve and users may see an error while interacting with the depot.
-- This experimental configuration can not be selectively enabled for a specific perforce depot.
-
-#### Mechanism
-
-To support CLs natively in the URLs, Sourcegraph performs background computation after syncing the contents of a depot. That's done by parsing each generated commit to retrieve the corresponding CL ID and store it in the `repo_commits_changelists` table. This is currently performed on only one depot at a time and we are working to support this for multiple depots in parallel in an upcoming release.
-
-Additionally, while removing a depot from a code host config will mark it as "deleted", the mapped information will **not** be deleted to prevent forced re-computation after an accidental removal of depot from a code host config. Similarly recloning a depot will **not** trigger a computation of all the CLs from the beginning of the depot's source control history. If site admins are recloning or deleting and re-adding a depot to Sourcegraph as a result of history rewrite of a depot in Perforce, they should get in [touch with us](mailto:support@sourcegraph.com) for next steps.
-
-### Batch Changes support for Perforce depots
-
-Add `"batchChanges.enablePerforce": true` to `experimentalFeatures` in the [site configuration](/admin/config/site_config):
-
-```json
-{
-  "experimentalFeatures": {
-   "batchChanges.enablePerforce": true,
-  }
-}
-```
 {/* SCHEMA_SYNC_END: admin/code_hosts/perforce.schema.json */}
-
 ## Configuration Notes
 
 - **p4-fusion Recommended**: Use the `fusionClient` configuration for better performance compared to `git p4`.


### PR DESCRIPTION
This PR updates the embedded JSON schemas to match the schemas from Sourcegraph v6.5.1211.

## Changes
- Updates JSON schema files referenced in MDX documentation
- Maintains version consistency between code and documentation

## Automation
This PR was created automatically by the schema sync tool during the v6.5.1211 release process.

/cc @sourcegraph/release