### PR TITLE
Update JSON schemas for v6.5.2654

### DIFF
--- a/docs/admin/code_hosts/aws_codecommit.mdx
+++ b/docs/admin/code_hosts/aws_codecommit.mdx
@@ -34,7 +34,7 @@ AWS CodeCommit connections support the following configuration options, which ar
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/aws_codecommit.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-07T17:35:38Z via sourcegraph/sourcegraph@v6.5.1211 */}
+{/* Last updated: 2025-07-10T00:07:31Z via sourcegraph/sourcegraph@v6.5.2654 */}
 ```json
 {
 	// REQUIRED:

--- a/docs/admin/code_hosts/azuredevops.mdx
+++ b/docs/admin/code_hosts/azuredevops.mdx
@@ -67,7 +67,7 @@ Azure DevOps connections support the following configuration options, which are 
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/azuredevops.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-07T17:35:37Z via sourcegraph/sourcegraph@v6.5.1211 */}
+{/* Last updated: 2025-07-10T00:07:30Z via sourcegraph/sourcegraph@v6.5.2654 */}
 ```json
 	// Authentication alternatives: token OR windowsPassword
 

--- a/docs/admin/code_hosts/bitbucket_cloud.mdx
+++ b/docs/admin/code_hosts/bitbucket_cloud.mdx
@@ -118,7 +118,7 @@ Bitbucket Cloud connections support the following configuration options, which a
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/bitbucket_cloud.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-07T17:35:37Z via sourcegraph/sourcegraph@v6.5.1211 */}
+{/* Last updated: 2025-07-10T00:07:29Z via sourcegraph/sourcegraph@v6.5.2654 */}
 ```json
 	// Authentication alternatives: username + appPassword
 

--- a/docs/admin/code_hosts/bitbucket_server.mdx
+++ b/docs/admin/code_hosts/bitbucket_server.mdx
@@ -209,7 +209,7 @@ Bitbucket Server / Bitbucket Data Center connections support the following confi
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/bitbucket_server.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-07T17:35:36Z via sourcegraph/sourcegraph@v6.5.1211 */}
+{/* Last updated: 2025-07-10T00:07:28Z via sourcegraph/sourcegraph@v6.5.2654 */}
 ```json
 	// Authentication alternatives: token OR password
 

--- a/docs/admin/code_hosts/gerrit.mdx
+++ b/docs/admin/code_hosts/gerrit.mdx
@@ -110,7 +110,7 @@ Gerrit connections support the following configuration options, which are specif
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/gerrit.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-07T17:35:39Z via sourcegraph/sourcegraph@v6.5.1211 */}
+{/* Last updated: 2025-07-10T00:07:32Z via sourcegraph/sourcegraph@v6.5.2654 */}
 ```json
 {
 	// If non-null, enforces Gerrit repository permissions. This requires that there is an item in the [site configuration json](https://sourcegraph.com/docs/admin/config/site_config#auth-providers) `auth.providers` field, of type "gerrit" with the same `url` field as specified in this `GerritConnection`.

--- a/docs/admin/code_hosts/github.mdx
+++ b/docs/admin/code_hosts/github.mdx
@@ -443,7 +443,7 @@ GitHub connections support the following configuration options, which are specif
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/github.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-07T17:35:34Z via sourcegraph/sourcegraph@v6.5.1211 */}
+{/* Last updated: 2025-07-10T00:07:27Z via sourcegraph/sourcegraph@v6.5.2654 */}
 ```json
 	// Authentication alternatives: token OR gitHubAppDetails OR externalAccount OR useRandomExternalAccount
 

