### PR TITLE
docs(sourcegraph): Document deep search timeout and remove deep search from mcp docs

### DIFF
--- a/docs/api/mcp/index.mdx
+++ b/docs/api/mcp/index.mdx
@@ -177,16 +177,7 @@ Find repositories where a contributor has made commits.
 - `limit` - Maximum repositories to return (optional, default 20)
 - `minCommits` - Minimum commits required (optional, default 1)
 
-### [Deep Search](/deep-search)
 
-#### `sg_deepsearch`
-
-Perform comprehensive analysis of complex questions about your codebase.
-
-**Parameters:**
-- `question` - Complex technical question (required)
-
-**Features:** Agentic LLM-powered research with automatic tool usage
 
 ## Usage Examples
 

--- a/docs/deep-search/api.mdx
+++ b/docs/deep-search/api.mdx
@@ -38,6 +38,10 @@ curl 'https://your-sourcegraph-instance.com/.api/deepsearch/v1' \
 
 ## Creating conversations
 
+<Callout type="note">
+	Synchronous API calls currently have a **1 minute timeout**. For complex questions that might take longer to process, request [asynchronous processing](#asynchronous-processing) instead.
+</Callout>
+
 Create a new Deep Search conversation by asking a question:
 
 ```bash


### PR DESCRIPTION
Adds callout for 1 minute synchronous Deep Search API timeout and removes Deep Search from the list of Sourcegraph MCP tools. 
