### PR TITLE
PowerShell example in quickstart.mdx will change the registry data ty…

### DIFF
--- a/docs/cli/quickstart.mdx
+++ b/docs/cli/quickstart.mdx
@@ -36,7 +36,7 @@ You can install using PowerShell as follows:
 
 ```powershell
 $SrcGraphInstallDir = "$env:ProgramFiles\Sourcegraph"
-New-Item -ItemType Directory -Path $SrcGraphInstallDir
+New-Item -ItemType Directory -Path $SrcGraphInstallDir -Force
 $regexAddPath = [regex]::Escape('%ProgramFiles%\Sourcegraph')
 
 Invoke-WebRequest https://sourcegraph.com/.api/src-cli/src_windows_amd64.exe -OutFile "$SrcGraphInstallDir\src.exe"
@@ -46,6 +46,7 @@ $arrPath = $Path -split ';' | Where-Object { $_ -notMatch "^$regexAddPath\\?" }
 $arrPath += '%ProgramFiles%\Sourcegraph'
 [String]$strPath = $arrPath -join ';' 
 Set-ItemProperty -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name Path -Value $strPath -Type ExpandString -ErrorAction 'Stop' | Out-Null
+$env:Path = (Get-Item -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment').GetValue('Path')
 ```
 
 For other options, please refer to [the Windows specific `src` documentation](/cli/explanations/windows).

--- a/docs/cli/quickstart.mdx
+++ b/docs/cli/quickstart.mdx
@@ -35,12 +35,17 @@ chmod +x /usr/local/bin/src
 You can install using PowerShell as follows:
 
 ```powershell
-New-Item -ItemType Directory 'C:\Program Files\Sourcegraph'
+$SrcGraphInstallDir = "$env:ProgramFiles\Sourcegraph"
+New-Item -ItemType Directory -Path $SrcGraphInstallDir
+$regexAddPath = [regex]::Escape('%ProgramFiles%\Sourcegraph')
 
-Invoke-WebRequest https://sourcegraph.com/.api/src-cli/src_windows_amd64.exe -OutFile 'C:\Program Files\Sourcegraph\src.exe'
+Invoke-WebRequest https://sourcegraph.com/.api/src-cli/src_windows_amd64.exe -OutFile "$SrcGraphInstallDir\src.exe"
 
-[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', [EnvironmentVariableTarget]::Machine) + ';C:\Program Files\Sourcegraph', [EnvironmentVariableTarget]::Machine)
-$env:Path += ';C:\Program Files\Sourcegraph'
+$Path = (Get-Item -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment').GetValue('Path', '', 'DoNotExpandEnvironmentNames')
+$arrPath = $Path -split ';' | Where-Object { $_ -notMatch "^$regexAddPath\\?" } 
+$arrPath += '%ProgramFiles%\Sourcegraph'
+[String]$strPath = $arrPath -join ';' 
+Set-ItemProperty -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name Path -Value $strPath -Type ExpandString -ErrorAction 'Stop' | Out-Null
 ```
 
 For other options, please refer to [the Windows specific `src` documentation](/cli/explanations/windows).


### PR DESCRIPTION
…pe of Path - update it

The current example will change the underlying data type of the Path environment variable (in HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment) from REG_EXPAND_SZ to REG_SZ, which will have undesirable consequences down the line, as REG_EXPAND_SZ is the required data type if you wish to use unexpanded paths in the Path statement... such as %SystemRoot% 😮 