### PR TITLE
docs: add smart hover summaries to entitlements

### DIFF
--- a/docs/admin/entitlements.mdx
+++ b/docs/admin/entitlements.mdx
@@ -11,8 +11,8 @@ Entitlements can be set as a global default: default entitlements are granted to
 Each entitlement has a detailed usage view to help administrators understand how users are using the entitlement, and reset entitlement usage for specific users.
 
 <Callout type="note">
-	Entitlements currently only support [Deep Search](/deep-search), but we may
-	support other features in the future. If you would like to request
+	Entitlements currently support [Deep Search](/deep-search) and [smart hover
+	summaries](/code-navigation/smart-hover). If you would like to request
 	entitlement support for a feature, please reach out at
 	support@sourcegraph.com.
 </Callout>

--- a/docs/code-navigation/smart-hover.mdx
+++ b/docs/code-navigation/smart-hover.mdx
@@ -20,6 +20,12 @@ Summaries are powered by a small, fast model, but only compiler-grade precise co
 
 Smart hover summaries are a [Beta feature](/beta-and-experimental) and free while the feature is in Beta. The feature may become [billable with credits](/beta-and-experimental#credits-and-billing) once it becomes generally available. At least 30 days notice will be given before such a change goes into effect.
 
+## Managing usage
+
+Sourcegraph administrators can configure entitlements for their users to control smart hover summary usage in `/site-admin/entitlements`.
+
+To learn more, refer to [Entitlements](/admin/entitlements).
+
 ## Feedback
 
 Please share feedback on this feature with us at [feedback@sourcegraph.com](mailto:feedback@sourcegraph.com) or via your customer success manager.


### PR DESCRIPTION
## Summary

- Updates the entitlements page to list smart hover summaries alongside Deep Search as a supported feature.
- Adds a "Managing usage" section to the smart hover summaries page linking to the entitlements docs, mirroring the pattern used on the Deep Search page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)