### PR TITLE
docs: remove experimental notice for Sourcegraph Connect

### DIFF
--- a/docs/cloud/private-connectivity-sourcegraph-connect.mdx
+++ b/docs/cloud/private-connectivity-sourcegraph-connect.mdx
@@ -1,10 +1,5 @@
 # Private resources in on-prem data centers via the Sourcegraph Connect agent
 
-<Callout type="note">
-	This feature is in the Experimental stage. [Contact
-	us](https://about.sourcegraph.com/contact) for more information.
-</Callout>
-
 As part of the [Enterprise tier](https://sourcegraph.com/pricing), Sourcegraph Cloud supports connecting to private code hosts and artifact registries in the customer's network by deploying the Sourcegraph Connect tunnel agent in the customer's network.
 
 ## How it works


### PR DESCRIPTION
Removes the "Experimental stage" callout from the Sourcegraph Connect agent page, as the feature is no longer experimental. No other changes were needed since this was the only experimental notice tied to Sourcegraph Connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)