### PR TITLE
Replace PRECISE_CODE_INTEL_UPLOAD_TTL with CODEINTEL_UPLOADSTORE_EXPIRER_MAX_AGE

### DIFF
--- a/docs/code-navigation/envvars.mdx
+++ b/docs/code-navigation/envvars.mdx
@@ -15,7 +15,6 @@ The following settings should be the same for the [`precise-code-intel-worker`](
 | `PRECISE_CODE_INTEL_UPLOAD_BACKEND`       | `blobstore`    | The target file service for code graph uploads. S3, GCS, and Blobstore are supported. In older versions of Sourcegraph (before v3.4.2) `Minio` was also a valid value. |
 | `PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET` | `false`        | Whether or not the client should manage the target bucket configuration                                                                                                |
 | `PRECISE_CODE_INTEL_UPLOAD_BUCKET`        | `lsif-uploads` | The name of the bucket to store LSIF uploads in                                                                                                                        |
-| `PRECISE_CODE_INTEL_UPLOAD_TTL`           | `168h`         | The maximum age of an upload before deletion                                                                                                                           |
 
 The following settings should be the same for the [`codeintel-auto-indexing`](#codeintel-auto-indexing) worker task as well.
 
@@ -76,6 +75,15 @@ The following variables influence the behavior of the [`codeintel-janitor` worke
 | `PRECISE_CODE_INTEL_RETENTION_COMMIT_BATCH_SIZE`                   | `100`       | The number of commits to process per upload at a time.                                                                                                                                                                               |
 | `PRECISE_CODE_INTEL_CONFIGURATION_POLICY_MEMBERSHIP_BATCH_SIZE`    | `100`       | The maximum number of policy configurations to update repository membership for at a time.                                                                                                                                           |
 
+### `codeintel-upload-store-expirer`
+
+The following variables influence the behavior of the upload store expirer job, which cleans up old SCIP uploads from object storage.
+
+| **Name**                                    | **Default** | **Description**                                                                                                                                                                  |
+| ------------------------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CODEINTEL_UPLOADSTORE_EXPIRER_MAX_AGE`     | `168h`      | Time to leave an uploaded SCIP index file in the bucket before deletion, which should be long enough for the Precise Code Intel Worker to process the file into the codeintel-db.|
+| `CODEINTEL_UPLOADSTORE_EXPIRER_INTERVAL`    | `1h`        | The frequency the expirer job runs.                                                                                                                                              |
+
 ## precise-code-intel-worker
 
 The following are variables are read from the `precise-code-intel-worker` service to control code graph data upload processing behavior.
@@ -92,4 +100,3 @@ The following settings should be the same for the [`frontend`](#frontend) servic
 | `PRECISE_CODE_INTEL_UPLOAD_BACKEND`       | `blobstore`    | The target file service for code graph data uploads. S3, GCS, and Blobstore are supported. |
 | `PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET` | `false`        | Whether or not the client should manage the target bucket configuration                    |
 | `PRECISE_CODE_INTEL_UPLOAD_BUCKET`        | `lsif-uploads` | The name of the bucket to store LSIF uploads in                                            |
-| `PRECISE_CODE_INTEL_UPLOAD_TTL`           | `168h`         | The maximum age of an upload before deletion                                               |

--- a/docs/self-hosted/external-services/object-storage.mdx
+++ b/docs/self-hosted/external-services/object-storage.mdx
@@ -57,10 +57,9 @@ To target a GCS bucket you've already provisioned, set the following environment
 
 ### Provisioning buckets
 
-If you would like to allow your Sourcegraph instance to control the creation and lifecycle configuration management of the target buckets, set the following environment variables:
+If you would like to allow your Sourcegraph instance to call the AWS S3 / GCS API to create the bucket, set the following environment variable:
 
 -   `PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET=true`
--   `PRECISE_CODE_INTEL_UPLOAD_TTL=168h` (default)
 
 ## Search Job Results
 


### PR DESCRIPTION
Our docs currently suggest customers configure a deprecated env var. This update replaces it with the effective env var. 

https://github.com/sourcegraph/sourcegraph/pull/11717 removes the deprecated env var from code. 