### PR TITLE
docs: mention search contexts in Deep Search

### DIFF
--- a/docs/deep-search/index.mdx
+++ b/docs/deep-search/index.mdx
@@ -37,9 +37,9 @@ The answer is formatted in Markdown and can include links to relevant files, dir
 
 ## Using search contexts
 
-You can reuse the same [search contexts](/code-search/working/search-contexts) you already use in Code Search when creating a new Deep Search query. Click **Set scope** in the composer to select a search context and limit Deep Search to that repository scope.
+You can reuse the same [search contexts](/code-search/working/search-contexts) you already use in Code Search when creating a new Deep Search query. Click **Set scope** in the composer to select a search context and limit Deep Search to that repository scope. Deep Search automatically pre-selects your default search context.
 
-Deep Search automatically pre-selects your default search context. Search contexts are useful when you want to keep Deep Search focused on a specific part of your codebase, such as a team's repositories, a product area, or another shared scope used across your organization. Limiting Deep Search to a smaller set of repositories can help it search faster and produce more focused, higher-quality answers.
+Search contexts are useful when you want to keep Deep Search focused on a specific part of your codebase, such as a team's repositories, a product area, or another shared scope used across your organization. Limiting Deep Search to a smaller set of repositories can help it search faster and produce more focused, higher-quality answers.
 
 To learn how to create and manage search contexts, see [Search contexts](/code-search/working/search-contexts).
 

--- a/docs/deep-search/index.mdx
+++ b/docs/deep-search/index.mdx
@@ -39,7 +39,7 @@ The answer is formatted in Markdown and can include links to relevant files, dir
 
 You can reuse the same [search contexts](/code-search/working/search-contexts) you already use in Code Search when creating a new Deep Search query. Click **Set scope** in the composer to select a search context and limit Deep Search to that repository scope.
 
-Deep Search automatically pre-selects your default search context. If you need a different scope, choose any other search context you have access to instead of repeating repository filters in your prompt.
+Deep Search automatically pre-selects your default search context. Search contexts are useful when you want to keep Deep Search focused on a specific part of your codebase, such as a team's repositories, a product area, or another shared scope used across your organization. Limiting Deep Search to a smaller set of repositories can help it search faster and produce more focused, higher-quality answers.
 
 To learn how to create and manage search contexts, see [Search contexts](/code-search/working/search-contexts).
 

--- a/docs/deep-search/index.mdx
+++ b/docs/deep-search/index.mdx
@@ -35,6 +35,14 @@ The answer is formatted in Markdown and can include links to relevant files, dir
 - Provide reasonably scoped questions. The agent will perform much better if it does not have to read the entire codebase at once.
 - Check the list of sources. This is extremely useful for debugging and understanding where the answer came from. Ask a follow-up question and mention the missing source if something is missing.
 
+## Using search contexts
+
+You can reuse the same [search contexts](/code-search/working/search-contexts) you already use in Code Search when creating a new Deep Search query. Click **Set scope** in the composer to select a search context and limit Deep Search to that repository scope.
+
+Deep Search automatically pre-selects your default search context. If you need a different scope, choose any other search context you have access to instead of repeating repository filters in your prompt.
+
+To learn how to create and manage search contexts, see [Search contexts](/code-search/working/search-contexts).
+
 ## Using @-mentions
 
 Type `@` at any point while entering a query to add context. By default, the menu shows repositories relevant to you based on your commit history. As you type, suggestions update in real-time to show matching files and repositories.


### PR DESCRIPTION
Adds a short Search contexts section to the Deep Search docs.