### PR TITLE
Remove Gemini models via Vertex AI mode config example

### DIFF
--- a/docs/cody/enterprise/model-config-examples.mdx
+++ b/docs/cody/enterprise/model-config-examples.mdx
@@ -668,63 +668,6 @@ In the configuration above,
 
 </Accordion>
 
-<Accordion title="Google Vertex (Gemini)">
-
-```json
-"modelConfiguration": {
-  "sourcegraph": null,
-  "providerOverrides": [
-      {
-          "id": "google",
-          "displayName": "Google Gemini",
-          "serverSideConfig": {
-            "type": "google",
-            "accessToken": "token",
-            "endpoint": "https://us-east5-aiplatform.googleapis.com/v1/projects/project-name/locations/us-east5/publishers/anthropic/models"
-          }
-      }
-  ],
-  "modelOverrides": [
-      {
-          "modelRef": "google::unknown::claude-3-5-sonnet",
-          "displayName": "Claude 3.5 Sonnet (via Google Vertex)",
-          "modelName": "claude-3-5-sonnet@20240620",
-          "contextWindow": {
-            "maxInputTokens": 45000,
-            "maxOutputTokens": 4000
-          },
-          "capabilities": ["chat"],
-          "category": "accuracy",
-          "status": "stable"
-      },
-      {
-          "modelRef": "google::unknown::claude-3-haiku",
-          "displayName": "Claude 3 Haiku",
-          "modelName": "claude-3-haiku@20240307",
-          "capabilities": ["autocomplete", "chat"],
-          "category": "speed",
-          "status": "stable",
-          "contextWindow": {
-            "maxInputTokens": 7000,
-            "maxOutputTokens": 4000
-          }
-      },
-  ],
-  "defaultModels": {
-    "chat": "google::unknown::claude-3-5-sonnet",
-    "fastChat": "google::unknown::claude-3-5-sonnet",
-    "codeCompletion": "google::unknown::claude-3-haiku"
-  }
-}
-```
-
-In the configuration above,
-
--   Set up a provider override for Google Anthropic, routing requests for this provider directly to the specified endpoint (bypassing Cody Gateway)
--   Add two Anthropic models: - `"google::unknown::claude-3-5-sonnet"` with "chat" capabiity - used for "chat" and "fastChat" - `"google::unknown::claude-3-haiku"` with "autocomplete" capability - used for "codeCompletion"
-
-</Accordion>
-
 <Accordion title="Amazon Bedrock">
 
 ```json


### PR DESCRIPTION
We do not support Gemini models via Vertex AI.
See [this Slack thread](https://sourcegraph.slack.com/archives/C05E2LHPQLX/p1751383518899469) for more context. 

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
