### PR TITLE
fix: batches now supports fine-grained pat

### DIFF
--- a/docs/admin/code_hosts/github.mdx
+++ b/docs/admin/code_hosts/github.mdx
@@ -261,15 +261,11 @@ Fine-grained tokens can access public repositories, but can only access the priv
 
 When creating your fine-grained access token, select the following permissions depending on the purpose of the token:
 
-| Feature                                               | Required token permissions                                  |
+| Feature                                               | Required token permissions                             |
 | ----------------------------------------------------- | ------------------------------------------------------ |
 | [Sync private repositories](#private-repositories)    | `Repository permissions: Contents - Access: Read-only` |
 | [Sync repository permissions][permissions]            | `Repository permissions: Contents - Access: Read-only` |
-| [Batch changes][batch-changes]                        | `Unsupported`                                          |
-
-
-
-> WARNING: Fine-grained tokens don't support the `repositoryQuery` code host connection option or batch changes. Both of these features rely on GitHub's GraphQL API, which is [unsupported by fine-grained access tokens](https://docs.github.com/en/graphql/guides/forming-calls-with-graphql#authenticating-with-graphql).
+| [Batch changes][batch-changes]                        | `Repository permissions: Contents: Read and write, Metadata: Read-only, Pull requests: Read and write, Workflows: Read and write` |
 
 ### Private repositories
 


### PR DESCRIPTION
We recently added official support for fine-grained access tokens. The previously linked limitation doesn't seem to exist anymore (at least I can't find it in the docs).

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
