### PR TITLE
Document result limits for MCP tools

### DIFF
--- a/docs/api/mcp/index.mdx
+++ b/docs/api/mcp/index.mdx
@@ -156,6 +156,8 @@ Read file contents with line numbers and support for specific ranges and revisio
 
 **Use cases:** Reading specific files, examining code sections, reviewing different versions
 
+<Callout type="note">File size limit is 128KB. Use line ranges for larger files.</Callout>
+
 #### `sg_list_files`
 
 List files and directories in a repository path.


### PR DESCRIPTION
Closes SPLF-1441

<img width="1456" height="442" alt="CleanShot 2025-10-29 at 10 41 20" src="https://github.com/user-attachments/assets/cbefe357-ee19-4dd5-a5c2-0ac0b3fb2db8" />
