### PR TITLE
chore/executors: docker-compose  executors upgrade procedure

### DIFF
--- a/docs/self-hosted/executors/deploy-executors-docker.mdx
+++ b/docs/self-hosted/executors/deploy-executors-docker.mdx
@@ -23,7 +23,7 @@ Privileged containers are required to run executors in docker-compose. This is b
 
 ## Upgrading executors
 
-Upgrading Docker Compose executors requires updating the executor image tag in the compose file and recreating the container. Check the [changelog](https://sourcegraph.com/changelog) for any executor-related breaking changes or new features.
+Upgrading Docker Compose executors requires updating the executor image tag in the compose file and recreating the container. Check the [changelog](https://sourcegraph.com/changelog/self-hosted/docker-compose) for any executor-related breaking changes or new features.
 
 1. Navigate to the `deploy-sourcegraph-docker` repository and pull the latest changes for the target version:
 

--- a/docs/self-hosted/executors/deploy-executors-docker.mdx
+++ b/docs/self-hosted/executors/deploy-executors-docker.mdx
@@ -21,6 +21,49 @@ Privileged containers are required to run executors in docker-compose. This is b
 -   Edit the `deploy-sourcegraph-docker/docker-compose/executors/executor.docker-compose.yaml` and update the [environment variables](/self-hosted/executors/executors-config)
 -   Follow the instructions in the `README` for more specific deployment instructions.
 
+## Upgrading executors
+
+Upgrading Docker Compose executors requires updating the executor image tag in the compose file and recreating the container. Check the [changelog](https://sourcegraph.com/changelog) for any executor-related breaking changes or new features.
+
+1. Navigate to the `deploy-sourcegraph-docker` repository and pull the latest changes for the target version:
+
+    ```bash
+    cd deploy-sourcegraph-docker
+    git fetch
+    git checkout v<target version>
+    ```
+
+    If you are using a custom compose file rather than the one from the repository, update the `image` field for the `executor` service to the target version. For example, to upgrade to version 7.5.0:
+
+    ```yaml
+    services:
+      executor:
+        image: 'index.docker.io/sourcegraph/executor:7.5.0'
+    ```
+
+2. Recreate the executor container with the updated image:
+
+    ```bash
+    cd docker-compose
+    docker compose -f docker-compose.yaml -f executors/executor.docker-compose.yaml up -d executor
+    ```
+
+    If you are running executors on a standalone machine:
+
+    ```bash
+    docker compose -f executor.docker-compose.yaml up -d
+    ```
+
+    Docker Compose will pull the new image and recreate the executor container. The executor will briefly disconnect during the restart.
+
+3. Verify the new container is running with the expected image:
+
+    ```bash
+    docker ps --filter name=executor --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}'
+    ```
+
+4. Confirm the executor is online and reporting the expected version under **Site admin > Executors > Instances**.
+
 ## Note
 
 Executors deployed via docker-compose do not use [Firecracker](/admin/executors/#how-it-works), meaning they require [privileged access](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities) to the docker daemon running on the host.


### PR DESCRIPTION
closes PLAT-795

Add upgrade procedure for docker-compose deployment type bringing it into parity with the other executors deployments and docs.

### Testing

Deployed a 7.5.0 sourcegraph docker-compose instance locally. Then started an executors docker-compose deployment on `7.4.0` verified it connects, then updated it to `7.5.0`

<img width="1401" height="702" alt="Screenshot 2026-07-09 at 3 25 21 PM" src="https://github.com/user-attachments/assets/352094d9-5b5c-447a-9cb2-d0cc79f68165" />

<img width="1406" height="888" alt="Screenshot 2026-07-09 at 3 32 04 PM" src="https://github.com/user-attachments/assets/842b0e86-9470-4534-b2f5-5a0291eba97f" />
