### PR TITLE
docs: remove Join our Community section from homepage

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -63,7 +63,3 @@ Some of the main Sourcegraph features include:
 ## What's New
 
 Stay in sync and get the latest news on Sourcegraph products, technologies, and culture. [Read the blog →](https://sourcegraph.com/blog)
-
-## Join our Community
-
-If you have questions about anything related to Sourcegraph, you're always welcome to ask in in our [Discord](https://discord.gg/s2qDtYGnAE), and [X](https://twitter.com/sourcegraph).


### PR DESCRIPTION
## Summary

- Remove the "Join our Community" section (Discord + X links) from the docs homepage (`docs/index.mdx`).

<img width="1800" height="576" alt="CleanShot 2026-07-02 at 10 36 39@2x" src="https://github.com/user-attachments/assets/39aa53a3-76f2-4874-a861-3190ae148e7c" />


## Test plan

- Ran the docs dev server locally and confirmed the homepage no longer renders the "Join our Community" section (required clearing the stale `.contentlayer` cache for the change to take effect).

Generated with [Claude Code](https://claude.com/claude-code)