### PR TITLE
remove endpoint command line and expand on SRC_ENDPOINT and SRC_ACCES_TOKEN

### DIFF
--- a/docs/batch-changes/quickstart.mdx
+++ b/docs/batch-changes/quickstart.mdx
@@ -31,15 +31,7 @@ curl -L https://<YOUR-SOURCEGRAPH-INSTANCE-URL>/.api/src-cli/src_linux_amd64 -o 
 chmod +x /usr/local/bin/src
 ```
 
-Authenticate `src` with your Sourcegraph instance by running `src login` and following the instructions:
-
-```bash
-src login https://<YOUR-SOURCEGRAPH-INSTANCE-URL>
-```
-
-![src-login-success](https://sourcegraphstatic.com/docs/images/batch_changes/src_login_success.png)
-
-Once `src login` reports that you're authenticated, you're ready for the next step.
+Authenticate `src` with your Sourcegraph instance by following the [CLI quickstart](/cli/quickstart) and you'll be ready for the next step.
 
 ## Write a batch spec
 

--- a/docs/cli/quickstart.mdx
+++ b/docs/cli/quickstart.mdx
@@ -47,17 +47,17 @@ For other options, please refer to [the Windows specific `src` documentation](/c
 
 ## Connect to Sourcegraph
 
-`src` needs to be authenticated against your Sourcegraph instance. The quickest way to do this is to run `src login https://YOUR-SOURCEGRAPH-INSTANCE` and follow the instructions:
-
-![Output from src login showing success](https://sourcegraphstatic.com/docs/images/batch_changes/src_login_success.png)
+`src` needs to be authenticated against your Sourcegraph instance. The quickest way to do this is to add `SRC_ENDPOINT=https://YOUR-SOURCEGRAPH-INSTANCE` to your shell environment, then run `src login` to launch OAuth authentication against your Sourcegraph instance.
 
 ### OAuth login
 
-`src login` supports interactive OAuth login, so you can sign in without creating or exporting a `SRC_ACCESS_TOKEN`.
+`src login` supports interactive OAuth login, so you can sign in without creating or exporting `SRC_ACCESS_TOKEN`.
 
 If you need to reuse the current `src` credential in another command, `src auth token` prints the raw token and `src auth token --header` prints a complete `Authorization` header for the active authentication mode.
 
-If you need non-interactive authentication, such as in CI or scripts, you can still use `SRC_ENDPOINT` and `SRC_ACCESS_TOKEN`.
+### PAT login
+
+If you need non-interactive authentication, such as in CI or scripts, you can still [create an access token](/cli/how-tos/creating-an-access-token) in your Sourcegraph instance, then use `SRC_ACCESS_TOKEN` in the shell environment.
 
 ## Run a code search
 

--- a/docs/cli/quickstart.mdx
+++ b/docs/cli/quickstart.mdx
@@ -57,7 +57,7 @@ If you need to reuse the current `src` credential in another command, `src auth 
 
 ### PAT login
 
-If you need non-interactive authentication, such as in CI or scripts, you can still [create an access token](/cli/how-tos/creating-an-access-token) in your Sourcegraph instance, then use `SRC_ACCESS_TOKEN` in the shell environment.
+If you need non-interactive authentication, such as in CI or scripts, you can still [create an access token](/cli/how-tos/creating-an-access-token) in your Sourcegraph instance, then use `SRC_ACCESS_TOKEN` in the shell environment, along with `SRC_ENDPOINT`. In this case, `src login` is not necessary: `src` will use the PAT from the environment to authenticate against your Sourcegraph instance.
 
 ## Run a code search
 


### PR DESCRIPTION
We're still figuring out how to expand `src login` with OAuth; made some (hopefully clarifying) changes to the CLI quickstart docs.