### PR TITLE
fix: typos and dead link in native k8s executor docs

### DIFF
--- a/docs/self-hosted/executors/deploy-executors-kubernetes.mdx
+++ b/docs/self-hosted/executors/deploy-executors-kubernetes.mdx
@@ -15,7 +15,7 @@ Executors interact with the Kubernetes API to manage the lifecycle of individual
 | API Groups | Resources          | Verbs                  | Reason                                                                                    |
 | ---------- | ------------------ | ---------------------- | ----------------------------------------------------------------------------------------- |
 | `batch`    | `jobs`             | `create`, `delete`     | Executors create Job pods to run processes. Once Jobs are completed, they are cleaned up. |
-|            | `pods`, `pods/log` | `get`, `list`, `watch` | Executors need to look up and steam logs from the Job Pods.                               |
+|            | `pods`, `pods/log` | `get`, `list`, `watch` | Executors need to look up and stream logs from the Job Pods.                               |
 
 Here's an example Role YAML to demonstrate the RBAC requirements for native Kubernetes Executors:
 
@@ -75,7 +75,7 @@ Native Kubernetes Executors can be deployed via either the `sourcegraph-executor
     1. `EXECUTOR_FRONTEND_URL` should match the URL of your Sourcegraph instance
     2. `EXECUTOR_FRONTEND_PASSWORD` should match the `executors.accessToken` key in the Sourcegraph instance's site configuration
     3. Either `EXECUTOR_QUEUE_NAMES` or `EXECUTOR_QUEUE_NAME` should be set depending on whether the Executor will process batch change or precise auto indexing jobs
-    4. `EXECUTOR_KUBERNETES_NAMESPACE` should be set to the Kubernetes namespace where you intend to run the worker pods. This should generally match the namesapce where you deploy the Executor resources in the next step.
+    4. `EXECUTOR_KUBERNETES_NAMESPACE` should be set to the Kubernetes namespace where you intend to run the worker pods. This should generally match the namespace where you deploy the Executor resources in the next step.
 
     <Callout type="note">
     	Additional environment variables may need to be configured for your
@@ -141,4 +141,4 @@ The Executor Docker image is available on Docker Hub at [`sourcegraph/executor-k
 
 ### Example Configuration YAML
 
-See the local development YAMLs for an example of how to configure the Executor in Kubernetes.
+For an example of how to configure the Executor in Kubernetes, see the [`sourcegraph-executor-k8s` Helm chart values reference](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph-executor/k8s/values.yaml).


### PR DESCRIPTION
closes PLAT-744

- Fix typo: 'steam' → 'stream' in RBAC table
- Fix typo: 'namesapce' → 'namespace' in deployment steps
- Replace dead-end 'local development YAMLs' reference with link to Helm chart values.yaml

This is a very minor fixup.

As part of this PR I tested the k8s-native executors connection docs to validate this local install works and the charts are working as expected. See https://linear.app/sourcegraph/issue/PLAT-744/native-kubernetes#comment-4e7a7676