### PR TITLE
Enhance SCIM setup instructions for Okta

### DIFF
--- a/docs/admin/scim.mdx
+++ b/docs/admin/scim.mdx
@@ -72,6 +72,24 @@ To configure:
 
 To set up user provisioning in [Okta](https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SCIM.htm), you must first set up a new app integration of the "SAML 2.0" type, then configure it to use SCIM. Here are the steps to do this:
 
+<Callout type="note">
+  Please note: Okta offers two different provisioning configuration UIs depending on the
+  integration type: **SCIM Connection** (used with standard integrations) and
+  **Connector Configuration** (used with custom connectors via the Okta
+  provisioning agent). The steps below apply to both, but the way the
+  `Authorization` header is entered differs slightly:
+
+  - In the **SCIM Connection** UI, there is a dedicated `Bearer` prefix field
+    alongside the token input — enter only the raw token in the token field.
+  - In the **Connector Configuration** UI, there is a single text field for the
+    full header value — you must enter the full string `Bearer {your token}`
+    (including the `Bearer ` prefix) in that field.
+
+  In both cases, the Sourcegraph SCIM server requires the `Authorization` header
+  to be in the format `Bearer {your token}`. Omitting the `Bearer ` prefix will
+  result in a `401 Unauthorized` error.
+</Callout>
+
 1. Follow our [SAML guide](/admin/auth/saml/okta) to set up a new app integration with SAML, then open the integration you just created.
     - If you already have the integration, just open your existing app integration.
 1. Go to the "General" tab and click "Edit" in the "App Settings" section.


### PR DESCRIPTION
Added detailed instructions for configuring SCIM with Okta, including notes on different provisioning UIs and authorization header formats.

More context in this customer issue from customer: https://app.plain.com/workspace/w_01K95VFHPKPY4ERZD73YRRR0RH/thread/th_01KNJ35T7Y4GJFW4CJ99P97F2H

And this internal discussion: https://sourcegraph.slack.com/archives/C05MW2TMYAV/p1775760662675869