### PR TITLE
docs: update batch changes video to new logo version

### DIFF
--- a/docs/batch-changes/index.mdx
+++ b/docs/batch-changes/index.mdx
@@ -23,7 +23,7 @@ Batch Changes helps you ship large-scale code changes across many repositories a
 	style={{width: '100%', height: 'auto'}}
 >
 	<source
-		src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/batch-changes.webm"
+		src="https://storage.googleapis.com/sourcegraph-assets/Docs/Media/batch-changes-new-logo.webm"
 		type="video/webm"
 	/>
 </video>


### PR DESCRIPTION
## Summary

- Updates the batch changes index page video source from `batch-changes.webm` to `batch-changes-new-logo.webm`
- Ensures the demo video reflects the current Sourcegraph branding/logo

### Before/Current
<img width="1414" height="1038" alt="CleanShot 2026-04-16 at 13 12 56@2x" src="https://github.com/user-attachments/assets/a2d5bfe5-2151-49d4-bde9-1a2e04a09a26" />


### After
<img width="1534" height="1646" alt="CleanShot 2026-04-16 at 13 11 04@2x" src="https://github.com/user-attachments/assets/58183da7-6708-44ac-9c92-4c0d82032532" />

## Test plan

- [ ] [Visit the Batch Changes docs page](https://sourcegraph-docs-git-fix-batch-chan-0389d1-sourcegraph-f8c71130.vercel.app/batch-changes) and verify the video loads and plays correctly with the new logo
