### PR TITLE
docs: update Batch Changes credentials to reflect GitHub OAuth support

### DIFF
--- a/docs/batch-changes/configuring-credentials.mdx
+++ b/docs/batch-changes/configuring-credentials.mdx
@@ -17,8 +17,8 @@ The following authentication methods are supported:
 
 | **Code Host**                    | **Personal Access Token** | **Fine-Grained Access Token** | **GitHub App** | **OAuth** |
 | -------------------------------- | :-----------------------: | :---------------------------: | :------------: | :-------: |
-| GitHub                           |             ✅             |               ✅               |  ✅ (experimental) |     ❌     |
-| GitHub Enterprise                |             ✅             |               ✅               |  ✅ (experimental) |     ❌     |
+| GitHub                           |             ✅             |               ✅               |  ✅ (experimental) |     ✅     |
+| GitHub Enterprise                |             ✅             |               ✅               |  ✅ (experimental) |     ✅     |
 | GitLab                           |             ✅             |               ❌               |       ❌        |     ✅     |
 | Bitbucket Server / Data Center   |             ✅             |               ❌               |       ❌        |     ✅     |
 | Bitbucket Cloud                  |             ✅             |               ❌               |       ❌        |     ✅     |
@@ -144,9 +144,7 @@ The `workflow` scope is technically only required if your batch changes modify f
 When working with organizations that have SAML SSO (Single Sign On) enabled, configuring credentials requires an additional step that [involves white-listing the token for use in that organization](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on).
 
 <Callout type="info">
-	Currently, classic and fine-grained access tokens are supported only.
-	Alternative token types like OAuth access tokens (for example, OAuth apps)
-	are not supported.
+	Classic and fine-grained access tokens, as well as OAuth access tokens, are supported.
 </Callout>
 
 #### Personal Access Token
@@ -233,9 +231,7 @@ When working with organizations that have SAML SSO (Single Sign On) enabled, con
 </Callout>
 
 <Callout type="info">
-	Currently, classic personal and fine-grained access tokens are supported
-	only. Alternative token types like OAuth access tokens (for example, OAuth
-	apps) are not supported.
+	Classic personal and fine-grained access tokens, as well as OAuth access tokens, are supported.
 </Callout>
 
 ### GitLab


### PR DESCRIPTION
## Summary

Updates the Batch Changes configuring credentials documentation to correctly reflect that GitHub OAuth is supported.

### Changes
- Mark OAuth as supported (✅) for GitHub and GitHub Enterprise in the authentication methods table
- Update callout notes for both GitHub.com and GitHub Enterprise sections to confirm OAuth access tokens are supported