### PR TITLE
revise admin consultation note for Experimental features

### DIFF
--- a/docs/beta-and-experimental/index.mdx
+++ b/docs/beta-and-experimental/index.mdx
@@ -41,7 +41,7 @@ If a feature is labeled **Beta**, this specifically means:
 - The feature may be widely available to all customers by default
 - There may be no fixed timeline for moving the feature to general availability
 - Some **Beta** features may have credit costs associated with them when they graduate to general availability; see [credits and billing](#credits-and-billing)
-- Admins can disable **Beta** features globally
+- Admins can request for **Beta** features to be temporarily disabled globally
 
 General points about [both beta and experimental features](#beta-and-experimental-features) also apply.
 

--- a/docs/beta-and-experimental/index.mdx
+++ b/docs/beta-and-experimental/index.mdx
@@ -30,7 +30,7 @@ If a feature is labeled **Experimental**, this specifically means:
 - The feature is intended for early evaluation and will generally require deliberate enablement
 - There may be no fixed timeline for moving the feature to **Beta** or general availability
 - Some **Experimental** features may have credit costs associated with them when they exit Beta into general availability; see [credits and billing](#credits-and-billing)
-- Admins can disable **Experimental** features globally
+- Admins will be consulted before **Experimental** features are enabled
 
 General points about [both beta and experimental features](#beta-and-experimental-features) also apply.
 


### PR DESCRIPTION
I think this made experimental sound more self-serve than it should - in practice, we should probably aim for a very hands-on approach in experimental stage, where we do enablement customer by customer.

Only in beta stage, should we allow customers to request for features to be request disablement on a temporary basis (because we dont want every feature to have toggles forever)