### PR TITLE
docs/cloud: clarify private network support via Private Connectivity

### DIFF
--- a/docs/cloud/index.mdx
+++ b/docs/cloud/index.mdx
@@ -197,7 +197,7 @@ Supported destinations:
 > NOTE: We may be able to [support special requests](#accommodating-special-requirements), please reach out to your account team.
 
 - The Sourcegraph instance can only be accessible via a public IP. Running it in a private network and pairing it with your private network via site-to-site VPN or VPC Peering is not yet supported.
-- Code hosts or user authentication providers running in a private network are not yet supported. They have to be publicly available or they must allow incoming traffic from Sourcegraph-owned static IP addresses. We do not have proper support for other connectivity methods, e.g. site-to-site VPN, VPC peering, tunneling.
+- Code hosts or user authentication providers running in a private network must be reachable either publicly (optionally restricted to [Sourcegraph-owned static IP addresses](#private-connectivity)) or through one of the supported [Private Connectivity](#private-connectivity) options (AWS Private Link, GCP Private Service Connect, Sourcegraph Connect agent, or alternate public load balancers). Other connectivity methods such as site-to-site VPN or VPC peering are not supported.
 - Instances currently run only on Google Cloud Platform in the [chosen regions](#multiple-region-availability). Other regions and cloud providers (such as AWS or Azure) are not yet supported.
 - Some [configuration options](/admin/) are managed by Sourcegraph and cannot be overridden by customers, e.g. feature flags, experimental features, and auto-indexing policy. Please reach out to your account team if you would like to make changes to these settings.
 


### PR DESCRIPTION
closes PLAT-574