### PR TITLE
Removed broken links on Telemetry page - added link to admin page

### DIFF
--- a/docs/admin/index.mdx
+++ b/docs/admin/index.mdx
@@ -31,6 +31,7 @@ Sourcegraph administration is primarily managed by site administrators, who are 
 - [Beta and experimental features](/admin/beta_and_experimental_features)
 - [Code navigation](/code-search/code-navigation/)
 - [Pings](/admin/pings)
+- [Telemetry](/admin/telemetry)
 - [Enterprise pricing and licenses](/admin/subscriptions/)
 - [Search](/admin/search)
 - [Usage statistics](/admin/usage_statistics)

--- a/docs/admin/telemetry/index.mdx
+++ b/docs/admin/telemetry/index.mdx
@@ -21,4 +21,4 @@ Some of the measures we take to ensure privacy and data security are:
 2. User identifiers are numeric and anonymized, as identifiers are specific per-instance.
 3. Data will be encrypted while in motion from each Sourcegraph instance to Sourcegraph.
 
-You can also explore our [telemetry development reference](https://docs-legacy.sourcegraph.com/dev/background-information/telemetry) to learn more about new system with which we record telemetry events, and refer to our [telemetry events data schema](https://docs-legacy.sourcegraph.com/dev/background-information/telemetry/protocol) for specific attributes that are and are not exported by default.
+You can reach out to support@sourcegraph.com for additional information about how telemetry events are recorded and which attributes are exported by default.


### PR DESCRIPTION
Issue:

The last paragraph of the [Telemetry page](https://sourcegraph.com/docs/admin/telemetry) contains two broken links that point to legacy docs. 

This PR removes the paragraph and replaces it with a sentence directing users to contact support for more information about telemetry.

Additionally, I noticed that customers could only find the telemetry from the search bar or the technical changelog. So I added a link to the telemetry page in the list of admin resources on /docs/admin.

Tested it by running local dev