### PR TITLE
Update JSON schemas for v6.6.6969

### DIFF
--- a/docs/admin/code_hosts/aws_codecommit.mdx
+++ b/docs/admin/code_hosts/aws_codecommit.mdx
@@ -34,7 +34,7 @@ AWS CodeCommit connections support the following configuration options, which ar
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/aws_codecommit.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-24T01:50:54Z via sourcegraph/sourcegraph@v6.6.0 */}
+{/* Last updated: 2025-07-25T19:23:11Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// REQUIRED:

--- a/docs/admin/code_hosts/azuredevops.mdx
+++ b/docs/admin/code_hosts/azuredevops.mdx
@@ -67,7 +67,7 @@ Azure DevOps connections support the following configuration options, which are 
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/azuredevops.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-24T01:50:53Z via sourcegraph/sourcegraph@v6.6.0 */}
+{/* Last updated: 2025-07-25T19:23:10Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 	// Authentication alternatives: token OR windowsPassword
 

--- a/docs/admin/code_hosts/bitbucket_cloud.mdx
+++ b/docs/admin/code_hosts/bitbucket_cloud.mdx
@@ -118,7 +118,7 @@ Bitbucket Cloud connections support the following configuration options, which a
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/bitbucket_cloud.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-24T01:50:52Z via sourcegraph/sourcegraph@v6.6.0 */}
+{/* Last updated: 2025-07-25T19:23:10Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// The workspace access token to use when authenticating with Bitbucket Cloud.

--- a/docs/admin/code_hosts/bitbucket_server.mdx
+++ b/docs/admin/code_hosts/bitbucket_server.mdx
@@ -209,7 +209,7 @@ Bitbucket Server / Bitbucket Data Center connections support the following confi
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/bitbucket_server.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-24T01:50:51Z via sourcegraph/sourcegraph@v6.6.0 */}
+{/* Last updated: 2025-07-25T19:23:09Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 	// Authentication alternatives: token OR password
 

--- a/docs/admin/code_hosts/gerrit.mdx
+++ b/docs/admin/code_hosts/gerrit.mdx
@@ -110,7 +110,7 @@ Gerrit connections support the following configuration options, which are specif
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/gerrit.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-24T01:50:55Z via sourcegraph/sourcegraph@v6.6.0 */}
+{/* Last updated: 2025-07-25T19:23:12Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// If non-null, enforces Gerrit repository permissions. This requires that there is an item in the [site configuration json](https://sourcegraph.com/docs/admin/config/site_config#auth-providers) `auth.providers` field, of type "gerrit" with the same `url` field as specified in this `GerritConnection`.

--- a/docs/admin/code_hosts/github.mdx
+++ b/docs/admin/code_hosts/github.mdx
@@ -443,7 +443,7 @@ GitHub connections support the following configuration options, which are specif
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/github.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-24T01:50:49Z via sourcegraph/sourcegraph@v6.6.0 */}
+{/* Last updated: 2025-07-25T19:23:07Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 	// Authentication alternatives: token OR gitHubAppDetails OR externalAccount OR useRandomExternalAccount
 

--- a/docs/admin/code_hosts/gitlab.mdx
+++ b/docs/admin/code_hosts/gitlab.mdx
@@ -187,7 +187,7 @@ See [Internal rate limits](/admin/code_hosts/rate_limits#internal-rate-limits).
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/gitlab.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-24T01:50:50Z via sourcegraph/sourcegraph@v6.6.0 */}
+{/* Last updated: 2025-07-25T19:23:08Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// If non-null, enforces GitLab repository permissions. This requires that there be an item in the `auth.providers` field of type "gitlab" with the same `url` field as specified in this `GitLabConnection`.

--- a/docs/admin/code_hosts/gitolite.mdx
+++ b/docs/admin/code_hosts/gitolite.mdx
@@ -27,7 +27,7 @@ To connect Gitolite to Sourcegraph:
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/gitolite.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-24T01:50:56Z via sourcegraph/sourcegraph@v6.6.0 */}
+{/* Last updated: 2025-07-25T19:23:13Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// A list of repositories to never mirror from this Gitolite instance. Supports excluding by exact name ({"name": "foo"}).

--- a/docs/admin/code_hosts/other.mdx
+++ b/docs/admin/code_hosts/other.mdx
@@ -70,7 +70,7 @@ Repositories must be listed individually:
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/other_external_service.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-24T01:50:57Z via sourcegraph/sourcegraph@v6.6.0 */}
+{/* Last updated: 2025-07-25T19:23:15Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// A list of repositories to never mirror by name after applying repositoryPathPattern. Supports excluding by exact name ({"name": "myrepo"}) or regular expression ({"pattern": ".*secret.*"}).

--- a/docs/admin/code_hosts/phabricator.mdx
+++ b/docs/admin/code_hosts/phabricator.mdx
@@ -79,7 +79,7 @@ The Sourcegraph instance's site admin must [update the `corsOrigin` site config 
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/phabricator.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-24T01:50:56Z via sourcegraph/sourcegraph@v6.6.0 */}
+{/* Last updated: 2025-07-25T19:23:14Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`.

--- a/docs/admin/config/settings.mdx
+++ b/docs/admin/config/settings.mdx
@@ -27,7 +27,7 @@ Settings options and their default values are shown below.
 
 {/* SCHEMA_SYNC_START: admin/config/settings.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-24T01:50:48Z via sourcegraph/sourcegraph@v6.6.0 */}
+{/* Last updated: 2025-07-25T19:23:06Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 

--- a/docs/admin/config/site_config.mdx
+++ b/docs/admin/config/site_config.mdx
@@ -21,7 +21,7 @@ All site configuration options and their default values are shown below.
 
 {/* SCHEMA_SYNC_START: admin/config/site.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-24T01:50:48Z via sourcegraph/sourcegraph@v6.6.0 */}
+{/* Last updated: 2025-07-25T19:23:05Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 

--- a/docs/admin/repo/perforce.mdx
+++ b/docs/admin/repo/perforce.mdx
@@ -221,7 +221,7 @@ With this setting, Sourcegraph will ignore any rules with a host other than `*`,
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/perforce.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-24T01:50:58Z via sourcegraph/sourcegraph@v6.6.0 */}
+{/* Last updated: 2025-07-25T19:23:16Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// If non-null, enforces Perforce depot permissions.


### PR DESCRIPTION
This PR updates the embedded JSON schemas to match the schemas from Sourcegraph v6.6.6969.

## Changes
- Updates JSON schema files referenced in MDX documentation
- Maintains version consistency between code and documentation

## Automation
This PR was created automatically by the schema sync tool during the v6.6.6969 release process.

/cc @sourcegraph/release