### PR TITLE
Mention non-experimental TLS settings

### DIFF
--- a/docs/admin/code_hosts/github.mdx
+++ b/docs/admin/code_hosts/github.mdx
@@ -192,21 +192,16 @@ These are OAuth tokens that Sourcegraph receives when a user signs into Sourcegr
 
 ### Custom Certificates
 
-> NOTE: Feature supported in Sourcegraph 5.1.5+
-
-
-If you are using a self-signed certificate for your GitHub Enterprise instance, configure `tls.external` under `experimentalFeatures`
+If you are using a self-signed certificate for your GitHub Enterprise instance, configure `tls.external`
 in the **Site configuration** with your certificate(s).
 
 ```json
 {
-  "experimentalFeatures": {
     "tls.external": {
       "certificates": [
         "-----BEGIN CERTIFICATE-----\n..."
       ]
     }
-  }
 }
 ```
 

--- a/docs/admin/code_hosts/index.mdx
+++ b/docs/admin/code_hosts/index.mdx
@@ -76,15 +76,13 @@ It may be the case that you'd like to temporarily disable all `git` and API requ
 
 ## Using Self-signed TLS Certificates
 
-To use Sourcegraph with self-signed TLS Certificates, update the site configuration to add the certificate and skip verification of the certificate chain. This configuration exists within the `experimentalFeatures`:
+To use Sourcegraph with self-signed TLS Certificates, update the site configuration to add the certificate and skip verification of the certificate chain:
 
 ```json
-"experimentalFeatures": {
     "tls.external": {
       "certificates": [
         "-----BEGIN CERTIFICATE-----\n..."
       ],
       "insecureSkipVerify": true
     }
-}
 ```

--- a/docs/admin/config/batch_changes.mdx
+++ b/docs/admin/config/batch_changes.mdx
@@ -306,19 +306,14 @@ Admins can configure Batch Changes to error when it creates commits that are not
 
 ## Custom Certificates
 
-<span class="badge badge-note">Sourcegraph 5.1.5+</span>
-
-If you are using a self-signed certificate for your GitHub Enterprise instance, configure `tls.external` under `experimentalFeatures`
-in the **Site configuration** with your certificate(s).
+If you are using a self-signed certificate for your GitHub Enterprise instance, configure `tls.external` in the **Site configuration** with your certificate(s).
 
 ```json
 {
-  "experimentalFeatures": {
-    "tls.external": {
-      "certificates": [
-        "-----BEGIN CERTIFICATE-----\n..."
-      ]
-    }
+  "tls.external": {
+    "certificates": [
+      "-----BEGIN CERTIFICATE-----\n..."
+    ]
   }
 }
 ```

--- a/docs/admin/config/private-network.mdx
+++ b/docs/admin/config/private-network.mdx
@@ -168,12 +168,10 @@ Add the formatted certificate to your Sourcegraph site configuration.
 
 ```json
 {
-    "experimentalFeatures": {
-        "tls.external": {
-            "certificates": [
-                "-----BEGIN CERTIFICATE-----\naZ...==\n-----END CERTIFICATE-----"
-            ]
-        }
+    "tls.external": {
+        "certificates": [
+            "-----BEGIN CERTIFICATE-----\naZ...==\n-----END CERTIFICATE-----"
+        ]
     }
 }
 ```
@@ -181,13 +179,11 @@ Add the formatted certificate to your Sourcegraph site configuration.
 For organizations with multiple root CAs (uncommon), additional certificates can be added to the array:
 ```json
 {
-    "experimentalFeatures": {
-        "tls.external": {
-            "certificates": [
-                "-----BEGIN CERTIFICATE-----\naZ...==\n-----END CERTIFICATE-----",
-                "-----BEGIN CERTIFICATE-----\nMI...I7\n-----END CERTIFICATE-----"
-            ]
-        }
+    "tls.external": {
+        "certificates": [
+            "-----BEGIN CERTIFICATE-----\naZ...==\n-----END CERTIFICATE-----",
+            "-----BEGIN CERTIFICATE-----\nMI...I7\n-----END CERTIFICATE-----"
+        ]
     }
 }
 ```

--- a/docs/cloud/private_connectivity_aws.mdx
+++ b/docs/cloud/private_connectivity_aws.mdx
@@ -77,7 +77,7 @@ Only if the private artifact registry is protected by authentication, the custom
 
 ### Can I use self-signed TLS certificate for my private resources?
 
-Yes. Please work with your account team to add the certificate chain of your internal CA to [site configuration](/admin/config/site_config#experimentalFeatures) at `experimentalFeatures.tls.external.certificates`.
+Yes. Please work with your account team to add the certificate chain of your internal CA to [site configuration](/admin/config/site_config) at `tls.external.certificates`.
 
 ### What is the disaster recovery plan?
 

--- a/docs/cloud/private_connectivity_gcp.mdx
+++ b/docs/cloud/private_connectivity_gcp.mdx
@@ -81,4 +81,4 @@ Only if the private artifact registry is protected by authentication, the custom
 
 ### Can I use self-signed TLS certificate for my private resources?
 
-Yes. Please work with your account team to add the certificate chain of your internal CA to [site configuration](/admin/config/site_config#experimentalFeatures) at `experimentalFeatures.tls.external.certificates`.
+Yes. Please work with your account team to add the certificate chain of your internal CA to [site configuration](/admin/config/site_config) at `tls.external.certificates`.

--- a/docs/cloud/private_connectivity_public_lb.mdx
+++ b/docs/cloud/private_connectivity_public_lb.mdx
@@ -69,4 +69,4 @@ If private artifact registry is protected by authentication, the customer will n
 
 ### Can I use self-signed TLS certificate for my private resources?
 
-Yes. Please work with your account team to add the certificate chain of your internal CA to [site configuration](/admin/config/site_config#experimentalFeatures) at `experimentalFeatures.tls.external.certificates`.
+Yes. Please work with your account team to add the certificate chain of your internal CA to [site configuration](/admin/config/site_config) at `tls.external.certificates`.

--- a/docs/cloud/private_connectivity_sourcegraph_connect.mdx
+++ b/docs/cloud/private_connectivity_sourcegraph_connect.mdx
@@ -134,7 +134,7 @@ The tunnel from the agent to the server is encrypted and authenticated by mTLS o
 
 ### Can I use Internal PKI or self-signed TLS certificates for my private resources?
 
-Yes. Please work with your account team to add the public certificate chain of your internal CAs, and / or your private resources' self-signed certs, under `experimentalFeatures.tls.external.certificates` in your instance's [site configuration](/admin/config/site_config#experimentalFeatures).
+Yes. Please work with your account team to add the public certificate chain of your internal CAs, and / or your private resources' self-signed certs, under `tls.external.certificates` in your instance's [site configuration](/admin/config/site_config).
 
 ### Is this connection highly available?
 


### PR DESCRIPTION
We're moving the setting out of experimental stage, as it's worked well for years. This is the corresponding docs change.

Works on SRC-1279.

Test plan: Code review.
