### PR TITLE
docs/batches: document grouped changeset titles

### DIFF
--- a/docs/batch-changes/batch-spec-yaml-reference.mdx
+++ b/docs/batch-changes/batch-spec-yaml-reference.mdx
@@ -821,6 +821,7 @@ transformChanges:
         # Create a separate changeset for all changes in the top-level `go` directory
         - directory: go
           branch: my-batch-change-go # will replace the `branch` in the `changesetTemplate`
+          title: Update ${{ steps.path }} # optional: will replace the `title` in the `changesetTemplate`
 
         - directory: internal/codeintel
           branch: my-batch-change-codeintel # will replace the `branch` in the `changesetTemplate`
@@ -861,6 +862,12 @@ The branch that should be used for this additional changeset. This **overwrites 
 	that](https://stackoverflow.com/a/22630664). Additionally, branch names must
 	be unique and cannot be used as arguments for multiple `directory` fields.
 </Callout>
+
+## `transformChanges.group.title`
+
+(Optional) The title that should be used for this additional changeset. This **overwrites the [`changesetTemplate.title`](#changesettemplate-title)** when creating the additional changeset.
+
+The title supports the same template variables as [`changesetTemplate.title`](#changesettemplate-title). When rendering the group title, `${{ steps.path }}` is set to this group's [`directory`](#transformchangesgroupdirectory).
 
 ## `transformChanges.group.repository`
 

--- a/docs/batch-changes/creating-multiple-changesets-in-large-repositories.mdx
+++ b/docs/batch-changes/creating-multiple-changesets-in-large-repositories.mdx
@@ -44,6 +44,7 @@ transformChanges:
     group:
         - directory: client
           branch: hello-world-client # will replace the `branch` in the `changesetTemplate`
+          title: Hello World in client # optional: will replace the `title` in the `changesetTemplate`
         - directory: docker-images
           # Optional: only apply the rule in this repository
           repository: github.com/sourcegraph/sourcegraph
@@ -72,6 +73,8 @@ This batch spec will produce up to 4 changesets in the `github.com/sourcegraph/s
 1. A changeset with the changes in the other directories.
 
 Since code hosts and Git don't allow creating multiple, different changesets on the same branch, it is **required** to specify a unique `branch` for each `directory` that will be used for the additional changesets. That `branch` will overwrite the default branch specified in `changesetTemplate`.
+
+You can optionally specify a `title` for each group. The group title overwrites the default title specified in `changesetTemplate` for the changeset created from that group. It supports the same template variables as `changesetTemplate.title`, and `${{ steps.path }}` is set to the group's `directory`.
 
 If no changes have been made in a `directory` specified in a `group`, no additional changeset will be produced. If the optional `repository` property is specified, only the changes in that repository will be grouped.
 


### PR DESCRIPTION
Grouped changesets can now customize each generated PR title with `transformChanges.group.title`, so the public Batch Changes docs should describe the field alongside the existing `directory`, `branch`, and `repository` group options.

This updates the YAML reference and the large-repository walkthrough with the new optional field, including the `steps.path` behavior for group-title rendering.

Implementation PR: sourcegraph/sourcegraph#13641