### PR TITLE
Add Deep Search to main docs page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,9 +1,10 @@
 Sourcegraph is a Code Intelligence platform that deeply understands your code, no matter how large or where it’s hosted, to power modern developer experiences.
 
 - **Code Search:** Search through all of your repositories across all branches and all code hosts
+- **Deep Search:** Ask natural language questions and get detailed answers from our AI agent 
 - **Code Intelligence:** Navigate code, find references, see code owners, trace history, and more
 - **Fix and Refactor:** Roll out and track large-scale changes and migrations across repos at once
-- **AI Assistant:** Use Cody our AI code assistant to read, write, and understand your entire codebase faster
+- **AI Assistant:** Use Cody, our AI code assistant to read, write, and understand your entire codebase faster
 
 ## Quickstart
 
@@ -21,6 +22,12 @@ Sourcegraph is a Code Intelligence platform that deeply understands your code, n
 		imgAlt="Cody"
 		title="Cody"
 		description="Write, fix, and maintain code with Sourcegraph’s AI coding assistant, Cody. "
+	/>
+	<QuickLink
+		title="Deep Search"
+		icon="plugins"
+		href="/deep-search"
+		description="Get comprehensive answers to complex code questions using an AI agent that explores your codebase."
 	/>
 	<QuickLink
 		title="Sourcegraph 101"
@@ -42,7 +49,8 @@ Some of the main Sourcegraph features include:
 
 | **Feature**         | **Description**                                                                                                                                                          |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Cody**            | Cody is and AI coding assistant that writes, fixes, and maintains your code                                                                                           |
+| **Deep Search**     | Natural language code search with a dedicated AI agent that explores your codebase	 																					 |
+| **Cody**            | Cody is and AI coding assistant that writes, fixes, and maintains your code                                                                                           	 |
 | **Code Navigation** | Jump-to-definition, find references, and other IDE-like code browsing features on any branch, commit, or PR/code review                                                  |
 | **Code Insights**   | Reveal high-level information about your codebase at its current state and over time, to track migrations, version usage, vulnerability remediation, ownership, and more |
 | **Batch Changes**   | Make large-scale code changes across many repositories and codehosts                                                                                                     |


### PR DESCRIPTION
It feels like we should feature DS a bit more prominently, so I added it to the main docs page.