### PR TITLE
Remove section on archive label for repositories

### DIFF
--- a/docs/admin/code_hosts/bitbucket_server.mdx
+++ b/docs/admin/code_hosts/bitbucket_server.mdx
@@ -191,10 +191,6 @@ Bitbucket Server / Bitbucket Data Center versions older than v5.5 require specif
 
 Sourcegraph by default clones repositories from your Bitbucket Server / Bitbucket Data Center via HTTP(S), using the access token or account credentials you provide in the configuration. The [`username`](/admin/code_hosts/bitbucket_server#configuration) field is always used when cloning, so it is required.
 
-## Repository labels
-
-Sourcegraph will mark repositories as archived if they have the `archived` label on Bitbucket Server / Bitbucket Data Center. You can exclude these repositories in search with `archived:no` [search syntax](/code-search/queries).
-
 ## Internal rate limits
 
 See [Internal rate limits](/admin/code_hosts/rate_limits#internal-rate-limits).


### PR DESCRIPTION
Wtih https://github.com/sourcegraph/sourcegraph/pull/7158 we now support Bitbucket Server's own archived repositories, so this label workaround is no longer relevant.