### PR TITLE
analytics: fix information hierarchy

### DIFF
--- a/docs/analytics/api.mdx
+++ b/docs/analytics/api.mdx
@@ -1,21 +1,6 @@
-# Sourcegraph Cloud Analytics
+# Sourcegraph Analytics API
 
-The following instructions are for all Sourcegraph Cloud and self-hosted customers who have upgraded to a sufficient version of Sourcegraph (5.9+) and fully enabled usage telemetry.
-
-![Sourcegraph-cloud-analytics](https://storage.googleapis.com/sourcegraph-assets/cloud-analytics.png)
-
-## Enablement instructions
-
-To enable Sourcegraph Analytics:
-
-- Create an account on [Sourcegraph Accounts](https://accounts.sourcegraph.com/), or find the email address associated with your existing account.
-- Contact your Sourcegraph Technical Advisor or point of contact (or email us at support@sourcegraph.com if you don't know your contact), provide them with the email address you used to register above and ask for access to Sourcegraph Analytics.
-- They will validate your account and link it to your Sourcegraph Enterprise instance's usage metrics.
-- Sign in to [Sourcegraph Analytics](https://analytics.sourcegraph.com).
-
-## Data export
-
-Sourcegraph Analytics also includes a CSV export option with key metrics like the number of searches, chats, autocomplete suggestions, Completion Acceptance Rate (CAR%), and more. The data is split by user, day, client/editor, and programming language, perfect for automating retrieval and analyzing data in ways that make the most sense to your organization.
+The Sourcegraph Analytics API is an API that provides programmatic access to your Sourcegraph Analytics data, including usage metrics, user activity, and performance data.
 
 ## Access tokens
 
@@ -120,7 +105,7 @@ curl -X DELETE https://analytics.sourcegraph.com/api/service-access-tokens/$TOKE
 
 ## API reference
 
-Sourcegraph Analytics API is a RESTful API that allows access to Sourcegraph Analytics data. To authenticate to the API, follow the instructions for [token creation](#token-creation).
+To authenticate to the API, follow the instructions for [token creation](#token-creation).
 
 Export your access token as an environment variable:
 

--- a/docs/analytics/index.mdx
+++ b/docs/analytics/index.mdx
@@ -2,29 +2,41 @@
 
 Enterprise customers can use Sourcegraph Analytics to get a clear view of usage, engagement, performance, and impact.
 
-## Sourcegraph Cloud Analytics
-This solution is available to:
+Our managed [cloud analytics service](https://analytics.sourcegraph.com) for Cody and Code Search usage data is available for:
+
 - [Sourcegraph Cloud](/cloud) customers
-- Self-hosted customers that have fully enabled usage telemetry, and that are running a supported version of Sourcegraph (5.9+)
-- [Sourcegraph Enterprise Starter](/pricing/plans/enterprise-starter) customers
+- Self-hosted customers that have fully enabled usage telemetry and are running a supported version of Sourcegraph (5.9+)
+- [Sourcegraph workspaces](https://workspaces.sourcegraph.com)
 
-[Sourcegraph Cloud](/cloud) customers can use our managed [cloud analytics service](https://analytics.sourcegraph.com) for Cody and Code Search usage data.
-Self-hosted customers can also use this service, but they must:
-- Upgrade to a supported version of Sourcegraph (5.9+)
-- Have fully enabled usage telemetry
-- [Enablement instructions](/analytics/cloud#enablement)
+To get started, follow our [enablement instructions](#enablement-instructions).
 
-[Sourcegraph Enterprise Starter](/pricing/plans/enterprise-starter) customers must be a workspace admin to get access to Code Search usage data. 
+Air-gapped customers can refer to [Sourcegraph Air-Gapped Analytics](/analytics/air-gapped).
 
-For more details on setting up Sourcegraph Analytics, see our [enablement instructions](/analytics/cloud#enablement)
+### Enablement instructions
 
-![Sourcegraph-cloud-analytics](https://storage.googleapis.com/sourcegraph-assets/Docs/Sourcegraph-Analytics-2025-01-28.png)
+#### Self-hosted and Cloud
 
-## Air-Gapped Analytics
+To enable Sourcegraph Analytics for self-hosted or Cloud instances:
 
-<Callout type="info">Air-Gapped analytics is an upcoming feature currently in development. If you would like to learn more, please get in touch with your Sourcegraph representative.</Callout>
+- Create an account on [Sourcegraph Accounts](https://accounts.sourcegraph.com/), or find the email address associated with your existing account.
+- Contact your Sourcegraph Technical Advisor or point of contact (or email us at support@sourcegraph.com if you don't know your contact), provide them with the email address you used to register above and ask for access to Sourcegraph Analytics.
+- They will validate your account and link it to your Sourcegraph Enterprise instance's usage metrics.
+- Sign in to [Sourcegraph Analytics](https://analytics.sourcegraph.com).
 
-Air-Gapped customers can view usage metrics in a locally deployed analytics service built on Grafana to see Sourcegraph usage data.
+#### Sourcegraph workspaces
+
+To access Sourcegraph workspaces:
+
+- Ensure you are an admin of your [Sourcegraph workspace](https://workspaces.sourcegraph.com).
+- Sign in to [Sourcegraph Analytics](https://analytics.sourcegraph.com) with the same account you use for your workspace.
+
+### Data export and API
+
+Sourcegraph Analytics includes a CSV export option with key metrics like the number of searches, chats, autocomplete suggestions, Completion Acceptance Rate (CAR%), and more. The data is split by user, day, client/editor, and programming language.
+
+You can export data directly from the Sourcegraph Analytics web interface, or programmatically via the API. For API access and detailed instructions, see our [Analytics API documentation](/analytics/api).
+
+![sourcegraph-analytics](https://storage.googleapis.com/sourcegraph-assets/Docs/Sourcegraph-Analytics-2025-01-28.png)
 
 ## Metrics
 

--- a/src/data/redirects.ts
+++ b/src/data/redirects.ts
@@ -6818,7 +6818,56 @@ const redirectsData = [
     permanent: true
   },
 
-
+  {
+    source: '/analytics/cloud#access-tokens',
+    destination: '/analytics/api#access-tokens',
+    permanent: true
+  },
+  {
+    source: '/analytics/cloud#token-management-apis',
+    destination: '/analytics/api#token-management-apis',
+    permanent: true
+  },
+  {
+    source: '/analytics/cloud#enablement-instructions',
+    destination: '/analytics#enablement-instructions',
+    permanent: true
+  },
+  {
+    source: '/analytics/cloud#data-export',
+    destination: '/analytics#data-export-and-api',
+    permanent: true
+  },
+  {
+    source: '/analytics/cloud#token-creation',
+    destination: '/analytics/api#token-creation',
+    permanent: true
+  },
+  {
+    source: '/analytics/cloud#token-listing',
+    destination: '/analytics/api#token-listing',
+    permanent: true
+  },
+  {
+    source: '/analytics/cloud#token-revocation',
+    destination: '/analytics/api#token-revocation',
+    permanent: true
+  },
+  {
+    source: '/analytics/cloud#api-reference',
+    destination: '/analytics/api#api-reference',
+    permanent: true
+  },
+  {
+    source: '/analytics/cloud#csv-export',
+    destination: '/analytics/api#csv-export',
+    permanent: true
+  },
+  {
+    source: '/analytics/cloud',
+    destination: '/analytics',
+    permanent: true
+  },
 ];
 
 const updatedRedirectsData = redirectsData.map(redirect => {


### PR DESCRIPTION
- Analytics is not a Cloud feature, no reason to name it and the pages "Cloud"
- Move API to another page - FYI @jac 
- Remove repetitive information
