### PR TITLE
Fix kustomize patch for searcher/symbols

### DIFF
--- a/docs/admin/deploy/kubernetes/configure.mdx
+++ b/docs/admin/deploy/kubernetes/configure.mdx
@@ -1010,7 +1010,7 @@ For example, to update the value for `SEARCHER_CACHE_SIZE_MB` and `SEARCHER_CACH
           value:
             name: SEARCHER_CACHE_SIZE_MB
             value: "50000"
-        - op: replace
+        - op: add
           path: /spec/template/spec/containers/0/env/0
           value:
             name: SYMBOLS_CACHE_SIZE_MB


### PR DESCRIPTION

<!-- Explain the changes introduced in your PR -->
This change fixes a minor double replace in the patch manifest in our docs that previously replaces  SEARCHER_CACHE_SIZE_MB with SYMBOLS_CACHE_SIZE_MB when the patch is applied.
## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
