### PR TITLE
docs: mark smart hover summaries as GA and document credit usage

### DIFF
--- a/docs/code-navigation/smart-hover.mdx
+++ b/docs/code-navigation/smart-hover.mdx
@@ -2,7 +2,6 @@
 
 <TierCallout>
 	Supported on [Enterprise](/pricing/plans/enterprise) plans.
-	<user>This feature is currently in [Beta](/beta-and-experimental).</user>
 </TierCallout>
 
 When [precise code intelligence](/code-navigation/precise-code-navigation) is available, Sourcegraph will provide a generated summary of the meaning of the symbol, and usage of the symbol across the codebase. In combination with the precise code intelligence hover information, this often saves the need to jump to a symbol and back which interrupts the flow of reading, and simplifies understanding complex codebases. Linked citations can even serve as an alternative to traditional code navigation.
@@ -18,11 +17,11 @@ Summaries are powered by a small, fast model, but only compiler-grade precise co
 
 ## Billing
 
-Smart hover summaries are a [Beta feature](/beta-and-experimental) and free while the feature is in Beta. The feature may become [billable with credits](/beta-and-experimental#credits-and-billing) once it becomes generally available. At least 30 days notice will be given before such a change goes into effect.
+Smart hover summaries consume credits from your subscription's shared credit balance.
 
 ## Managing usage
 
-Sourcegraph administrators can configure entitlements for their users to control smart hover summary usage in `/site-admin/entitlements`.
+Sourcegraph administrators can configure entitlements for their users, for example "60 smart hover summaries per hour", in `/site-admin/entitlements`.
 
 To learn more, refer to [Entitlements](/admin/entitlements).
 


### PR DESCRIPTION
Update docs to reflect Smart Hover GA

_Created by Sourcegraph agentic batch change._