### PR TITLE
Update JSON schemas for v6.6.6969

### DIFF
--- a/docs/admin/code_hosts/aws_codecommit.mdx
+++ b/docs/admin/code_hosts/aws_codecommit.mdx
@@ -34,7 +34,7 @@ AWS CodeCommit connections support the following configuration options, which ar
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/aws_codecommit.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-10T00:07:31Z via sourcegraph/sourcegraph@v6.5.2654 */}
+{/* Last updated: 2025-07-21T22:37:46Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// REQUIRED:

--- a/docs/admin/code_hosts/azuredevops.mdx
+++ b/docs/admin/code_hosts/azuredevops.mdx
@@ -67,7 +67,7 @@ Azure DevOps connections support the following configuration options, which are 
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/azuredevops.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-10T00:07:30Z via sourcegraph/sourcegraph@v6.5.2654 */}
+{/* Last updated: 2025-07-21T22:37:45Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 	// Authentication alternatives: token OR windowsPassword
 

--- a/docs/admin/code_hosts/bitbucket_cloud.mdx
+++ b/docs/admin/code_hosts/bitbucket_cloud.mdx
@@ -118,13 +118,14 @@ Bitbucket Cloud connections support the following configuration options, which a
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/bitbucket_cloud.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-10T00:07:29Z via sourcegraph/sourcegraph@v6.5.2654 */}
+{/* Last updated: 2025-07-21T22:37:44Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
-	// Authentication alternatives: username + appPassword
-
 {
 	// The workspace access token to use when authenticating with Bitbucket Cloud.
 	"accessToken": null,
+
+	// The API token to use when authenticating with Bitbucket Cloud.
+	"apiToken": null,
 
 	// The API URL of Bitbucket Cloud, such as https://api.bitbucket.org. Generally, admin should not modify the value of this option because Bitbucket Cloud is a public hosting platform.
 	// Other example values:
@@ -132,6 +133,7 @@ Bitbucket Cloud connections support the following configuration options, which a
 	"apiURL": null,
 
 	// The app password to use when authenticating to the Bitbucket Cloud. Also set the corresponding "username" field.
+	// 🚨 NOTE 🚨: Please use the "apiToken" field instead of this field, since Bitbucket Cloud is deprecating app passwords as of June 9, 2026. See https://www.atlassian.com/blog/bitbucket/bitbucket-cloud-transitions-to-api-tokens-enhancing-security-with-app-password-deprecation for more details.
 	"appPassword": null,
 
 	// If non-null, enforces Bitbucket Cloud repository permissions. This requires that there is an item in the [site configuration json](https://sourcegraph.com/docs/admin/config/site_config#auth-providers) `auth.providers` field, of type "bitbucketcloud" with the same `url` field as specified in this `BitbucketCloudConnection`.

--- a/docs/admin/code_hosts/bitbucket_server.mdx
+++ b/docs/admin/code_hosts/bitbucket_server.mdx
@@ -209,7 +209,7 @@ Bitbucket Server / Bitbucket Data Center connections support the following confi
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/bitbucket_server.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-10T00:07:28Z via sourcegraph/sourcegraph@v6.5.2654 */}
+{/* Last updated: 2025-07-21T22:37:43Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 	// Authentication alternatives: token OR password
 

--- a/docs/admin/code_hosts/gerrit.mdx
+++ b/docs/admin/code_hosts/gerrit.mdx
@@ -110,7 +110,7 @@ Gerrit connections support the following configuration options, which are specif
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/gerrit.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-10T00:07:32Z via sourcegraph/sourcegraph@v6.5.2654 */}
+{/* Last updated: 2025-07-21T22:37:47Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// If non-null, enforces Gerrit repository permissions. This requires that there is an item in the [site configuration json](https://sourcegraph.com/docs/admin/config/site_config#auth-providers) `auth.providers` field, of type "gerrit" with the same `url` field as specified in this `GerritConnection`.

--- a/docs/admin/code_hosts/github.mdx
+++ b/docs/admin/code_hosts/github.mdx
@@ -443,7 +443,7 @@ GitHub connections support the following configuration options, which are specif
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/github.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-10T00:07:27Z via sourcegraph/sourcegraph@v6.5.2654 */}
+{/* Last updated: 2025-07-21T22:37:41Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 	// Authentication alternatives: token OR gitHubAppDetails OR externalAccount OR useRandomExternalAccount
 

--- a/docs/admin/code_hosts/gitlab.mdx
+++ b/docs/admin/code_hosts/gitlab.mdx
@@ -187,7 +187,7 @@ See [Internal rate limits](/admin/code_hosts/rate_limits#internal-rate-limits).
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/gitlab.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-10T00:07:28Z via sourcegraph/sourcegraph@v6.5.2654 */}
+{/* Last updated: 2025-07-21T22:37:42Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// If non-null, enforces GitLab repository permissions. This requires that there be an item in the `auth.providers` field of type "gitlab" with the same `url` field as specified in this `GitLabConnection`.

--- a/docs/admin/code_hosts/gitolite.mdx
+++ b/docs/admin/code_hosts/gitolite.mdx
@@ -27,7 +27,7 @@ To connect Gitolite to Sourcegraph:
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/gitolite.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-10T00:07:33Z via sourcegraph/sourcegraph@v6.5.2654 */}
+{/* Last updated: 2025-07-21T22:37:47Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// A list of repositories to never mirror from this Gitolite instance. Supports excluding by exact name ({"name": "foo"}).

--- a/docs/admin/code_hosts/other.mdx
+++ b/docs/admin/code_hosts/other.mdx
@@ -70,7 +70,7 @@ Repositories must be listed individually:
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/other_external_service.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-10T00:07:35Z via sourcegraph/sourcegraph@v6.5.2654 */}
+{/* Last updated: 2025-07-21T22:37:49Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// A list of repositories to never mirror by name after applying repositoryPathPattern. Supports excluding by exact name ({"name": "myrepo"}) or regular expression ({"pattern": ".*secret.*"}).

--- a/docs/admin/code_hosts/phabricator.mdx
+++ b/docs/admin/code_hosts/phabricator.mdx
@@ -79,7 +79,7 @@ The Sourcegraph instance's site admin must [update the `corsOrigin` site config 
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/phabricator.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-10T00:07:34Z via sourcegraph/sourcegraph@v6.5.2654 */}
+{/* Last updated: 2025-07-21T22:37:48Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`.

--- a/docs/admin/config/settings.mdx
+++ b/docs/admin/config/settings.mdx
@@ -27,7 +27,7 @@ Settings options and their default values are shown below.
 
 {/* SCHEMA_SYNC_START: admin/config/settings.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-10T00:07:26Z via sourcegraph/sourcegraph@v6.5.2654 */}
+{/* Last updated: 2025-07-21T22:37:40Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 

--- a/docs/admin/config/site_config.mdx
+++ b/docs/admin/config/site_config.mdx
@@ -21,7 +21,7 @@ All site configuration options and their default values are shown below.
 
 {/* SCHEMA_SYNC_START: admin/config/site.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-10T00:07:25Z via sourcegraph/sourcegraph@v6.5.2654 */}
+{/* Last updated: 2025-07-21T22:37:39Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 

--- a/docs/admin/repo/perforce.mdx
+++ b/docs/admin/repo/perforce.mdx
@@ -221,7 +221,7 @@ With this setting, Sourcegraph will ignore any rules with a host other than `*`,
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/perforce.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-10T00:07:36Z via sourcegraph/sourcegraph@v6.5.2654 */}
+{/* Last updated: 2025-07-21T22:37:50Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// If non-null, enforces Perforce depot permissions.


### PR DESCRIPTION
This PR updates the embedded JSON schemas to match the schemas from Sourcegraph v6.6.6969.

## Changes
- Updates JSON schema files referenced in MDX documentation
- Maintains version consistency between code and documentation

## Automation
This PR was created automatically by the schema sync tool during the v6.6.6969 release process.

/cc @sourcegraph/release