### PR TITLE
Cloud LogPush: supports s3 destination

### DIFF
--- a/docs/cloud/index.mdx
+++ b/docs/cloud/index.mdx
@@ -169,6 +169,7 @@ Sourcegraph LogPush is an optional add-on to deliver audit logs to a customer pr
 Supported destinations:
 
 - Google Cloud Storage (GCS)
+- Amazon S3 (AWS)
 
 ## Requirements
 


### PR DESCRIPTION
Cloud supports configuring instant audit logs streaming to AWS S3 bucket.
Works instantly on internal instance:
<img width="1440" height="440" alt="Screenshot 2025-07-11 at 10 05 27" src="https://github.com/user-attachments/assets/da55360f-55f5-45d2-b062-1e6f94be07e4" />


## Pull Request approval

- [ ] @cloudyadi 
- [ ] @michaellzc 
