### PR TITLE
chore(docs): update file name for arch diagram

### DIFF
--- a/docs/admin/architecture.mdx
+++ b/docs/admin/architecture.mdx
@@ -4,7 +4,7 @@
 
 ## Diagram
 
-![sourcegraph-architecture](https://storage.googleapis.com/sourcegraph-assets/Docs/sg-architecture.svg)
+![sourcegraph-architecture](https://storage.googleapis.com/sourcegraph-assets/Docs/architecture.svg)
 
 ## Repository syncing
 


### PR DESCRIPTION
The architecture diagram generated in the monorepo is actually called `architecture.svg`, not `sg-architecture.svg`, so just changing it here. I've confirmed the file is in GCP ready to publish.

