### PR TITLE
Fix malformed code blocks in technical changelog

### DIFF
--- a/docs/technical-changelog.mdx
+++ b/docs/technical-changelog.mdx
@@ -309,19 +309,7 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 - Fede/ep UI fix left nav `(PR #6230)`
 - CI: remove scip-go upload to demo.sourcegraph.com `(PR #6220)`
   - [https://sourcegraph.slack.com/archives/C04MYFW01NV/p1750800014304569](https://sourcegraph.slack.com/archives/C04MYFW01NV/p1750800014304569)
-
-    ```
-Run src code-intel upload -github-token='***' -no-progress -repo=github.com/sourcegraph/sourcegraph
-💡 Inferred arguments
-   repo: github.com/sourcegraph/sourcegraph
-   commit: 552dc9[1](https://github.com/sourcegraph/sourcegraph/actions/runs/15861555759/job/44720169430?pr=6219#step:9:1)055580be3a0c021e40aacf0977710f1e1
-   root: dev/ci/images
-   file: index.scip
-   indexer: scip-go
-   indexerVersion: 0.1.24
-unexpected status code: 404 (failed to authorize request: repo not found: name="github.com/sourcegraph/sourcegraph")
-Error: Process completed with exit code 1.
-```
+  - Removed failing upload process that was causing CI errors
 - Polished EP UI `(PR #6207)`
 - completions/aws-sdk-compatibility `(PR #6198)`
 - feat(deep search): single URL for deepsearch [SPLF-1207] `(PR #6181)`
@@ -11024,4 +11012,3 @@ The following PRs were merged onto the previous release branch but could not be 
 ## Older versions
 
 For older versions of Sourcegraph, see the [CHANGELOG](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/CHANGELOG.md) on GitHub.
-```


### PR DESCRIPTION
## Problem

The technical changelog had malformed markdown code blocks that were breaking the rendering and making content unreadable. Specifically:

1. **PR #6220 entry**: Had content incorrectly wrapped in a code block that should have been regular text
2. **Stray closing backticks**: Extra ``` at the end of the file breaking markdown parsing

## Solution

- ✅ Removed incorrect code block formatting around PR #6220 description  
- ✅ Replaced with properly formatted bullet point explaining the change
- ✅ Removed stray closing backticks at end of file
- ✅ Preserved valid JSON code block for experimental features (this one was correctly formatted)

## Testing

- Verified all code blocks are now properly paired
- Confirmed markdown structure is valid
- No other formatting issues detected

## Related

This is a manual fix for the immediate formatting issue. The root cause in the changelog generation tool will be addressed separately to prevent similar issues in future releases.

Fixes the formatting problems shown in the attached screenshots where code blocks were not closing properly.