### PR TITLE
Remove research preview verbiage from Deep Search

### DIFF
--- a/docs/deep-search/index.mdx
+++ b/docs/deep-search/index.mdx
@@ -2,7 +2,7 @@
 
 <p className= "subtitle">Learn more about Sourcegraph's agentic Code Search tool Deep Search.</p>
 
-<Callout type="note"> New in version 6.5. Deep Search is available for Enterprise and Enterprise Starter customers. It's not supported for BYOK users. Please reach out to your Sourcegraph account team to request access. </Callout>
+<Callout type="note">Deep Search is available for Enterprise and Enterprise Starter customers. It's not supported for BYOK users. Please reach out to your Sourcegraph account team to request access. </Callout>
 
 Deep Search is an agentic code search tool that understands natural language questions about your codebase. When a question is submitted, Deep Search performs an in-depth search and returns a detailed answer. The conversation can be continued with follow-up questions to dive deeper into relevant code.
 


### PR DESCRIPTION
Deep Search isn't a preview feature anymore, so we can remove the text calling it a research preview.
