### PR TITLE
GitHub Apps: Add additional permissions requirement

### DIFF
--- a/docs/admin/code_hosts/github.mdx
+++ b/docs/admin/code_hosts/github.mdx
@@ -47,7 +47,7 @@ To create a GitHub App and connect it to Sourcegraph:
     Emails (Manage a user's email addresses): read
     Members (Organization members and teams): read
     Metadata (Search repositories, list collaborators, and access repository metadata): read
-    Administration (Repository creation, deletion, settings, teams, and collaborators): read (required for groups caching)
+    Administration (Repository creation, deletion, settings, teams, and collaborators): read (only required for groups caching)
 	```
 
 <img alt="The GitHub App creation page on Sourcegraph, with the default values filled out" src="https://sourcegraphstatic.com/docs/images/administration/config/github-apps/github-apps-create-dark.png" />


### PR DESCRIPTION
Add an additional required permission to GitHub Apps, which is required when using groups caching
