### PR TITLE
add smart hover docs

### DIFF
--- a/docs/code-navigation/smart-hover.mdx
+++ b/docs/code-navigation/smart-hover.mdx
@@ -1,4 +1,4 @@
-# Smart Hover Summaries
+# Smart hover summaries
 
 <TierCallout>
 	Supported on [Enterprise](/pricing/plans/enterprise) plans.

--- a/docs/code-navigation/smart-hover.mdx
+++ b/docs/code-navigation/smart-hover.mdx
@@ -18,7 +18,7 @@ Summaries are powered by a small, fast model, but only compiler-grade precise co
 
 ## Billing
 
-Smart hover summaries are a [Beta feature](/beta-and-experimental) and free while the feature is in Beta. The feature may become [billable with credits](/beta-and-experimental#credits-and-billing) and a very small associated cost in the future once it becomes generally available. However, at least 30 days notice will be given before such a change goes into effect.
+Smart hover summaries are a [Beta feature](/beta-and-experimental) and free while the feature is in Beta. The feature may become [billable with credits](/beta-and-experimental#credits-and-billing) once it becomes generally available. At least 30 days notice will be given before such a change goes into effect.
 
 ## Feedback
 

--- a/docs/code-navigation/smart-hover.mdx
+++ b/docs/code-navigation/smart-hover.mdx
@@ -1,0 +1,25 @@
+# Smart Hover Summaries
+
+<TierCallout>
+	Supported on [Enterprise](/pricing/plans/enterprise) plans.
+	<user>This feature is currently in [Beta](/beta-and-experimental).</user>
+</TierCallout>
+
+When [precise code intelligence](/code-navigation/precise-code-navigation) is available, Sourcegraph will provide a generated summary of the meaning of the symbol, and usage of the symbol across the codebase. In combination with the precise code intelligence hover information, this often saves the need to jump to a symbol and back which interrupts the flow of reading, and simplifies understanding complex codebases. Linked citations can even serve as an alternative to traditional code navigation.
+
+![Smart hover summary demo](https://storage.googleapis.com/changelog-static-assets-prod/20260417_smart-hover-summaries-beta_smart-hover-demo2.jpg)
+
+Summaries are powered by a small, fast model, but only compiler-grade precise code intelligence data is used to inform the LLM of actual usage patterns across your repositories, allowing the LLM to cite factual usage locations in its answers — even across repositories.
+
+## Requirements
+
+1. [Precise code navigation](/code-navigation/precise-code-navigation) must be configured for your repositories. Smart hover summaries only appear when precise code intelligence data is available.
+2. Summaries are only provided for top-level symbols (function names, types, interfaces, etc.) and are not available for local symbols (e.g. variables inside a function)
+
+## Billing
+
+Smart hover summaries are a [Beta feature](/beta-and-experimental) and free while the feature is in Beta. The feature may become [billable with credits](/beta-and-experimental#credits-and-billing) and a very small associated cost in the future once it becomes generally available. However, at least 30 days notice will be given before such a change goes into effect.
+
+## Feedback
+
+Please share feedback on this feature with us at [feedback@sourcegraph.com](mailto:feedback@sourcegraph.com) or via your customer success manager.

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -126,7 +126,7 @@ export const navigation: NavigationItem[] = [
 						href: '/code-navigation/syntactic-code-navigation'
 					},
 					{
-						title: 'Smart Hover Summaries',
+						title: 'Smart hover summaries',
 						href: '/code-navigation/smart-hover'
 					},
 					{

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -126,6 +126,10 @@ export const navigation: NavigationItem[] = [
 						href: '/code-navigation/syntactic-code-navigation'
 					},
 					{
+						title: 'Smart Hover Summaries',
+						href: '/code-navigation/smart-hover'
+					},
+					{
 						title: 'Auto-indexing',
 						href: '/code-navigation/auto-indexing'
 					},


### PR DESCRIPTION
Adds the missing(😅) docs page mentioned in https://sourcegraph.com/docs/code-navigation/precise-code-navigation

<img width="1724" height="985" alt="image" src="https://github.com/user-attachments/assets/4a9bfd97-fc1c-4741-b425-8a5442a5b124" />

<img width="1728" height="992" alt="image" src="https://github.com/user-attachments/assets/dea09e0c-9ca7-4b49-84cd-28798bc2e13a" />

