### PR TITLE
Updated cody analytics cookie name to SAMS cookie

### DIFF
--- a/docs/analytics/api.mdx
+++ b/docs/analytics/api.mdx
@@ -8,17 +8,17 @@ For Sourcegraph Analytics, you can generate an access token for programmatic acc
 
 ### Getting Started
 
-Access tokens are created using the `cas` cookie for authentication to the token creation endpoint. Access tokens are longer lived than the `cas` cookie making them more suitable for programmatic access to the Sourcegraph Analytics API.
+Access tokens are created using the SAMS session cookie (`accounts_session_v2`) for authentication to the token creation endpoint. Access tokens are longer lived than the SAMS session cookie making them more suitable for programmatic access to the Sourcegraph Analytics API.
 
 - Sign in to [Sourcegraph Analytics](https://analytics.sourcegraph.com).
-- Retrieve your session cookie, `cas`, from your browser's developer tools.
+- Retrieve your SAMS session cookie, `accounts_session_v2`, from your browser's developer tools.
 
 ![Sourcegraph Analytics session cookie](https://storage.googleapis.com/sourcegraph-assets/Docs/analytics-cookie.png)
 
 - Export the cookie as an environment variable to use in the following commands:
 
 ```sh
-export CAS_COOKIE="<CAS_COOKIE_VALUE>"
+export SAMS_COOKIE="<ACCOUNTS_SESSION_V2_VALUE>"
 ```
 
 #### Token creation
@@ -28,7 +28,7 @@ Create the token by running the following command:
 ```sh
 curl -X POST https://analytics.sourcegraph.com/api/service-access-tokens \
  -H "Content-Type: application/json" \
- -H "Cookie: cas=$CAS_COOKIE" \
+ -H "Cookie: accounts_session_v2=$SAMS_COOKIE" \
  -d '{}'
 
 # Optionally include displayName, expiresAt, or both in the request body.
@@ -54,7 +54,7 @@ List the tokens by running the following command:
 
 ```sh
 curl -X GET https://analytics.sourcegraph.com/api/service-access-tokens \
- -H "Cookie: cas=$CAS_COOKIE"
+ -H "Cookie: accounts_session_v2=$SAMS_COOKIE"
 ```
 
 Each token in the response will include the token ID, creation date, a boolean indicating if the token has expired, and display name and expiration date if provided. For example:
@@ -98,7 +98,7 @@ Revoke a token by running the following commands:
 export TOKEN_ID="<TOKEN_ID>"
 
 curl -X DELETE https://analytics.sourcegraph.com/api/service-access-tokens/$TOKEN_ID \
- -H "Cookie: cas=$CAS_COOKIE"
+ -H "Cookie: accounts_session_v2=$SAMS_COOKIE"
 ```
 
 <Callout type="note">The revocation request does not produce output. To verify that a token has been revoked, list the tokens and verify that `isExpired` is `true`.</Callout>


### PR DESCRIPTION
Updated documentation on how to use Sourcegraph Analytics API. Once [PR-207](https://github.com/sourcegraph/cody-analytics/pull/207)  is merged, the `cas` cookie will be updated to `accounts_session_v2`, unifying SAMS user sessions and closing [CORE-850](https://linear.app/sourcegraph/issue/CORE-850/src-analytics-unified-sams-user-sessions)

This PR will only be merged once [PR-207](https://github.com/sourcegraph/cody-analytics/pull/207) is fully tested and merged. 
