### PR TITLE
docs: Add Redis 7.4.6-272 security patch to v6.9.0 changelog

### DIFF
--- a/docs/technical-changelog.mdx
+++ b/docs/technical-changelog.mdx
@@ -54,6 +54,13 @@ This page documents all notable changes to Sourcegraph. For more detailed change
 
 - [kustomize](https://github.com/sourcegraph/deploy-sourcegraph-k8s/releases/tag/v6.9.0)
 
+### Chore
+
+#### Security
+
+- Update redis to 7.4.6-272 `(PR #7488)`
+  - This release patches multiple critical CVEs in Redis, including CVE-2025-49844, CVE-2025-46817, CVE-2025-46818, and CVE-2025-46819. See [Redis release notes](https://redis.io/docs/latest/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-272/) for details.
+
 ### Reverts
 
   There were no reverts for this release


### PR DESCRIPTION
## Changes

This PR adds the Redis security update to the technical changelog for version 6.9.0.

The entry documents the update to Redis 7.4.6-272, which patches multiple critical CVEs:
- CVE-2025-49844
- CVE-2025-46817
- CVE-2025-46818
- CVE-2025-46819

## References

- [Original PR](https://github.com/sourcegraph/sourcegraph/pull/7488)
- [Redis release notes](https://redis.io/docs/latest/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-272/)


Test Plan:

Ran this locally: See image attached 


<img width="695" height="634" alt="image" src="https://github.com/user-attachments/assets/756b0cd5-df5a-4748-9518-014d9d30de11" />
