### PR TITLE
Correct incorrectly placed end tags for schema syncher

### DIFF
--- a/docs/admin/code_hosts/aws_codecommit.mdx
+++ b/docs/admin/code_hosts/aws_codecommit.mdx
@@ -88,6 +88,7 @@ AWS CodeCommit connections support the following configuration options, which ar
 	"secretAccessKey": null
 }
 ```
+{/* SCHEMA_SYNC_END: admin/code_hosts/aws_codecommit.schema.json */}
 
 ## Setup steps for SSH connections to AWS CodeCommit repositories
 
@@ -112,7 +113,6 @@ To add CodeCommit repositories in Docker Container:
   }
 }
 ```
-{/* SCHEMA_SYNC_END: admin/code_hosts/aws_codecommit.schema.json */}
 
 ## Configuration Notes
 

--- a/docs/admin/code_hosts/gitlab.mdx
+++ b/docs/admin/code_hosts/gitlab.mdx
@@ -321,6 +321,7 @@ See [Internal rate limits](/admin/code_hosts/rate_limits#internal-rate-limits).
 	"webhooks": null
 }
 ```
+{/* SCHEMA_SYNC_END: admin/code_hosts/gitlab.schema.json */}
 
 ## Native integration
 
@@ -336,7 +337,6 @@ The Sourcegraph instance's site admin must [update the `corsOrigin` site config 
   // ...
 }
 ```
-{/* SCHEMA_SYNC_END: admin/code_hosts/gitlab.schema.json */}
 
 ## Configuration Notes
 

--- a/docs/admin/config/site_config.mdx
+++ b/docs/admin/config/site_config.mdx
@@ -859,6 +859,7 @@ All site configuration options and their default values are shown below.
 	"dotcom": null
 }
 ```
+{/* SCHEMA_SYNC_END: admin/config/site.schema.json */}
 
 #### Known bugs
 
@@ -935,7 +936,6 @@ You can check the container logs to see if you have made any typos or mistakes i
 	],
 }
 ```
-{/* SCHEMA_SYNC_END: admin/config/site.schema.json */}
 
 ## Configuration Notes
 

--- a/docs/admin/repo/perforce.mdx
+++ b/docs/admin/repo/perforce.mdx
@@ -266,6 +266,7 @@ With this setting, Sourcegraph will ignore any rules with a host other than `*`,
 	"repositoryPathPattern": "{depot}"
 }
 ```
+{/* SCHEMA_SYNC_END: admin/code_hosts/perforce.schema.json */}
 
 ## Known issues and limitations
 
@@ -335,7 +336,6 @@ Add `"batchChanges.enablePerforce": true` to `experimentalFeatures` in the [site
   }
 }
 ```
-{/* SCHEMA_SYNC_END: admin/code_hosts/perforce.schema.json */}
 
 ## Configuration Notes
 


### PR DESCRIPTION
Some of the end markers for the schema syncher were in the wrong place

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
