### PR TITLE
Update JSON schemas for v6.6.6969

### DIFF
--- a/docs/admin/code_hosts/aws_codecommit.mdx
+++ b/docs/admin/code_hosts/aws_codecommit.mdx
@@ -34,7 +34,7 @@ AWS CodeCommit connections support the following configuration options, which ar
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/aws_codecommit.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-28T21:25:35Z via sourcegraph/sourcegraph@v6.6.868 */}
+{/* Last updated: 2025-07-31T23:32:47Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// REQUIRED:
@@ -83,9 +83,6 @@ AWS CodeCommit connections support the following configuration options, which ar
 	// The type of Git URLs to use for cloning and fetching Git repositories.
 	// Valid options: "http", "ssh"
 	"gitURLType": "http",
-
-	// Deprecated and ignored field which will be removed entirely in the next release. AWS CodeCommit repositories can no longer be enabled or disabled explicitly. Configure which repositories should not be mirrored via "exclude" instead.
-	"initialRepositoryEnablement": false,
 
 	// The maximum number of repos that will be deleted per sync. A value of 0 or less indicates no maximum.
 	"maxDeletions": 0,

--- a/docs/admin/code_hosts/azuredevops.mdx
+++ b/docs/admin/code_hosts/azuredevops.mdx
@@ -67,7 +67,7 @@ Azure DevOps connections support the following configuration options, which are 
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/azuredevops.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-28T21:25:34Z via sourcegraph/sourcegraph@v6.6.868 */}
+{/* Last updated: 2025-07-31T23:32:46Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 	// Authentication alternatives: token OR windowsPassword
 

--- a/docs/admin/code_hosts/bitbucket_cloud.mdx
+++ b/docs/admin/code_hosts/bitbucket_cloud.mdx
@@ -118,7 +118,7 @@ Bitbucket Cloud connections support the following configuration options, which a
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/bitbucket_cloud.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-28T21:25:33Z via sourcegraph/sourcegraph@v6.6.868 */}
+{/* Last updated: 2025-07-31T23:32:45Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// The workspace access token to use when authenticating with Bitbucket Cloud.

--- a/docs/admin/code_hosts/bitbucket_server.mdx
+++ b/docs/admin/code_hosts/bitbucket_server.mdx
@@ -209,7 +209,7 @@ Bitbucket Server / Bitbucket Data Center connections support the following confi
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/bitbucket_server.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-28T21:25:32Z via sourcegraph/sourcegraph@v6.6.868 */}
+{/* Last updated: 2025-07-31T23:32:44Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 	// Authentication alternatives: token OR password
 
@@ -274,9 +274,6 @@ Bitbucket Server / Bitbucket Data Center connections support the following confi
 	// Other example values:
 	// - "ssh"
 	"gitURLType": "http",
-
-	// Deprecated and ignored field which will be removed entirely in the next release. BitBucket repositories can no longer be enabled or disabled explicitly.
-	"initialRepositoryEnablement": false,
 
 	// The maximum number of repos that will be deleted per sync. A value of 0 or less indicates no maximum.
 	"maxDeletions": 0,

--- a/docs/admin/code_hosts/gerrit.mdx
+++ b/docs/admin/code_hosts/gerrit.mdx
@@ -110,7 +110,7 @@ Gerrit connections support the following configuration options, which are specif
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/gerrit.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-28T21:25:36Z via sourcegraph/sourcegraph@v6.6.868 */}
+{/* Last updated: 2025-07-31T23:32:48Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// If non-null, enforces Gerrit repository permissions. This requires that there is an item in the [site configuration json](https://sourcegraph.com/docs/admin/config/site_config#auth-providers) `auth.providers` field, of type "gerrit" with the same `url` field as specified in this `GerritConnection`.

--- a/docs/admin/code_hosts/github.mdx
+++ b/docs/admin/code_hosts/github.mdx
@@ -443,7 +443,7 @@ GitHub connections support the following configuration options, which are specif
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/github.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-28T21:25:30Z via sourcegraph/sourcegraph@v6.6.868 */}
+{/* Last updated: 2025-07-31T23:32:42Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 	// Authentication alternatives: token OR gitHubAppDetails OR externalAccount OR useRandomExternalAccount
 
@@ -522,12 +522,6 @@ GitHub connections support the following configuration options, which are specif
 	// Valid options: "http", "ssh"
 	"gitURLType": "http",
 
-	// DEPRECATED: The installation ID of the GitHub App.
-	"githubAppInstallationID": null,
-
-	// Deprecated and ignored field which will be removed entirely in the next release. GitHub repositories can no longer be enabled or disabled explicitly. Configure repositories to be mirrored via "repos", "exclude" and "repositoryQuery" instead.
-	"initialRepositoryEnablement": false,
-
 	// The maximum number of repos that will be deleted per sync. A value of 0 or less indicates no maximum.
 	"maxDeletions": 0,
 
@@ -542,9 +536,6 @@ GitHub connections support the following configuration options, which are specif
 	//     "facebook"
 	//   ]
 	"orgs": null,
-
-	// Whether the code host connection is in a pending state.
-	"pending": false,
 
 	// Rate limit applied when making background API requests to GitHub.
 	"rateLimit": {

--- a/docs/admin/code_hosts/gitlab.mdx
+++ b/docs/admin/code_hosts/gitlab.mdx
@@ -187,7 +187,7 @@ See [Internal rate limits](/admin/code_hosts/rate_limits#internal-rate-limits).
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/gitlab.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-28T21:25:31Z via sourcegraph/sourcegraph@v6.6.868 */}
+{/* Last updated: 2025-07-31T23:32:43Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// If non-null, enforces GitLab repository permissions. This requires that there be an item in the `auth.providers` field of type "gitlab" with the same `url` field as specified in this `GitLabConnection`.
@@ -236,9 +236,6 @@ See [Internal rate limits](/admin/code_hosts/rate_limits#internal-rate-limits).
 	// If "ssh", Sourcegraph will access GitLab repositories using Git URLs of the form git@example.gitlab.com:myteam/myproject.git. See the documentation for how to provide SSH private keys and known_hosts: https://sourcegraph.com/docs/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.
 	// Valid options: "http", "ssh"
 	"gitURLType": "http",
-
-	// Deprecated and ignored field which will be removed entirely in the next release. GitLab repositories can no longer be enabled or disabled explicitly.
-	"initialRepositoryEnablement": false,
 
 	// If true, internal repositories will be accessible to all users on Sourcegraph as if they were public, and user permission syncs will no longer check for public repositories. This overrides repository permissions but allows easier discovery and access to internal repositories, and may be desirable if all users on the Sourcegraph instance should have access to all internal repositories anyways. Defaults to false.
 	"markInternalReposAsPublic": false,

--- a/docs/admin/code_hosts/gitolite.mdx
+++ b/docs/admin/code_hosts/gitolite.mdx
@@ -27,7 +27,7 @@ To connect Gitolite to Sourcegraph:
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/gitolite.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-28T21:25:37Z via sourcegraph/sourcegraph@v6.6.868 */}
+{/* Last updated: 2025-07-31T23:32:49Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// A list of repositories to never mirror from this Gitolite instance. Supports excluding by exact name ({"name": "foo"}).

--- a/docs/admin/code_hosts/other.mdx
+++ b/docs/admin/code_hosts/other.mdx
@@ -70,7 +70,7 @@ Repositories must be listed individually:
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/other_external_service.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-28T21:25:39Z via sourcegraph/sourcegraph@v6.6.868 */}
+{/* Last updated: 2025-07-31T23:32:50Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// A list of repositories to never mirror by name after applying repositoryPathPattern. Supports excluding by exact name ({"name": "myrepo"}) or regular expression ({"pattern": ".*secret.*"}).

--- a/docs/admin/code_hosts/phabricator.mdx
+++ b/docs/admin/code_hosts/phabricator.mdx
@@ -79,7 +79,7 @@ The Sourcegraph instance's site admin must [update the `corsOrigin` site config 
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/phabricator.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-28T21:25:38Z via sourcegraph/sourcegraph@v6.6.868 */}
+{/* Last updated: 2025-07-31T23:32:50Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// SSH cipher to use when cloning via SSH. Must be a valid choice from `ssh -Q cipher`.

--- a/docs/admin/config/settings.mdx
+++ b/docs/admin/config/settings.mdx
@@ -27,7 +27,7 @@ Settings options and their default values are shown below.
 
 {/* SCHEMA_SYNC_START: admin/config/settings.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-28T21:25:29Z via sourcegraph/sourcegraph@v6.6.868 */}
