### PR TITLE
feat/docs: mention coding agent provider configuration

### DIFF
--- a/docs/agentic-batch-changes/index.mdx
+++ b/docs/agentic-batch-changes/index.mdx
@@ -72,6 +72,8 @@ The coding agent step is a new native step type for Agentic Batch Changes that a
 
 We currently support [Claude Code](https://claude.com/product/claude-code) and [Codex](https://openai.com/codex) as native coding agent steps.
 
+By default, coding agent LLM traffic is routed through the Sourcegraph Model Provider. Site administrators can configure their own API keys to route traffic directly to Anthropic or OpenAI in **Administration → Batch Changes → Agents**. An optional `endpoint` field can be set for each agent to override the default provider URL.
+
 Note that Agentic Batch Changes does not use coding agent steps for every task. For deterministic changes, the agent will opt to write a script - or even an entire program - to efficiently apply some, or all, of the target changes.
 
 ### Building images for steps


### PR DESCRIPTION
Adds a brief note that site admins can configure coding agent provider API keys and optional endpoint overrides from the Batch Changes Agents admin UI.