### PR TITLE
batch-changes: update bitbucket cloud api token docs

### DIFF
--- a/docs/batch-changes/configuring-credentials.mdx
+++ b/docs/batch-changes/configuring-credentials.mdx
@@ -258,17 +258,17 @@ Alternatively, you can use [Bitbucket Server OAuth](#bitbucket-server-oauth) to 
 
 ### Bitbucket Cloud
 
-On Bitbucket, follow the steps to [create an app password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/). Batch Changes requires the following scopes:
+On Bitbucket, follow the steps to [create an API token with scopes](https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/). Batch Changes requires the following Bitbucket scopes:
 
--   `account:read`
--   `repo:read`
--   `repo:write`
--   `pr:write`
--   `pipeline:read`
+-   `read:account`
+-   `read:repository:bitbucket`
+-   `read:pipeline:bitbucket`
+-   `write:repository:bitbucket`
+-   `write:pullrequest:bitbucket`
 
-![bb-cloud](https://sourcegraphstatic.com/docs/images/batch_changes/bb-cloud-app-password.png)
+If you have an existing Bitbucket Cloud app password, you can continue using it until Bitbucket Cloud disables app passwords. For new credentials, use an API token.
 
-Alternatively, you can use [Bitbucket Cloud OAuth](#bitbucket-cloud-oauth) to authenticate without manually creating an app password.
+Alternatively, you can use [Bitbucket Cloud OAuth](#bitbucket-cloud-oauth) to authenticate without manually creating a token.
 
 ### Azure DevOps
 


### PR DESCRIPTION
Our documentation was outdated. BitBucket cloud now uses a different flow to create a token and the names of the scopes have changed. The new UX also doesn't have a reasonable screenshot to take, so we leave it out.

Closes https://linear.app/sourcegraph/issue/CPL-394/bitbucketorg-scopes-have-changed