### PR TITLE
Updated a link on point to code-host-interactions-in-batch-changes

### DIFF
--- a/docs/admin/code_hosts/github.mdx
+++ b/docs/admin/code_hosts/github.mdx
@@ -249,7 +249,7 @@ No [token scopes](https://docs.github.com/en/developers/apps/building-oauth-apps
 [permissions]: #repository-permissions
 [permissions-caching]: #teams-and-organizations-permissions-caching
 [batch-changes]: /batch-changes/
-[batch-changes-interactions]: /batch_changes/explanations/permissions_in_batch_changes#code-host-interactions-in-batch-changes
+[batch-changes-interactions]: /batch-changes/permissions-in-batch-changes#code-host-interactions-in-batch-changes
 
 
 > WARNING: In addition to the prerequisite token scopes, the account attached to the token must actually have the same level of access to the relevant resources that you are trying to grant. For example:


### PR DESCRIPTION

## Pull Request approval


On our docs, **Admin -> Cody Host -> Github**, in the section [Personal Access Tokens,](https://sourcegraph.com/docs/admin/code_hosts/github#personal-access-token-scopes) we have a broken link on the text "(learn more)" 


<img width="653" height="348" alt="image" src="https://github.com/user-attachments/assets/035d4103-9926-4762-a0a6-b4f9ea073bb1" />


This section had a broken link pointing to this path: 
https://sourcegraph.com/docs/batch_changes/explanations/permissions_in_batch_changes#code-host-interactions-in-batch-changes

I've updated it to point to:
https://sourcegraph.com/docs/batch-changes/permissions-in-batch-changes#code-host-interactions-in-batch-changes

Tested on local env







