### PR TITLE
Add redirect from old to new deep search URL

### DIFF
--- a/src/data/redirects.ts
+++ b/src/data/redirects.ts
@@ -6868,6 +6868,11 @@ const redirectsData = [
     destination: '/analytics',
     permanent: true
   },
+  {
+    source: '/code-search/types/deep-search',
+    destination: '/deep-search',
+    permanent: true
+  },
 ];
 
 const updatedRedirectsData = redirectsData.map(redirect => {


### PR DESCRIPTION
We moved it but the product deep links to the old location.

Test plan: CI.
