### PR TITLE
chore/executors: executors dind deploy docs improvements

### DIFF
--- a/docs/self-hosted/executors/deploy-executors-dind.mdx
+++ b/docs/self-hosted/executors/deploy-executors-dind.mdx
@@ -7,13 +7,18 @@
 	[Linux binary](/self-hosted/executors/deploy-executors-binary).
 </Callout>
 
-[Kubernetes manifests](https://github.com/sourcegraph/deploy-sourcegraph-k8s) are provided to deploy Sourcegraph Executors on a running Kubernetes cluster. If you are deploying Sourcegraph with helm, charts are available [here](https://github.com/sourcegraph/deploy-sourcegraph-helm).
+[Kubernetes manifests](https://github.com/sourcegraph/deploy-sourcegraph-k8s/tree/main/components/executors/dind) are provided to deploy Sourcegraph Executors on a running Kubernetes cluster. If you are deploying Sourcegraph with Helm, charts are available [here](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph-executor/dind).
 
 ## Deployment
 
 Executors on Kubernetes require privileged access to a container runtime daemon in order to operate correctly. To ensure maximum capability across Kubernetes versions and container runtimes, a [Docker in Docker](https://www.docker.com/blog/docker-can-now-run-within-docker/) sidecar is deployed with each executor pod so that the executor does not have to access the host container runtime directly.
 
 ### Step-by-step Guide
+
+<Callout type="note">
+  Before deploying, ensure your Sourcegraph instance is configured to accept executor connections.
+  See [Executor authentication](/self-hosted/executors/deploy-executors#executor-authentication) for instructions on setting the required `executors.accessToken` in your site configuration.
+</Callout>
 
 Ensure you have the following tools installed:
 
@@ -26,10 +31,25 @@ Please refer to the [Sourcegraph Helm docs](/self-hosted/deploy/kubernetes#quick
 
 To specifically deploy Executors,
 
-1. Create an overrides file, `override.yaml`, with any other customizations you may require.
+1. Create an overrides file, `override.yaml`, with any other customizations you may require. At a minimum, you must set the frontend URL and access token:
+
+    ```yaml
+    executor:
+      # The in-cluster frontend service endpoint.
+      # If the executor is deployed in a different namespace than Sourcegraph, use the FQDN form:
+      # "http://sourcegraph-frontend.sourcegraph.svc.cluster.local:30080"
+      frontendUrl: "http://sourcegraph-frontend:30080"
+      frontendPassword: "the-shared-access-token-from-site-config"
+      # Required. Valid values: batches, codeintel, or both.
+      queueNames: ["batches", "codeintel"]
+    ```
+
+    For additional configuration options:
 
     1. See [details on configurations](/self-hosted/deploy/kubernetes#configuration)
-    2. See [here](/self-hosted/executors/executors-config) for a full list of executor environment variables
+    2. See the [full values reference](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph-executor/dind/README.md) for all available Helm fields
+    3. See [executor environment variables](/self-hosted/executors/executors-config) for the complete configuration reference
+    4. See the [GCP example override](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph-executor/dind/examples/gcp/values.yaml) for a more complete example including storage, replica count, and gVisor configuration
 
 2. Run the following command:
     ```bash

--- a/docs/self-hosted/executors/deploy-executors-dind.mdx
+++ b/docs/self-hosted/executors/deploy-executors-dind.mdx
@@ -35,7 +35,7 @@ To specifically deploy Executors,
     ```bash
     helm upgrade --install --values ./override.yaml --version <your Sourcegraph Version> sg-executor sourcegraph/sourcegraph-executor-dind
     ```
-3. Confirm executors are working by checking the _Executors_ page under **Site admin > Executors > Instances** .
+3. Confirm executors are working by checking the _Executors_ page under **Site admin > Executors > Instances**.
 
 ## Security considerations
 
@@ -45,12 +45,12 @@ Docker-in-docker executors require the Docker sidecar to run as a [privileged](h
 
 Every executor deployment method exists to run **arbitrary, untrusted code**. Auto-indexing invokes language indexers and package-manager hooks to resolve dependencies, and batch changes run user-defined tooling against the contents of a repository. See [Executors](/admin/executors/) and [Firecracker](/self-hosted/executors/firecracker) for the full sandboxing model.
 
-This means the risk of a malicious job attempting to break out of its sandbox, consume excessive compute, or exfiltrate code and credentialsis is inherent to running executors. It is not unique to Docker-in-Docker:
+This means the risk of a malicious job attempting to break out of its sandbox, consume excessive compute, or exfiltrate code and credentials is inherent to running executors. It is not unique to Docker-in-Docker:
 
 -   **Firecracker** provides the strongest per-job isolation (a MicroVM boundary), but it is not a complete security control on its own. Even with Firecracker, Sourcegraph additionally configures `iptables` to stop jobs from reaching [private IP ranges](/self-hosted/executors/firecracker#known-caveats) and the cloud metadata service.
 -   **Native Kubernetes** and **Docker-in-Docker** run jobs as containers without a MicroVM boundary, so they rely more heavily on the surrounding isolation and network controls.
 
-The runtime you choose changes the isolation boundary, but they do not negate the need for additional controls to furthur limit the blast radius.
+The runtime you choose changes the isolation boundary, but they do not negate the need for additional controls to further limit the blast radius.
 
 ### Security hardening and risk management
 


### PR DESCRIPTION
closes PLAT-743

These docs improvements are mostly just ease of use improvements linking relevant docs and providing some visual examples in the dind splash page.

Procedure tested via a local deployment with `kind` and the executors helm charts

I did uncover an issue about the frontend port specification in our configmaps for dind but that will be addressed in a separate PR