### PR TITLE
fix typo in scip-go circle ci job example

### DIFF
--- a/docs/code-search/code-navigation/how-to/index_a_go_repository.mdx
+++ b/docs/code-search/code-navigation/how-to/index_a_go_repository.mdx
@@ -60,9 +60,9 @@ jobs:
       - run: src code-intel upload -github-token=<<parameters.github-token>> -ignore-upload-failure
 
 workflows:
-  scip-typescript:
+  scip-go:
     jobs:
-      - scip-typescript
+      - scip-go
 ```
 
 The following projects have example CircleCI configurations to generate and upload SCIP indexes.


### PR DESCRIPTION
fix typo in scip-go circle ci job example