### PR TITLE
chore/executors: explicit upgrade procedures for dind and k8s-native executors + QA

### DIFF
--- a/docs/self-hosted/executors/deploy-executors-dind.mdx
+++ b/docs/self-hosted/executors/deploy-executors-dind.mdx
@@ -57,6 +57,47 @@ To specifically deploy Executors,
     ```
 3. Confirm executors are working by checking the _Executors_ page under **Site admin > Executors > Instances**.
 
+#### Deployment via Kustomize
+
+If you are using Kustomize instead of Helm, apply the `executors/dind` [component](https://github.com/sourcegraph/deploy-sourcegraph-k8s/tree/main/components/executors/dind) from the `deploy-sourcegraph-k8s` repository. See the [Kustomize configuration docs](/self-hosted/deploy/kubernetes/configure#overview) for details.
+
+## Upgrading executors
+
+Upgrading Docker-in-Docker executors follows the same pattern as the initial deployment. Check the [changelog](https://sourcegraph.com/changelog) for any executor-related breaking changes or new features.
+
+### Helm
+
+1. Update your Helm repo to fetch the latest chart versions:
+
+    ```bash
+    helm repo update sourcegraph
+    ```
+
+2. Run `helm upgrade` with the target Sourcegraph version:
+
+    ```bash
+    helm upgrade --install --values ./override.yaml --version <target Sourcegraph version> sg-executor sourcegraph/sourcegraph-executor-dind
+    ```
+
+3. Verify the executor pod restarts with the new version:
+
+    ```bash
+    kubectl get pods -l app=executor
+    ```
+
+4. Confirm the executor is online and reporting the expected version under **Site admin > Executors > Instances**.
+
+### Kustomize
+
+1. Update the `deploy-sourcegraph-k8s` repository to the tag matching your target Sourcegraph version.
+2. Re-apply the Kustomize overlay:
+
+    ```bash
+    kubectl apply --prune -l deploy=sourcegraph -f <path to your overlay output>
+    ```
+
+3. Confirm the executor is online under **Site admin > Executors > Instances**.
+
 ## Security considerations
 
 Docker-in-docker executors require the Docker sidecar to run as a [privileged](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) container. `privileged: true` understandably raises concerns, so it's worth understanding the threat model before evaluating it — and seeing why, with the right deployment practices, it is acceptable for the large majority of self-hosted Sourcegraph instances.

--- a/docs/self-hosted/executors/deploy-executors-dind.mdx
+++ b/docs/self-hosted/executors/deploy-executors-dind.mdx
@@ -82,7 +82,7 @@ Upgrading Docker-in-Docker executors follows the same pattern as the initial dep
 3. Verify the executor pod restarts with the new version:
 
     ```bash
-    kubectl get pods -l app=executor
+    kubectl get pods -l app.kubernetes.io/component=executor
     ```
 
 4. Confirm the executor is online and reporting the expected version under **Site admin > Executors > Instances**.

--- a/docs/self-hosted/executors/deploy-executors-kubernetes.mdx
+++ b/docs/self-hosted/executors/deploy-executors-kubernetes.mdx
@@ -109,7 +109,7 @@ Upgrading native Kubernetes executors follows the same pattern as the initial de
 3. Verify the executor pod restarts with the new version:
 
     ```bash
-    kubectl get pods -l app=executor
+    kubectl get pods -l app.kubernetes.io/component=executor
     ```
 
 4. Confirm the executor is online and reporting the expected version under **Site admin > Executors > Instances**.

--- a/docs/self-hosted/executors/deploy-executors-kubernetes.mdx
+++ b/docs/self-hosted/executors/deploy-executors-kubernetes.mdx
@@ -88,6 +88,43 @@ Native Kubernetes Executors can be deployed via either the `sourcegraph-executor
     2. For more details on how to configure the `executors/k8s` component for your Kustomize deployment, see the [Kustomize configuration docs](/self-hosted/deploy/kubernetes/configure#overview)
 4. Once all the native Kubernetes Executor resources have been deployed to your cluster, confirm that the Executors are online by checking the _Executors_ page under **Site admin > Executors > Instances**
 
+## Upgrading executors
+
+Upgrading native Kubernetes executors follows the same pattern as the initial deployment. Check the [changelog](https://sourcegraph.com/changelog) for any executor-related breaking changes or new features.
+
+### Helm
+
+1. Update your Helm repo to fetch the latest chart versions:
+
+    ```bash
+    helm repo update sourcegraph
+    ```
+
+2. Run `helm upgrade` with the target Sourcegraph version:
+
+    ```bash
+    helm upgrade --install --values ./override.yaml --version <target Sourcegraph version> sg-executor sourcegraph/sourcegraph-executor-k8s
+    ```
+
+3. Verify the executor pod restarts with the new version:
+
+    ```bash
+    kubectl get pods -l app=executor
+    ```
+
+4. Confirm the executor is online and reporting the expected version under **Site admin > Executors > Instances**.
+
+### Kustomize
+
+1. Update the `deploy-sourcegraph-k8s` repository to the tag matching your target Sourcegraph version.
+2. Re-apply the Kustomize overlay:
+
+    ```bash
+    kubectl apply --prune -l deploy=sourcegraph -f <path to your overlay output>
+    ```
+
+3. Confirm the executor is online under **Site admin > Executors > Instances**.
+
 ## Additional Notes
 
 ### Firecracker


### PR DESCRIPTION
closes PLAT-793

This PR adds an upgrade procedure section to both the k8s native and dind deployment types

I dogfooded the procedure deploying executors locally via kind and then connecting them to the clouddev-qa test instance. Then upgrading from 7.4.0 to 7.5.0

<img width="985" height="1091" alt="Screenshot 2026-07-08 at 5 21 00 PM" src="https://github.com/user-attachments/assets/25a845ee-4342-46ae-82e4-edc2e6aa40aa" />

Tested the selectors as well

<img width="1089" height="737" alt="Screenshot 2026-07-08 at 5 33 10 PM" src="https://github.com/user-attachments/assets/41842fbd-f12e-4980-805d-052aef6a6139" />



