### PR TITLE
Update docs latest version to 7.3

### DIFF
--- a/docs.config.js
+++ b/docs.config.js
@@ -1,5 +1,5 @@
 const config = {
-	DOCS_LATEST_VERSION: '7.1'
+	DOCS_LATEST_VERSION: '7.3'
 };
 
 module.exports = config;

--- a/docs/legacy.mdx
+++ b/docs/legacy.mdx
@@ -4,6 +4,14 @@
 	Find versioned documentation for previous versions of Sourcegraph below.
 </p>
 
+<Accordion title="Sourcegraph 7.X">
+
+- [7.2](https://7.2.sourcegraph.com)
+- [7.1](https://7.1.sourcegraph.com)
+- [7.0](https://7.0.sourcegraph.com)
+
+</Accordion>
+
 <Accordion title="Sourcegraph 6.X">
 
 - [6.12](https://6.12.sourcegraph.com)

--- a/src/data/versions.ts
+++ b/src/data/versions.ts
@@ -13,11 +13,18 @@ export const versions: VersionI[] = [
 		label: 'latest',
 		url: '/docs'
 	},
-        {
-                name: 'v7.0',
-                url: 'https://7.0.sourcegraph.com'
-        },
-
+	{
+		name: 'v7.2',
+		url: 'https://7.2.sourcegraph.com'
+	},
+	{
+		name: 'v7.1',
+		url: 'https://7.1.sourcegraph.com'
+	},
+	{
+		name: 'v7.0',
+		url: 'https://7.0.sourcegraph.com'
+	},
 	{
 		name: 'v6.12',
 		url: 'https://6.12.sourcegraph.com'


### PR DESCRIPTION
## Summary
- Set DOCS_LATEST_VERSION to 7.3
- Add 7.2 and 7.1 to the version selector previous versions
- Add a Sourcegraph 7.X section to the legacy versions page

## Test plan
- Not run (config/navigation content change only)