### PR TITLE
fix(source): update docs for enterprise starter release

### DIFF
--- a/docs/pricing/plans/enterprise-starter.mdx
+++ b/docs/pricing/plans/enterprise-starter.mdx
@@ -40,7 +40,7 @@ Sourcegraph Enterprise Starter offers the following limits:
 - Max 500 users per workspace
 - Max 100 repos per workspace
 - Starts with 25 GB of storage
-- 1 GB storage per seat added
+- 5 GB storage per seat added
 - 50 GB max total storage
 
 ## Workspace settings


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/SRC-1442/update-the-enterprise-starter-docs

This change updates the enterprise starter docs to reflect:

- we now have gitlab.com and bitbucket.org support
- the updated workspace limits 
- the lack of repository permissions for gitlab and bitbucket
- the updated repository picker UI 

