### PR TITLE
docs/deepsearch: document search context limits

### DIFF
--- a/docs/deep-search/index.mdx
+++ b/docs/deep-search/index.mdx
@@ -41,6 +41,12 @@ You can reuse the same [search contexts](/code-search/working/search-contexts) y
 
 Search contexts are useful when you want to keep Deep Search focused on a specific part of your codebase, such as a team's repositories, a product area, or another shared scope used across your organization. Limiting Deep Search to a smaller set of repositories can help it search faster and produce more focused, higher-quality answers.
 
+Query-based search contexts can include repository filters as well as file, language, case, and content-style filters. Deep Search can use these contexts for code search, but its repository-listing step can only enumerate contexts that are defined by repository constraints. If Deep Search reports that the active search context cannot be listed, either:
+
+- Ask Deep Search to search directly within the selected context instead of listing repositories first.
+- Change the selected search context to use repository-only constraints, such as `repo:`, `rev:`, `fork:`, `archived:`, `visibility:`, or supported repository metadata predicates like `repo:has.topic(...)`.
+- Create a repository-defined search context for scopes that Deep Search should list as repositories.
+
 To learn how to create and manage search contexts, see [Search contexts](/code-search/working/search-contexts).
 
 ## Using @-mentions


### PR DESCRIPTION
- Documents that Deep Search can use query-based search contexts for search, but repository listing only supports contexts that can be represented as repository constraints.
- Gives users concrete next steps when Deep Search reports that an active search context cannot be listed.
- Companion to sourcegraph/sourcegraph#12154.
- [Slack thread](https://sourcegraph.slack.com/archives/C05MW2TMYAV/p1777575547229569)

## Test plan

- Verified locally
