### PR TITLE
Update docs latest version to 7.5

### DIFF
--- a/docs.config.js
+++ b/docs.config.js
@@ -1,5 +1,5 @@
 const config = {
-	DOCS_LATEST_VERSION: '7.4'
+	DOCS_LATEST_VERSION: '7.5'
 };
 
 module.exports = config;

--- a/docs/legacy.mdx
+++ b/docs/legacy.mdx
@@ -6,6 +6,7 @@
 
 <Accordion title="Sourcegraph 7.X">
 
+- [7.4](https://7.4.sourcegraph.com)
 - [7.3](https://7.3.sourcegraph.com)
 - [7.2](https://7.2.sourcegraph.com)
 - [7.1](https://7.1.sourcegraph.com)

--- a/src/data/versions.ts
+++ b/src/data/versions.ts
@@ -14,6 +14,10 @@ export const versions: VersionI[] = [
 		url: '/docs'
 	},
 	{
+		name: 'v7.4',
+		url: 'https://7.4.sourcegraph.com'
+	},
+	{
 		name: 'v7.3',
 		url: 'https://7.3.sourcegraph.com'
 	},


### PR DESCRIPTION
## Summary
- Set DOCS_LATEST_VERSION to 7.5
- Add 7.4 to the version selector
- Update the legacy versions page

## Test plan
- Not run (config/navigation content change only)