### PR TITLE
Removes community forum links

### DIFF
--- a/docs/code-search/index.mdx
+++ b/docs/code-search/index.mdx
@@ -71,7 +71,3 @@ No, the default search-based code navigation works out of the box without any co
 By default, files larger than **1 MB** are excluded from search results.
 
 <Callout type="note"> Read more in detail about other [Code Search FAQs here →](/code-search/faq)</Callout>
-
-## Join our community
-
-If you have any questions about Code Search, ask in [our community forum](https://community.sourcegraph.com).

--- a/docs/cody/faq.mdx
+++ b/docs/cody/faq.mdx
@@ -62,7 +62,7 @@ Cody supports a wide range of programming languages, including:
 - COBOL
 - Shell scripting languages (like Bash, PowerShell)
 
-Cody's response quality on a programming language depends on many factors, including the underlying LLM being used. We monitor accuracy metrics across all languages and regularly make improvements. [Let us know](https://community.sourcegraph.com/) if you're seeing poor quality on a particular programming language.
+Cody's response quality on a programming language depends on many factors, including the underlying LLM being used. We monitor accuracy metrics across all languages and regularly make improvements.
 
 ### Can Cody answer non-programming questions?
 

--- a/docs/cody/index.mdx
+++ b/docs/cody/index.mdx
@@ -62,4 +62,4 @@ Cody is compatible with other Sourcegraph products, like [Code Search](/code-sea
 
 ## Join our community
 
-If you have any questions regarding Cody, you can always [ask our community](https://community.sourcegraph.com), [Discord](https://discord.com/invite/s2qDtYGnAE), or [create a post on X](https://twitter.com/sourcegraphcody).
+If you have any questions regarding Cody, you can always [ask in Discord](https://discord.com/invite/s2qDtYGnAE), or [create a post on X](https://twitter.com/sourcegraphcody).

--- a/docs/cody/troubleshooting.mdx
+++ b/docs/cody/troubleshooting.mdx
@@ -2,7 +2,7 @@
 
 <p className="subtitle">Learn about common reasons for errors that you might run into when using Cody and how to troubleshoot them.</p>
 
-If you encounter errors or bugs while using Cody, try applying these troubleshooting methods to understand and configure the issue better. If the problem persists, you can report by using the [Support Forum](https://community.sourcegraph.com/), or by asking in the [Discord](https://discord.gg/s2qDtYGnAE) server.
+If you encounter errors or bugs while using Cody, try applying these troubleshooting methods to understand and configure the issue better. If the problem persists, you can report by asking in the [Discord](https://discord.gg/s2qDtYGnAE) server.
 
 ## VS Code extension
 
@@ -82,7 +82,7 @@ To troubleshoot further:
 
 ### Rate limits
 
-On Enterprise plans, usage limits are increased, and controlled by **Fair Usage**. This means that some users occasionally experience a limitation placed on their account. This limitation resets within 24 hours. If this issue persists, contact us through our [community forum](https://community.sourcegraph.com), Discord, or email support@sourcegraph.com.
+On Enterprise plans, usage limits are increased, and controlled by **Fair Usage**. This means that some users occasionally experience a limitation placed on their account. This limitation resets within 24 hours. If this issue persists, contact us through our [Discord](https://discord.com/invite/s2qDtYGnAE), or email support@sourcegraph.com.
 
 ### Error logging in VS Code on Linux and Windows
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -54,4 +54,4 @@ Stay in sync and get the latest news on Sourcegraph products, technologies, and 
 
 ## Join our Community
 
-If you have questions about anything related to Sourcegraph, you're always welcome to ask our in our [Sourcegraph community forum](https://community.sourcegraph.com), [Discord](https://discord.gg/s2qDtYGnAE), and [X](https://twitter.com/sourcegraph).
+If you have questions about anything related to Sourcegraph, you're always welcome to ask in in our [Discord](https://discord.gg/s2qDtYGnAE), and [X](https://twitter.com/sourcegraph).

--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -168,17 +168,6 @@ export function TableOfContents({ headings }: Props) {
 								Go to Sourcegraph.com
 							</a>
 						</div>
-						<div className="flex items-center mt-2 text-sm">
-							<a
-								href="https://community.sourcegraph.com"
-								target="_blank"
-								rel="noopener noreferrer"
-								className="flex items-center text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
-							>
-								<BugIcon className="mr-1 h-4 w-4" />
-								Questions? Give us feedback
-							</a>
-						</div>
 					</>
 				)}
 			</nav>


### PR DESCRIPTION
Removes links to the community forum from the documentation and table of contents. This change focuses on directing users to Discord and X (Twitter) for community support and discussions.

<!-- Explain the changes introduced in your PR -->

## Pull Request approval

You will need to get your PR approved by at least one member of the Sourcegraph team. For reviews of docs formatting, styles, and component usage, please tag the docs team via the #docs Slack channel.
