### PR TITLE
Update azuredevops.mdx

### DIFF
--- a/docs/admin/code-hosts/azuredevops.mdx
+++ b/docs/admin/code-hosts/azuredevops.mdx
@@ -40,6 +40,11 @@ Next, configure the code host connection by following the next steps:
     	"token": "<admin token>",
     	"projects": ["org1/project1"],
     	"orgs": ["org2"]
+		// Optionally, use the `repos` field below to sync only specific repositories.
+		"repos": [
+		    "myorg/myproject/myrepo1", 
+		    "myorg/myproject/myrepo2"
+		  ]
     }
     ```
 
@@ -47,7 +52,7 @@ Next, configure the code host connection by following the next steps:
 
 ## Repository syncing
 
-Currently, all repositories belonging to the configured organizations/projects will be synced.
+All repositories within the configured organizations/projects are synced by default, but you can also choose to sync either all repositories or only specific repositories from those organizations/projects.
 
 In addition, you may exclude one or more repositories by setting the [`exclude`](/admin/code-hosts/azuredevops#configuration) field in the code host connection.
 
@@ -126,6 +131,13 @@ Azure DevOps connections support the following configuration options, which are 
 	//     "org/project"
 	//   ]
 	"projects": null,
+
+	// An array of "org/project/repo" strings specifying which Azure DevOps repositories within a project should be mirrored in Sourcegraph.
+	"repos": [
+	    "myorg/my-project/myrepo",        // Format: <organization>/<project>/<repository>
+	    "myorg/myproject/myproject",     // Format: repository where project and repo share the same name
+	    "myorg/my project/my project"    // Format: spaces in project or repository names
+  	]
 
 	// Rate limit applied when making background API requests.
 	"rateLimit": {

--- a/docs/admin/code-hosts/azuredevops.mdx
+++ b/docs/admin/code-hosts/azuredevops.mdx
@@ -39,8 +39,7 @@ Next, configure the code host connection by following the next steps:
     	"username": "<admin username>",
     	"token": "<admin token>",
     	"projects": ["org1/project1"],
-    	"orgs": ["org2"]
-		// Optionally, use the `repos` field below to sync only specific repositories.
+    	"orgs": ["org2"],
 		"repos": [
 		    "myorg/myproject/myrepo1", 
 		    "myorg/myproject/myrepo2"


### PR DESCRIPTION
Updated the page to include the recently Added `repos` field to Azure DevOps external service for explicit repository selection