### PR TITLE
docs/agentic-batch-changes: link to Batch Changes configuration

### DIFF
--- a/docs/agentic-batch-changes/index.mdx
+++ b/docs/agentic-batch-changes/index.mdx
@@ -88,9 +88,11 @@ All [batch changes capabilities](/batch-changes/batch-spec-yaml-reference) are a
 
 For example, the agent can write conditional steps, template changeset titles and descriptions, and split changes in one repository into multiple changesets.
 
+Administration options like rollout windows and commit signing also carry over. See [Administration](#administration) for details.
+
 ## Administration
 
-Most Batch Changes configurations still apply in Agentic Batch Changes, unless otherwise listed before. To learn more about Batch Changes configuration options, refer to [Site Admin Configuration for Batch Changes](/batch-changes/site-admin-configuration).
+Most Batch Changes configuration options, such as rollout windows and commit signing, still apply in Agentic Batch Changes unless otherwise noted. To learn more, refer to [Batch Changes configuration](/admin/config/batch-changes).
 
 ### Access control
 


### PR DESCRIPTION
Adds a note that Batch Changes configuration options like rollout windows and commit signing also apply to Agentic Batch Changes, with a cross-link between the "Batch Changes capabilities" and "Administration" sections. The Administration paragraph now links to the [Batch Changes configuration reference](/admin/config/batch-changes) (which actually documents those options) instead of the lighter overview page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)