### PR TITLE
docs: document Codex MCP setup and invalid_scope workaround

### DIFF
--- a/docs/api/mcp/client-integrations.mdx
+++ b/docs/api/mcp/client-integrations.mdx
@@ -18,6 +18,7 @@
     - [Antigravity](#antigravity)
     - [Windsurf](#windsurf)
 - [OpenCode](#opencode)
+- [Codex](#codex)
 
 ### Amp
 
@@ -281,3 +282,32 @@ You can add the Sourcegraph MCP server to OpenCode by configuring it in your MCP
 
 3. Save the configuration file.
 4. Restart OpenCode to apply the changes.
+
+### Codex
+
+You can add the Sourcegraph MCP server to [OpenAI Codex](https://github.com/openai/codex) by editing its `config.toml` file (default `~/.codex/config.toml`, or a project-scoped `.codex/config.toml`):
+
+1. Open or create the configuration file at `~/.codex/config.toml` (or `.codex/config.toml` in your project).
+2. Add the following configuration:
+
+    ```toml
+    [mcp_servers.sourcegraph]
+    url = "https://your-sourcegraph-instance.com/.api/mcp"
+    scopes = ["mcp"]
+    ```
+
+    <Callout type="info">
+    	Replace `your-sourcegraph-instance.com` with your Sourcegraph instance
+    	URL.
+    </Callout>
+
+    <Callout type="note">
+    	`scopes = ["mcp"]` is required. Without it, Codex's OAuth login fails
+    	with an `invalid_scope` error because Sourcegraph's MCP endpoints
+    	require the `mcp` scope. See [Troubleshooting:
+    	`invalid_scope` error during
+    	OAuth](/api/mcp#invalid_scope-error-during-oauth) for details.
+    </Callout>
+
+3. Save the configuration file.
+4. Restart Codex and complete the Codex OAuth login flow to sign in to your Sourcegraph instance.

--- a/docs/api/mcp/index.mdx
+++ b/docs/api/mcp/index.mdx
@@ -414,6 +414,22 @@ Use this matrix to choose the smallest endpoint that has the tools your MCP clie
 	`deepsearch` tool.
 </Callout>
 
+## Troubleshooting
+
+### `invalid_scope` error during OAuth
+
+If your MCP client's OAuth login fails with an `invalid_scope` error when connecting to `/.api/mcp`, the client requested a scope that the Sourcegraph identity provider does not allow for the MCP resource. MCP endpoints require the `mcp` scope.
+
+To fix this, pin `scopes = ["mcp"]` in your client's OAuth configuration so the client requests only the `mcp` scope during the OAuth flow.
+
+For OpenAI Codex specifically, set `scopes = ["mcp"]` in your `config.toml`. See the [Codex](/api/mcp/client-integrations#codex) section on the client integrations page for the full configuration.
+
+<Callout type="info">
+	Clients that use Dynamic Client Registration (for example, Claude Code with
+	`--transport http` and Amp CLI) are automatically registered with the `mcp`
+	scope and should not normally encounter this error.
+</Callout>
+
 ## Best Practices
 
 1. **Repository Scoping:** Use `list_repos` first to find relevant repositories for better performance


### PR DESCRIPTION
Adds documentation for connecting OpenAI Codex to the Sourcegraph MCP server.

Codex's OAuth login to the MCP server fails with an `invalid_scope` error
unless the `mcp` scope is pinned, because MCP endpoints require the `mcp`
scope. This documents the fix.

Changes:
- Adds a Codex section to docs/api/mcp/client-integrations.mdx showing the
  `config.toml` setup (`scopes = ["mcp"]`).
- Adds a Troubleshooting section to docs/api/mcp/index.mdx documenting the
  `invalid_scope` error and its fix.

[_Created by Sourcegraph batch change `bahrmichael/6a183402-8f47-46ab-8ce0-48661bae0502`._](https://sourcegraph.sourcegraph.com/users/bahrmichael/batch-changes/6a183402-8f47-46ab-8ce0-48661bae0502)