+{/* Last updated: 2025-07-31T23:32:41Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 

--- a/docs/admin/config/site_config.mdx
+++ b/docs/admin/config/site_config.mdx
@@ -21,7 +21,7 @@ All site configuration options and their default values are shown below.
 
 {/* SCHEMA_SYNC_START: admin/config/site.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-28T21:25:28Z via sourcegraph/sourcegraph@v6.6.868 */}
+{/* Last updated: 2025-07-31T23:32:40Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 
@@ -198,13 +198,6 @@ All site configuration options and their default values are shown below.
 			"bigQueryDataset": null,
 			"bigQueryGoogleProjectID": null,
 			"bigQueryTable": null
-		},
-		"codyProConfig": {
-			"samsBackendOrigin": "",
-			"sscBackendOrigin": "",
-			"sscBaseUrl": "https://accounts.sourcegraph.com/cody",
-			"stripePublishableKey": null,
-			"useEmbeddedUI": false
 		},
 		"enterprisePortal.enableProxies": true,
 		"sams.clientID": null,
@@ -894,14 +887,6 @@ All site configuration options and their default values are shown below.
 		"fastChatModel": null,
 		"fastChatModelMaxTokens": 0,
 		"model": null,
-		"perCommunityUserChatMonthlyInteractionLimit": 0,
-		"perCommunityUserChatMonthlyLLMRequestLimit": 0,
-		"perCommunityUserCodeCompletionsMonthlyInteractionLimit": 0,
-		"perCommunityUserCodeCompletionsMonthlyLLMRequestLimit": 0,
-		"perProUserChatDailyInteractionLimit": 0,
-		"perProUserChatDailyLLMRequestLimit": 0,
-		"perProUserCodeCompletionsDailyInteractionLimit": 0,
-		"perProUserCodeCompletionsDailyLLMRequestLimit": 0,
 		"perUserCodeCompletionsDailyLimit": 0,
 		"perUserDailyLimit": 0,
 		"provider": "sourcegraph",
@@ -964,8 +949,6 @@ All site configuration options and their default values are shown below.
 		"maxEmbeddingsPerRepo": 0,
 		"minimumInterval": "24h",
 		"model": null,
-		"perCommunityUserEmbeddingsMonthlyLimit": 0,
-		"perProUserEmbeddingsMonthlyLimit": 0,
 		"policyRepositoryMatchLimit": "5000",
 		"provider": null,
 		"url": null

--- a/docs/admin/repo/perforce.mdx
+++ b/docs/admin/repo/perforce.mdx
@@ -221,7 +221,7 @@ With this setting, Sourcegraph will ignore any rules with a host other than `*`,
 
 {/* SCHEMA_SYNC_START: admin/code_hosts/perforce.schema.json */}
 {/* WARNING: This section is auto-generated during releases. Do not edit manually. */}
-{/* Last updated: 2025-07-28T21:25:40Z via sourcegraph/sourcegraph@v6.6.868 */}
+{/* Last updated: 2025-07-31T23:32:51Z via sourcegraph/sourcegraph@v6.6.6969 */}
 ```json
 {
 	// If non-null, enforces Perforce depot permissions.


### PR DESCRIPTION
This PR updates the embedded JSON schemas to match the schemas from Sourcegraph v6.6.6969.

## Changes
- Updates JSON schema files referenced in MDX documentation
- Maintains version consistency between code and documentation

## Automation
This PR was created automatically by the schema sync tool during the v6.6.6969 release process.

/cc @sourcegraph/release