### PR TITLE
executors binary deploy type docs cleanup

### DIFF
--- a/docs/self-hosted/executors/deploy-executors-binary-offline.mdx
+++ b/docs/self-hosted/executors/deploy-executors-binary-offline.mdx
@@ -6,7 +6,7 @@ When running in an air-gap environment, the executor binary can be deployed with
 
 Executors
 require [initial dependencies](/self-hosted/executors/deploy-executors-binary#dependencies) to
-be installed on the host machine. The minimum dependencies (when not using [Firecracker](/admin/executors/#firecracker)
+be installed on the host machine. The minimum dependencies (when not using [Firecracker](/self-hosted/executors/firecracker)
 Isolation) are:
 
 -   [Docker](https://docs.docker.com/engine/install/binaries/#install-daemon-and-client-binaries-on-linux)
@@ -47,7 +47,7 @@ Executors require `src-cli` to be installed on the host machine. To install `src
 2. Copy the `src` binary to the offline host machine
 3. Extract the binary from the archive
     ```shell
-    $ tar -zxcf src-cli_${VERSION}_linux_amd64.tar.gz
+    $ tar -zxf src-cli_${VERSION}_linux_amd64.tar.gz
     ```
 4. Set the binary as executable by running `chmod +x src`
 5. Move the binary to a location in your `$PATH` (e.g. `/usr/local/bin`)
@@ -97,25 +97,23 @@ be installed on the host machine.
 In order for `ignite` to function properly, CNI Plugins must be installed. To install CNI Plugins:
 
 1. Download
-   the [CNI Plugins](https://github.com/containernetworking/plugins/releases/download/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz)
-   and [CNI Isolation](https://github.com/AkihiroSuda/cni-isolation/releases/download/v0.0.4/cni-isolation-amd64.tgz)
-   archives on a machine with internet access
-2. Copy the archives to the offline host machine
+   the [CNI Plugins](https://github.com/containernetworking/plugins/releases/download/v1.7.1/cni-plugins-linux-amd64-v1.7.1.tgz)
+   archive on a machine with internet access
+2. Copy the archive to the offline host machine
 3. Create the `/opt/cni/bin` directory
     ```shell
     $ mkdir -p /opt/cni/bin
     ```
-4. Extract the archives to the `/opt/cni/bin` directory
+4. Extract the archive to the `/opt/cni/bin` directory
     ```shell
-    $ tar -zxcf cni-plugins-linux-amd64-v0.9.1.tgz -C /opt/cni/bin
-    $ tar -zxcf cni-isolation-amd64.tgz -C /opt/cni/bin
+    $ tar -zxf cni-plugins-linux-amd64-v1.7.1.tgz -C /opt/cni/bin
     ```
 
 ### Install Ignite
 
 Executors use `ignite` to spawn Firecracker VMs to run code in isolation. To install `ignite`:
 
-1. Download [`ignite`](https://github.com/sourcegraph/ignite/releases/download/v0.10.5/ignite-amd64) on a machine with
+1. Download [`ignite`](https://github.com/sourcegraph/ignite/releases/download/v0.10.8/ignite-amd64) on a machine with
    internet access
 2. Copy `ignite-amd64` to the offline host machine
 3. Set the binary as executable by running `chmod +x ignite-amd64`
@@ -123,7 +121,7 @@ Executors use `ignite` to spawn Firecracker VMs to run code in isolation. To ins
 5. Confirm `ignite` is installed by running `ignite`
     ```shell
     $ ignite version
-    Ignite version: version.Info{Major:"0", Minor:"8", GitVersion:"v0.10.0", GitCommit:"...", GitTreeState:"clean", BuildDate:"...", GoVersion:"...", Compiler:"gc", Platform:"linux/amd64"}
+    Ignite version: version.Info{Major:"0", Minor:"10", GitVersion:"v0.10.8", GitCommit:"...", GitTreeState:"clean", BuildDate:"...", GoVersion:"...", Compiler:"gc", Platform:"linux/amd64"}
     Firecracker version: v0.22.4
     Runtime: containerd
     ```
@@ -160,7 +158,7 @@ If you are using a custom image instead of the Sourcegraph image, you will need 
 To install the Firecracker sandbox image, import the image using `docker`.
 
 ```shell
-$ docker pull <docker repository image for sourcegraph/ignite:v0.10.5>
+$ docker pull <docker repository image for sourcegraph/ignite:v0.10.8>
 ```
 
 > Note: Check the version against the version of executors being installed.
@@ -170,10 +168,10 @@ If you are using a custom image instead of the Sourcegraph image, you will need 
 
 #### Kernel Image
 
-To install the Firecracker Kernel image, import the image (`sourcegraph/ignite-kernel:5.10.135-amd64`) using `ignite`.
+To install the Firecracker Kernel image, import the image (`sourcegraph/ignite-kernel:6.1.140-amd64`) using `ignite`.
 
 ```shell
-$ ignite kernel import --runtime docker <docker repository image for sourcegraph/ignite-kernel:5.10.135-amd64>
+$ ignite kernel import --runtime docker <docker repository image for sourcegraph/ignite-kernel:6.1.140-amd64>
 ```
 
 > Note: Check the version against the version of executors being installed.
@@ -188,3 +186,12 @@ Once the `executor` binary is installed and dependencies are met, you can valida
 ```shell
 $ executor validate
 ```
+
+If you are using [Firecracker](/self-hosted/executors/firecracker) isolation, you can also verify that the executor is able to spin up isolation VMs properly:
+
+```shell
+# Optionally provide a repo to clone into the VM's workspace, to verify that cloning works properly as well.
+$ executor test-vm [--repo=github.com/sourcegraph/sourcegraph --revision=main]
+```
+
+This should succeed and print a command to use to attach to the guest VM. If it is able to spin up properly, that is a good indication that everything is set up correctly.

--- a/docs/self-hosted/executors/deploy-executors-binary.mdx
+++ b/docs/self-hosted/executors/deploy-executors-binary.mdx
@@ -28,7 +28,7 @@ If [Firecracker isolation will be used](/self-hosted/executors/firecracker): _(r
 
 ### **Step 0:** Confirm that virtualization is enabled (if using Firecracker)
 
-KVM (virtualization) support is required for our [sandboxing model](/admin/executors/#sandboxing-model) with Firecracker. The following command checks whether virtualization is enabled on the machine (it should print something):
+KVM (virtualization) support is required for our [sandboxing model](/self-hosted/executors#sandboxing-model) with Firecracker. The following command checks whether virtualization is enabled on the machine (it should print something):
 
 ```bash
 $ lscpu | grep Virtualization
@@ -95,6 +95,8 @@ executor install all
 executor install --help
 ```
 
+> Note: `executor install all` includes Firecracker-specific components (ignite, CNI plugins, VM images) and requires KVM to be available on the host. If KVM is not enabled, this command will fail. Ensure [Step 0](#step-0-confirm-that-virtualization-is-enabled-if-using-firecracker) passes before running this command.
+
 ### **Step 4:** Validate your machine is ready to receive workloads
 
 All set up! Before letting the executor start receiving workloads from your Sourcegraph instance, you might want to verify your setup. Run the following command:
@@ -105,7 +107,7 @@ executor validate
 
 If any issues are found, correct them before proceeding.
 
-If you use our [sandboxing model](/admin/executors/#sandboxing-model) with Firecracker _(recommended)_, you can also verify that the executor is able to spin up the isolation VMs properly. For that, use the following command:
+If you use our [sandboxing model](/self-hosted/executors#sandboxing-model) with Firecracker _(recommended)_, you can also verify that the executor is able to spin up the isolation VMs properly. For that, use the following command:
 
 ```bash
 # Optionally provide a repo to clone into the VMs workspace, to verify that cloning works properly as well.

--- a/docs/self-hosted/executors/deploy-executors-binary.mdx
+++ b/docs/self-hosted/executors/deploy-executors-binary.mdx
@@ -53,8 +53,7 @@ KVM acceleration can be used
 
 Below are the download links for the _latest_ release of executors:
 
-**Note:** Executors need to match the version of Sourcegraph they're running against. Latest will usually only work for you when
-you run the latest version of Sourcegraph.
+**Note:** The executor binary version must match the version of the Sourcegraph instance it connects to.
 
 -   [`linux-amd64/executor`](https://storage.googleapis.com/sourcegraph-artifacts/executor/latest/linux-amd64/executor)
 -   [`linux-amd64/executor_SHA256SUM`](https://storage.googleapis.com/sourcegraph-artifacts/executor/latest/linux-amd64/executor_SHA256SUM)
@@ -63,8 +62,7 @@ you run the latest version of Sourcegraph.
 Download and setup the `executor` binary:
 
 ```bash
-# Plug in the version of your Sourcegraph instance, like v4.1.0.
-# Before Sourcegraph 3.43.0, tagged releases of executors are not available and you should default to using "latest" instead.
+# Plug in the version of your Sourcegraph instance, e.g. v7.4.0.
 # Using latest is NOT recommended, because it might be incompatible with your Sourcegraph version.
 curl -sfLo executor https://storage.googleapis.com/sourcegraph-artifacts/executor/${SOURCEGRAPH_VERSION}/linux-amd64/executor
 chmod +x executor
@@ -74,7 +72,7 @@ mv executor /usr/local/bin
 
 ### **Step 2:** Setup environment variables
 
-The executor Linux binary is configured through environment variables which need to be passed to it when you run it (including for the `install`, `validate` and `test-vm` comamnds). You can add these to your shell profile, or an environment file. The `EXECUTOR_FRONTEND_URL`, `EXECUTOR_FRONTEND_PASSWORD` and `EXECUTOR_QUEUE_NAME` **or** `EXECUTOR_QUEUE_NAMES` are _required_ and will need to be set prior to running the executor service for the first time.
+The executor Linux binary is configured through environment variables which need to be passed to it when you run it (including for the `install`, `validate` and `test-vm` commands). You can add these to your shell profile, or an environment file. The `EXECUTOR_FRONTEND_URL`, `EXECUTOR_FRONTEND_PASSWORD` and `EXECUTOR_QUEUE_NAME` **or** `EXECUTOR_QUEUE_NAMES` are _required_ and will need to be set prior to running the executor service for the first time.
 
 See [Executor configuration](/self-hosted/executors/executors-config) for a full list of configuration options for the executor service.
 


### PR DESCRIPTION
closes PLAT-739

This PR is mostly just cleanup for deadlinks, typos, and some stale versions.

I tested the binary runs and starts via the `sg start` and `sg start batches-executor` local dev methods. This isn't a good full walkthrough of the binary installation path, but is sufficient for the task at hand.

Tested that installation docs worked locally via an orb vm. Unable to test the ignite on local machine. 