--- a/docs/admin/code_hosts/gitlab.mdx
+++ b/docs/admin/code_hosts/gitlab.mdx
@@ -187,7 +187,7 @@ See [Internal rate limits](/admin/code_hosts/rate_limits#internal-rate-limits).
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/gitlab.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-07T17:35:35Z via sourcegraph/sourcegraph@v6.5.1211 */}
+{/* Last updated: 2025-07-10T00:07:28Z via sourcegraph/sourcegraph@v6.5.2654 */}
 ```json
 {
 	// If non-null, enforces GitLab repository permissions. This requires that there be an item in the `auth.providers` field of type "gitlab" with the same `url` field as specified in this `GitLabConnection`.

--- a/docs/admin/code_hosts/gitolite.mdx
+++ b/docs/admin/code_hosts/gitolite.mdx
@@ -27,7 +27,7 @@ To connect Gitolite to Sourcegraph:
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/gitolite.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-07T17:35:40Z via sourcegraph/sourcegraph@v6.5.1211 */}
+{/* Last updated: 2025-07-10T00:07:33Z via sourcegraph/sourcegraph@v6.5.2654 */}
 ```json
 {
 	// A list of repositories to never mirror from this Gitolite instance. Supports excluding by exact name ({"name": "foo"}).

--- a/docs/admin/code_hosts/other.mdx
+++ b/docs/admin/code_hosts/other.mdx
@@ -70,7 +70,7 @@ Repositories must be listed individually:
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/other_external_service.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-07T17:35:42Z via sourcegraph/sourcegraph@v6.5.1211 */}
+{/* Last updated: 2025-07-10T00:07:35Z via sourcegraph/sourcegraph@v6.5.2654 */}
 ```json
 {
 	// A list of repositories to never mirror by name after applying repositoryPathPattern. Supports excluding by exact name ({"name": "myrepo"}) or regular expression ({"pattern": ".*secret.*"}).

--- a/docs/admin/code_hosts/phabricator.mdx
+++ b/docs/admin/code_hosts/phabricator.mdx
@@ -79,7 +79,7 @@ The Sourcegraph instance's site admin must [update the `corsOrigin` site config 
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/phabricator.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-07T17:35:41Z via sourcegraph/sourcegraph@v6.5.1211 */}
+{/* Last updated: 2025-07-10T00:07:34Z via sourcegraph/sourcegraph@v6.5.2654 */}
 ```json
 {
 	// SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`.

--- a/docs/admin/config/settings.mdx
+++ b/docs/admin/config/settings.mdx
@@ -27,7 +27,7 @@ Settings options and their default values are shown below.
 
 {/* SCHEMA_SYNC_START: admin/config/settings.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-07T17:35:33Z via sourcegraph/sourcegraph@v6.5.1211 */}
+{/* Last updated: 2025-07-10T00:07:26Z via sourcegraph/sourcegraph@v6.5.2654 */}
 ```json
 {
 

--- a/docs/admin/config/site_config.mdx
+++ b/docs/admin/config/site_config.mdx
@@ -21,7 +21,7 @@ All site configuration options and their default values are shown below.
 
 {/* SCHEMA_SYNC_START: admin/config/site.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-07T17:35:32Z via sourcegraph/sourcegraph@v6.5.1211 */}
+{/* Last updated: 2025-07-10T00:07:25Z via sourcegraph/sourcegraph@v6.5.2654 */}
 ```json
 {
 

--- a/docs/admin/repo/perforce.mdx
+++ b/docs/admin/repo/perforce.mdx
@@ -221,7 +221,7 @@ With this setting, Sourcegraph will ignore any rules with a host other than `*`,
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/perforce.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-07T17:35:43Z via sourcegraph/sourcegraph@v6.5.1211 */}
+{/* Last updated: 2025-07-10T00:07:36Z via sourcegraph/sourcegraph@v6.5.2654 */}
 ```json
 {
 	// If non-null, enforces Perforce depot permissions.


### PR DESCRIPTION
This PR updates the embedded JSON schemas to match the schemas from Sourcegraph v6.5.2654.

## Changes
- Updates JSON schema files referenced in MDX documentation
- Maintains version consistency between code and documentation

## Automation
This PR was created automatically by the schema sync tool during the v6.5.2654 release process.

/cc @sourcegraph/release