### PR TITLE
Add Enhanced Context Windows documentation for Cody Token Limits docs page

### DIFF
--- a/docs/cody/core-concepts/token-limits.mdx
+++ b/docs/cody/core-concepts/token-limits.mdx
@@ -50,7 +50,7 @@ When the `enhanced-context-window` feature flag is enabled, Cody Enterprise cust
 - OpenAI o-series: **100k tokens**
 - Reasoning models: up to **100k tokens**
 
-<Callout type="note">The enhanced context windows require the `enhanced-context-window` feature flag to be set to `true` in your Sourcegraph instance. Contact your Sourcegraph support if you need help enabling this feature.</Callout>
+<Callout type="note">The enhanced context windows require the `enhanced-context-window` feature flag to be set to `true` in your Sourcegraph instance. Contact Sourcegraph support if you need help enabling this feature.</Callout>
 
 ## What is a Context Window?
 

--- a/docs/cody/core-concepts/token-limits.mdx
+++ b/docs/cody/core-concepts/token-limits.mdx
@@ -31,6 +31,27 @@ Here's a detailed breakdown of the token limits by model:
 
 <Callout type="info">For Cody Enterprise, the token limits are the standard limits. Exact token limits may vary depending on your deployment. Please get in touch with your Sourcegraph representative. For more information on how Cody builds context, see our [docs here](/cody/core-concepts/context).</Callout>
 
+## Enhanced Context Windows (Feature Flag)
+
+Since 6.5 for Enterprise, we rolled out a feature flag `enhanced-context-window` that significantly expands Cody's context capabilities. This feature addresses developers' need to work with more context by expanding both input and output context windows.
+
+When the `enhanced-context-window` feature flag is enabled, Cody Enterprise customers get access to:
+
+**Input context window (via @mention and user input):**
+- Anthropic Claude: up to **150k tokens**
+- Google Gemini: up to **150k tokens**  
+- OpenAI GPT-series: up to **102k tokens**
+- OpenAI o-series: up to **93k tokens**
+
+**Output context window:**
+- Anthropic Claude: up to **64k tokens**
+- Google Gemini: up to **65k tokens**
+- OpenAI GPT-series: **16k tokens**
+- OpenAI o-series: **100k tokens**
+- Reasoning models: up to **100k tokens**
+
+<Callout type="note">The enhanced context windows require the `enhanced-context-window` feature flag to be set to `true` in your Sourcegraph instance. Contact your Sourcegraph support if you need help enabling this feature.</Callout>
+
 ## What is a Context Window?
 
 A context window in large language models refers to the maximum number of tokens (words or subwords) the model can process simultaneously. This window determines how much context the model can consider when generating text or code.


### PR DESCRIPTION
Documenting the feature flag is important for customers to understand that they can take advantage of enhanced context limits. I added this section to the Cody Input and Output Limits page to reflect how the feature flag enables larger context windows for various models supported by Sourcegraph.

	•	Enhanced context windows require the enhanced-context-window feature flag to be enabled
	•	Available since Sourcegraph 6.5 for Enterprise customers
	•	Input: Claude/Gemini up to 150k, OpenAI GPT up to 102k, OpenAI o-series up to 93k
	•	Output: Claude 64k, Gemini 65k, OpenAI GPT 16k, OpenAI o-series 100k, Reasoning models 100k
	
	
Testing: Ran docs locally, confirmed everything looks good