### PR TITLE
docs: reframe k8s docker-in-docker executors around threat model

### DIFF
--- a/docs/self-hosted/executors/deploy-executors-dind.mdx
+++ b/docs/self-hosted/executors/deploy-executors-dind.mdx
@@ -1,18 +1,17 @@
 # Deploying Sourcegraph executors on Kubernetes (docker-in-docker)
 
 <Callout type="warning">
-	Docker-in-Docker Kubernetes executors are in beta and are not recommended for production use.
-	This deployment mode requires privileged pod access and does not use Firecracker isolation.
-	For production workloads, deploy using
+	Docker-in-Docker Kubernetes executors are in beta. For production workloads where you
+	want the strongest reliability and support guarantees, you can also deploy via
 	[Terraform](/self-hosted/executors/deploy-executors-terraform) or the
-	[Linux binary](/self-hosted/executors/deploy-executors-binary) instead.
+	[Linux binary](/self-hosted/executors/deploy-executors-binary).
 </Callout>
 
 [Kubernetes manifests](https://github.com/sourcegraph/deploy-sourcegraph-k8s) are provided to deploy Sourcegraph Executors on a running Kubernetes cluster. If you are deploying Sourcegraph with helm, charts are available [here](https://github.com/sourcegraph/deploy-sourcegraph-helm).
 
 ## Deployment
 
-Executors on kubernetes machines require privileged access to a container runtime daemon in order to operate correctly. In order to ensure maximum capability across Kubernetes versions and container runtimes, a [Docker in Docker](https://www.docker.com/blog/docker-can-now-run-within-docker/) sidecar is deployed with each executor pod to avoid accessing the host container runtime directly.
+Executors on Kubernetes require privileged access to a container runtime daemon in order to operate correctly. To ensure maximum capability across Kubernetes versions and container runtimes, a [Docker in Docker](https://www.docker.com/blog/docker-can-now-run-within-docker/) sidecar is deployed with each executor pod so that the executor does not have to access the host container runtime directly.
 
 ### Step-by-step Guide
 
@@ -20,12 +19,6 @@ Ensure you have the following tools installed:
 
 -   [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
 -   [Helm](https://helm.sh/) if you're installing Sourcegraph with `helm`.
-
-#### Deployment via Kustomize
-
-Please refer to the [Sourcegraph Kustomize docs](/self-hosted/deploy/kubernetes/kustomize) for the latest instructions.
-
-To include Executors dind, see [configure Sourcegraph with Kustomize](/self-hosted/deploy/kubernetes/configure) on how to specify the component.
 
 #### Deployment via Helm
 
@@ -44,8 +37,31 @@ To specifically deploy Executors,
     ```
 3. Confirm executors are working by checking the _Executors_ page under **Site admin > Executors > Instances** .
 
-## Note
+## Security considerations
 
-Executors deployed in kubernetes do not use [Firecracker](/admin/executors/#how-it-works), meaning they require [privileged access](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) to the docker daemon running in a sidecar alongside the executor pod.
+Docker-in-docker executors require the Docker sidecar to run as a [privileged](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) container. `privileged: true` understandably raises concerns, so it's worth understanding the threat model before evaluating it — and seeing why, with the right deployment practices, it is acceptable for the large majority of self-hosted Sourcegraph instances.
 
-If you have security concerns, consider deploying via [terraform](/self-hosted/executors/deploy-executors-terraform) or [installing the binary](/self-hosted/executors/deploy-executors-binary) directly.
+### Executors run untrusted code by design
+
+Every executor deployment method exists to run **arbitrary, untrusted code**. Auto-indexing invokes language indexers and package-manager hooks to resolve dependencies, and batch changes run user-defined tooling against the contents of a repository. See [Executors](/admin/executors/) and [Firecracker](/self-hosted/executors/firecracker) for the full sandboxing model.
+
+This means the risk of a malicious job attempting to break out of its sandbox, consume excessive compute, or exfiltrate code and credentialsis is inherent to running executors. It is not unique to Docker-in-Docker:
+
+-   **Firecracker** provides the strongest per-job isolation (a MicroVM boundary), but it is not a complete security control on its own. Even with Firecracker, Sourcegraph additionally configures `iptables` to stop jobs from reaching [private IP ranges](/self-hosted/executors/firecracker#known-caveats) and the cloud metadata service.
+-   **Native Kubernetes** and **Docker-in-Docker** run jobs as containers without a MicroVM boundary, so they rely more heavily on the surrounding isolation and network controls.
+
+The runtime you choose changes the isolation boundary, but they do not negate the need for additional controls to furthur limit the blast radius.
+
+### Security hardening and risk management
+
+A privileged container shares the host kernel and can access host devices, so in principle a successful container breakout could affect the node. The mitigations below contain that blast radius to a pool of disposable nodes that run *only* untrusted executor jobs and that cannot reach your internal network — which is the same posture Sourcegraph applies to Firecracker-isolated executors.
+
+We strongly recommend applying the following controls when running docker-in-docker executors:
+
+1. **Run executors on a dedicated, isolated node pool.** Schedule executor pods onto their own node pool using taints/tolerations and node selectors or affinity, kept separate from the rest of your Sourcegraph workloads and any other sensitive services. A breakout is then contained to nodes that run only untrusted executor jobs, and those nodes can be recycled aggressively.
+
+2. **Sandbox the executor nodes where supported.** Run the executor node pool on a sandboxed runtime such as [gVisor](https://gvisor.dev/) (for example, [GKE Sandbox](https://cloud.google.com/kubernetes-engine/docs/concepts/sandbox-pods)). We offer built-in support for `gVisor` in the docker-in-docker helm chart. Learn more from the documentation.
+
+3. **Restrict network access.** Apply Kubernetes [NetworkPolicies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) and/or cloud firewall rules to the executor node pool to:
+    - Block access to internal and private resources and services.
+    - Block access to the cloud instance metadata service at `169.254.169.254` (AWS / GCP).


### PR DESCRIPTION
Reframes the Docker-in-Docker (DinD) Kubernetes executor docs away from a "not recommended / requires privileged pod" warning toward a proper threat-model explanation. Adds a "Security considerations" section clarifying that running untrusted code is inherent to *all* executor runtimes (not unique to DinD) and that defense in depth bounds the blast radius regardless of runtime. Documents recommended hardening: dedicated/isolated node pools, gVisor sandboxing (e.g. GKE Sandbox), and network restrictions (blocking private ranges and the cloud metadata service). The goal is to help customers evaluate `privileged: true` in context rather than be scared off it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)