### PR TITLE
feat(source): Document the 'all' option for requiredSsoOrgs

### DIFF
--- a/docs/admin/auth/index.mdx
+++ b/docs/admin/auth/index.mdx
@@ -188,7 +188,9 @@ When combined with `"allowSignup": false` or unset, an admin should first create
 
 Requires that users have SAML SSO authorization for specific GitHub organizations when authenticating via OAuth. This is useful when your GitHub organizations enforce SAML SSO, and you want to ensure users properly authorize the OAuth application for those organizations during the authentication flow. Not doing so could cause permissions syncing issues.
 
-This setting accepts **GitHub organization IDs** (numeric strings), not organization names.
+This setting accepts one of two values:
+- A list of **GitHub organization IDs** (numeric strings), not organization names.
+- A list with a single entry: ["any"], which means **all** organizations need to be authorized.
 
 **Finding your GitHub organization ID:**
 


### PR DESCRIPTION
Documents the "all" option for `requiredSsoOrgs` added here: https://github.com/sourcegraph/sourcegraph/pull/7519