### PR TITLE
Updating our Support LLMs page: gemini pro 2.5 preview, gemini flash 2.5 preview -> gemini pro 2.5, gemini flash 2.5

### DIFF
--- a/docs/cody/capabilities/supported-models.mdx
+++ b/docs/cody/capabilities/supported-models.mdx
@@ -28,8 +28,8 @@ Cody supports a variety of cutting-edge large language models for use in chat an
 | Google       | [Gemini 1.5 Pro](https://deepmind.google/technologies/gemini/pro/)                                                                            | ✅ (beta)         |
 | Google       | [Gemini 2.0 Flash](https://deepmind.google/technologies/gemini/flash/)                                                                        | ✅                |
 | Google       | [Gemini 2.0 Flash](https://deepmind.google/technologies/gemini/flash/)                                                                        | ✅                |
-| Google       | [Gemini 2.5 Pro Preview](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-pro)                                         | ✅                |
-| Google       | [Gemini 2.5 Flash Preview](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash)                                     | ✅ (experimental) |
+| Google       | [Gemini 2.5 Pro](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-pro)                                                 | ✅                |
+| Google       | [Gemini 2.5 Flash](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash)                                             | ✅                |
 
 <Callout type="note">To use Claude 3 Sonnet models with Cody Enterprise, make sure you've upgraded your Sourcegraph instance to the latest version. </Callout>
 


### PR DESCRIPTION
Changing the docs to reflect recent changes in Cody Gateway.  The preview models have been deprecated by Google. 

We recently swapped our models from: 

- Gemini Pro 2.5 Preview
- Gemini Flash 2.5 Preview
### Previous 
<img width="756" height="116" alt="GeminiModels_Before_Changes" src="https://github.com/user-attachments/assets/1dec061f-5027-41f9-947c-2c3ac2f11b4c" />


To: 

- Gemini Pro 2.5 
- Gemini Flash 2.5
### After PR 
<img width="732" height="150" alt="gemini_models_after_changes" src="https://github.com/user-attachments/assets/1189b13b-5fcd-4d88-bff9-d1f1457a2751" />

 ** Additionally, I removed the "experimental" word from Gemini 2.5 Flash

### Test

I ran the dev page on localhost to check the changes. 
