### PR TITLE
Move 5.x releases to legacy section

### DIFF
--- a/docs/legacy.mdx
+++ b/docs/legacy.mdx
@@ -1,77 +1,77 @@
 # Legacy Versions
 
 <p className="subtitle">
-	This page displays the docs for legacy Sourcegraph versions less than 5.1
+	Find versioned documentation for previous versions of Sourcegraph below.
 </p>
 
 <Accordion title="Sourcegraph 6.X">
 
--   [6.12](https://6.12.sourcegraph.com)
--   [6.11](https://6.11.sourcegraph.com)
--   [6.10](https://6.10.sourcegraph.com)
--   [6.9](https://6.9.sourcegraph.com)
--   [6.8](https://6.8.sourcegraph.com)
--   [6.7](https://6.7.sourcegraph.com)
--   [6.6](https://6.6.sourcegraph.com)
--   [6.5](https://6.5.sourcegraph.com)
--   [6.4](https://6.4.sourcegraph.com)
--   [6.3](https://6.3.sourcegraph.com)
--   [6.2](https://6.2.sourcegraph.com)
--   [6.1](https://6.1.sourcegraph.com)
--   [6.0](https://6.0.sourcegraph.com)
+- [6.12](https://6.12.sourcegraph.com)
+- [6.11](https://6.11.sourcegraph.com)
+- [6.10](https://6.10.sourcegraph.com)
+- [6.9](https://6.9.sourcegraph.com)
+- [6.8](https://6.8.sourcegraph.com)
+- [6.7](https://6.7.sourcegraph.com)
+- [6.6](https://6.6.sourcegraph.com)
+- [6.5](https://6.5.sourcegraph.com)
+- [6.4](https://6.4.sourcegraph.com)
+- [6.3](https://6.3.sourcegraph.com)
+- [6.2](https://6.2.sourcegraph.com)
+- [6.1](https://6.1.sourcegraph.com)
+- [6.0](https://6.0.sourcegraph.com)
 
 </Accordion>
 
 <Accordion title="Sourcegraph 5.X">
 
--   [5.11](https://5.11.sourcegraph.com/)
--   [5.10](https://5.10.sourcegraph.com/)
--   [5.9](https://5.9.sourcegraph.com/)
--   [5.8](https://5.8.sourcegraph.com/)
--   [5.7](https://5.7.sourcegraph.com/)
--   [5.6](https://5.6.sourcegraph.com/)
--   [5.5](https://5.5.sourcegraph.com/)
--   [5.4](https://5.4.sourcegraph.com)
--   [5.3](https://5.3.sourcegraph.com/)
--   [5.2](https://5.2.sourcegraph.com/)
--   [5.1](https://docs.sourcegraph.com/@5.1/)
--   [5.0](https://docs.sourcegraph.com/@5.0/)
+- [5.11](https://5.11.sourcegraph.com/)
+- [5.10](https://5.10.sourcegraph.com/)
+- [5.9](https://5.9.sourcegraph.com/)
+- [5.8](https://5.8.sourcegraph.com/)
+- [5.7](https://5.7.sourcegraph.com/)
+- [5.6](https://5.6.sourcegraph.com/)
+- [5.5](https://5.5.sourcegraph.com/)
+- [5.4](https://5.4.sourcegraph.com)
+- [5.3](https://5.3.sourcegraph.com/)
+- [5.2](https://5.2.sourcegraph.com/)
+- [5.1](https://docs.sourcegraph.com/@5.1/)
+- [5.0](https://docs.sourcegraph.com/@5.0/)
 
 </Accordion>
 
 <Accordion title="Sourcegraph 4.X">
 
--   [4.5](https://docs.sourcegraph.com/@4.5/)
--   [4.4](https://docs.sourcegraph.com/@4.4/)
--   [4.3](https://docs.sourcegraph.com/@4.3/)
--   [4.2](https://docs.sourcegraph.com/@4.2/)
--   [4.1](https://docs.sourcegraph.com/@4.1/)
--   [4.0](https://docs.sourcegraph.com/@4.0/)
+- [4.5](https://docs.sourcegraph.com/@4.5/)
+- [4.4](https://docs.sourcegraph.com/@4.4/)
+- [4.3](https://docs.sourcegraph.com/@4.3/)
+- [4.2](https://docs.sourcegraph.com/@4.2/)
+- [4.1](https://docs.sourcegraph.com/@4.1/)
+- [4.0](https://docs.sourcegraph.com/@4.0/)
 
 </Accordion>
 
 <Accordion title="Sourcegraph 3.X">
 
--   [3.43](https://docs.sourcegraph.com/@3.43/)
--   [3.41](https://docs.sourcegraph.com/@3.41/)
--   [3.40](https://docs.sourcegraph.com/@3.40/)
--   [3.39](https://docs.sourcegraph.com/@3.39/)
--   [3.38](https://docs.sourcegraph.com/@3.38/)
--   [3.37](https://docs.sourcegraph.com/@3.37/)
--   [3.36](https://docs.sourcegraph.com/@3.36/)
--   [3.35](https://docs.sourcegraph.com/@3.35/)
--   [3.34](https://docs.sourcegraph.com/@3.34/)
--   [3.32](https://docs.sourcegraph.com/@3.32/)
--   [3.31](https://docs.sourcegraph.com/@3.31/)
--   [3.30](https://docs.sourcegraph.com/@3.30/)
--   [3.29](https://docs.sourcegraph.com/@3.29/)
--   [3.28](https://docs.sourcegraph.com/@3.28/)
--   [3.27](https://docs.sourcegraph.com/@3.27/)
--   [3.26](https://docs.sourcegraph.com/@3.26/)
--   [3.25](https://docs.sourcegraph.com/@3.25/)
--   [3.24](https://docs.sourcegraph.com/@3.24/)
--   [3.23](https://docs.sourcegraph.com/@3.23/)
--   [3.22](https://docs.sourcegraph.com/@3.22/)
--   [3.21](https://docs.sourcegraph.com/@3.21/)
+- [3.43](https://docs.sourcegraph.com/@3.43/)
+- [3.41](https://docs.sourcegraph.com/@3.41/)
+- [3.40](https://docs.sourcegraph.com/@3.40/)
+- [3.39](https://docs.sourcegraph.com/@3.39/)
+- [3.38](https://docs.sourcegraph.com/@3.38/)
+- [3.37](https://docs.sourcegraph.com/@3.37/)
+- [3.36](https://docs.sourcegraph.com/@3.36/)
+- [3.35](https://docs.sourcegraph.com/@3.35/)
+- [3.34](https://docs.sourcegraph.com/@3.34/)
+- [3.32](https://docs.sourcegraph.com/@3.32/)
+- [3.31](https://docs.sourcegraph.com/@3.31/)
+- [3.30](https://docs.sourcegraph.com/@3.30/)
+- [3.29](https://docs.sourcegraph.com/@3.29/)
+- [3.28](https://docs.sourcegraph.com/@3.28/)
+- [3.27](https://docs.sourcegraph.com/@3.27/)
+- [3.26](https://docs.sourcegraph.com/@3.26/)
+- [3.25](https://docs.sourcegraph.com/@3.25/)
+- [3.24](https://docs.sourcegraph.com/@3.24/)
+- [3.23](https://docs.sourcegraph.com/@3.23/)
+- [3.22](https://docs.sourcegraph.com/@3.22/)
+- [3.21](https://docs.sourcegraph.com/@3.21/)
 
 </Accordion>

--- a/src/components/ReleasesTable.tsx
+++ b/src/components/ReleasesTable.tsx
@@ -25,35 +25,6 @@ function formatDate(dateString: string): string {
 	});
 }
 
-type LegacyRelease = {
-	name: string;
-	date: string;
-	anchor?: string;
-	url?: string;
-};
-
-const legacySupportedReleases: LegacyRelease[] = [
-	{name: '5.10 Patch 1', date: 'December 2024', url: 'https://sourcegraph.com/changelog/releases/5.10.1164'},
-	{name: '5.10 Patch 0', date: 'November 2024', url: 'https://sourcegraph.com/changelog/releases/5.10.0'},
-	{name: '5.9 Patch 3', date: 'November 2024', url: 'https://sourcegraph.com/changelog/releases/5.9.1590'},
-	{name: '5.9 Patch 2', date: 'November 2024', url: 'https://sourcegraph.com/changelog/releases/5.9.347'},
-	{name: '5.9 Patch 1', date: 'November 2024', url: 'https://sourcegraph.com/changelog/releases/5.9.45'},
-	{name: '5.9 Patch 0', date: 'October 2024', url: 'https://sourcegraph.com/changelog/releases/5.9.0'},
-	{name: '5.8 Patch 1', date: 'October 2024', url: 'https://sourcegraph.com/changelog/releases/5.8.1579'},
-	{name: '5.8 Patch 0', date: 'October 2024', url: 'https://sourcegraph.com/changelog/releases/5.8.0'},
-	{name: '5.7 Patch 1', date: 'September 2024', url: 'https://sourcegraph.com/changelog/releases/5.7.2474'},
-	{name: '5.7 Patch 0', date: 'September 2024', url: 'https://sourcegraph.com/changelog/releases/5.7.0'},
-	{name: '5.6 Patch 2', date: 'August 2024', anchor: 'v562535'},
-	{name: '5.6 Patch 1', date: 'August 2024', anchor: 'v56185'},
-	{name: '5.6', date: 'August 2024', anchor: 'v560'},
-	{name: '5.5', date: 'July 2024', anchor: 'v553956'},
-	{name: '5.4', date: 'May 2024', anchor: 'v547765'},
-	{name: '5.3', date: 'February 2024', anchor: 'v5312303'},
-	{name: '5.2', date: 'October 2023', anchor: 'v527'},
-	{name: '5.1', date: 'June 2023', anchor: 'v519'},
-	{name: '5.0', date: 'March 2023', anchor: 'v506'}
-];
-
 export function SupportedReleasesTable() {
 	const [releases, setReleases] = useState<Release[]>([]);
 	const [loading, setLoading] = useState(true);
@@ -147,38 +118,6 @@ export function SupportedReleasesTable() {
 							</td>
 						</tr>
 					))}
-					{legacySupportedReleases.map(release => (
-						<tr key={release.name}>
-							<td className="px-4 py-2">{release.name}</td>
-							<td className="px-4 py-2">{release.date}</td>
-							<td className="px-4 py-2">✅</td>
-							<td className="px-4 py-2">
-								{release.url ? (
-									<a
-										href={release.url}
-										className="text-blue-600 hover:underline dark:text-blue-400"
-									>
-										Notes
-									</a>
-								) : (
-									<Link
-										href={`/technical-changelog#${release.anchor}`}
-										className="text-blue-600 hover:underline dark:text-blue-400"
-									>
-										Notes
-									</Link>
-								)}
-							</td>
-							<td className="px-4 py-2">
-								<Link
-									href="/admin/deploy"
-									className="text-blue-600 hover:underline dark:text-blue-400"
-								>
-									Install
-								</Link>
-							</td>
-						</tr>
-					))}
 				</tbody>
 			</table>
 		</div>
@@ -187,6 +126,65 @@ export function SupportedReleasesTable() {
 
 export function DeprecatedReleasesTable() {
 	const deprecatedReleases = [
+		{
+			version: '5.10 Patch 1',
+			date: 'December 2024',
+			url: 'https://sourcegraph.com/changelog/releases/5.10.1164'
+		},
+		{
+			version: '5.10 Patch 0',
+			date: 'November 2024',
+			url: 'https://sourcegraph.com/changelog/releases/5.10.0'
+		},
+		{
+			version: '5.9 Patch 3',
+			date: 'November 2024',
+			url: 'https://sourcegraph.com/changelog/releases/5.9.1590'
+		},
+		{
+			version: '5.9 Patch 2',
+			date: 'November 2024',
+			url: 'https://sourcegraph.com/changelog/releases/5.9.347'
+		},
+		{
+			version: '5.9 Patch 1',
+			date: 'November 2024',
+			url: 'https://sourcegraph.com/changelog/releases/5.9.45'
+		},
+		{
+			version: '5.9 Patch 0',
+			date: 'October 2024',
+			url: 'https://sourcegraph.com/changelog/releases/5.9.0'
+		},
+		{
+			version: '5.8 Patch 1',
+			date: 'October 2024',
+			url: 'https://sourcegraph.com/changelog/releases/5.8.1579'
+		},
+		{
+			version: '5.8 Patch 0',
+			date: 'October 2024',
+			url: 'https://sourcegraph.com/changelog/releases/5.8.0'
+		},
+		{
+			version: '5.7 Patch 1',
+			date: 'September 2024',
+			url: 'https://sourcegraph.com/changelog/releases/5.7.2474'
+		},
+		{
+			version: '5.7 Patch 0',
+			date: 'September 2024',
+			url: 'https://sourcegraph.com/changelog/releases/5.7.0'
+		},
+		{version: '5.6 Patch 2', date: 'August 2024', anchor: 'v562535'},
+		{version: '5.6 Patch 1', date: 'August 2024', anchor: 'v56185'},
+		{version: '5.6', date: 'August 2024', anchor: 'v560'},
+		{version: '5.5', date: 'July 2024', anchor: 'v553956'},
+		{version: '5.4', date: 'May 2024', anchor: 'v547765'},
+		{version: '5.3', date: 'February 2024', anchor: 'v5312303'},
+		{version: '5.2', date: 'October 2023', anchor: 'v527'},
+		{version: '5.1', date: 'June 2023', anchor: 'v519'},
+		{version: '5.0', date: 'March 2023', anchor: 'v506'},
 		{version: '4.5', date: 'February 2023', anchor: 'v451'},
 		{version: '4.4', date: 'January 2023', anchor: 'v442'},
 		{version: '4.3', date: 'December 2022', anchor: 'v431'},


### PR DESCRIPTION
Policy is latest two major releases (so 7.x and 6.x at this time), we just forgot to update this.