### PR TITLE
Update docs latest version to 7.4

### DIFF
--- a/docs.config.js
+++ b/docs.config.js
@@ -1,5 +1,5 @@
 const config = {
-	DOCS_LATEST_VERSION: '7.3'
+	DOCS_LATEST_VERSION: '7.4'
 };
 
 module.exports = config;

--- a/docs/legacy.mdx
+++ b/docs/legacy.mdx
@@ -6,6 +6,7 @@
 
 <Accordion title="Sourcegraph 7.X">
 
+- [7.3](https://7.3.sourcegraph.com)
 - [7.2](https://7.2.sourcegraph.com)
 - [7.1](https://7.1.sourcegraph.com)
 - [7.0](https://7.0.sourcegraph.com)

--- a/src/data/versions.ts
+++ b/src/data/versions.ts
@@ -14,6 +14,10 @@ export const versions: VersionI[] = [
 		url: '/docs'
 	},
 	{
+		name: 'v7.3',
+		url: 'https://7.3.sourcegraph.com'
+	},
+	{
 		name: 'v7.2',
 		url: 'https://7.2.sourcegraph.com'
 	},


### PR DESCRIPTION
## Summary
- Set DOCS_LATEST_VERSION to 7.4
- Add 7.3 to the version selector as a previous version
- Update the legacy versions page with 7.3