### PR TITLE
mcp: make static OAuth client setup discoverable

### DIFF
--- a/docs/admin/oauth-apps.mdx
+++ b/docs/admin/oauth-apps.mdx
@@ -402,9 +402,10 @@ Applications created through Dynamic Client Registration are limited to the
 `user:all`, `openid`, or `offline_access`, create an OAuth app manually.
 
 <Callout type="note">
-	To disable self-registration, set
-	`auth.idpDynamicClientRegistrationEnabled` to `false`. If `mcp.enabled` is
-	`false`, Dynamic Client Registration is also unavailable. See
-	[MCP authentication and access control](/api/mcp#availability-and-access-control)
-	for the MCP-specific behavior.
+	To disable self-registration, set `auth.idpDynamicClientRegistrationEnabled`
+	to `false`. If `mcp.enabled` is `false`, Dynamic Client Registration is also
+	unavailable. Configure and test pre-registered OAuth clients before
+	disabling DCR to avoid interrupting MCP users. See [MCP
+	Authentication](/api/mcp/authentication) for setup and migration
+	instructions.
 </Callout>

--- a/docs/api/mcp/authentication.mdx
+++ b/docs/api/mcp/authentication.mdx
@@ -1,0 +1,95 @@
+# MCP Authentication
+
+<p className="subtitle">
+	Authenticate MCP clients with OAuth or a Sourcegraph access token.
+</p>
+
+<TierCallout>
+	Supported on [Enterprise](/pricing/plans/enterprise) plans.
+</TierCallout>
+
+The Sourcegraph MCP server supports OAuth 2.0 and access token authentication.
+
+| Method                                 | When to use                                                                                   |
+| -------------------------------------- | --------------------------------------------------------------------------------------------- |
+| OAuth with Dynamic Client Registration | Your MCP client supports OAuth and your organization allows clients to register automatically |
+| OAuth with a pre-registered client     | Your organization requires administrators to approve OAuth clients in advance                 |
+| Access token                           | Your MCP client does not support OAuth                                                        |
+
+## OAuth with Dynamic Client Registration
+
+Sourcegraph implements Dynamic Client Registration (DCR) as defined by [RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591). Compatible MCP clients can register automatically and authenticate through a browser without a pre-configured client ID.
+
+DCR is enabled by default. Applications created through DCR are restricted to the `mcp` scope, which limits access to MCP endpoints.
+
+## OAuth with a Pre-registered Client
+
+Organizations that require administrators to approve OAuth clients can use pre-registered OAuth clients, also called static OAuth clients. This method also works with MCP clients that do not support DCR.
+
+Configure and test pre-registered clients before disabling DCR to avoid interrupting users.
+
+### Create an OAuth Client
+
+1. In Sourcegraph, navigate to **Site admin > OAuth clients**.
+2. Click **Create OAuth client** and configure it with:
+    - A descriptive name and optional description.
+    - The redirect URI required by your MCP client. For `mcp-remote`, use `http://localhost:3334/oauth/callback`.
+    - **Public** as the client type.
+    - The `mcp` scope.
+3. Create the client and copy its client ID.
+
+See [OAuth Apps](/admin/oauth-apps#creating-an-oauth-app) for more information about creating and managing OAuth clients.
+
+### Configure the MCP Client
+
+If your MCP client supports a pre-configured OAuth client ID, add the client ID using the client's OAuth settings.
+
+If it does not, use [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) as a local proxy and add the following configuration to your client's MCP server configuration:
+
+```json
+{
+	"sourcegraph": {
+		"type": "stdio",
+		"command": "npx",
+		"args": [
+			"mcp-remote",
+			"https://your-sourcegraph-instance.com/.api/mcp",
+			"3334",
+			"--static-oauth-client-info",
+			"{\"client_id\":\"YOUR_CLIENT_ID\"}",
+			"--static-oauth-client-metadata",
+			"{\"scope\":\"mcp\"}"
+		]
+	}
+}
+```
+
+Replace `your-sourcegraph-instance.com` with your Sourcegraph instance URL and `YOUR_CLIENT_ID` with the client ID you copied. Start the MCP client and complete authorization in your browser.
+
+## Disable Dynamic Client Registration
+
+After configuring and testing pre-registered clients, disable DCR while leaving MCP available by setting:
+
+```json
+{
+	"auth.idpDynamicClientRegistrationEnabled": false
+}
+```
+
+When DCR is disabled:
+
+- Requests to `/.auth/idp/oauth/register` return `404 not found`.
+- Existing DCR-registered clients and their tokens stop working.
+- Pre-registered OAuth clients and access tokens continue to work.
+
+If `mcp.enabled` is `false`, DCR is also unavailable and the MCP endpoints are disabled.
+
+## Access Tokens
+
+For clients that do not support OAuth, include a [Sourcegraph access token](/cli/how-tos/creating-an-access-token) in the `Authorization` header:
+
+```
+Authorization: token YOUR_ACCESS_TOKEN
+```
+
+Access tokens can use the `mcp` scope to restrict access to MCP endpoints only.

--- a/docs/api/mcp/index.mdx
+++ b/docs/api/mcp/index.mdx
@@ -51,80 +51,16 @@ https://your-sourcegraph-instance.com/.api/mcp
 
 ## Authentication
 
-The MCP server supports OAuth 2.0 and access token authentication.
+The MCP server supports OAuth 2.0 through Dynamic Client Registration or pre-registered OAuth clients, as well as Sourcegraph access tokens. Organizations that require administrators to approve OAuth clients can configure static OAuth clients and disable Dynamic Client Registration.
 
-### OAuth 2.0
-
-Sourcegraph implements Dynamic Client Registration ([RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591)), so compatible clients can authenticate automatically without pre-configured client IDs. DCR-registered applications are restricted to the `mcp` scope, which limits access to MCP endpoints only.
-
-<Accordion title="Manual OAuth Setup">
-
-If your agent doesn't support Dynamic Client Registration, you can manually create an OAuth application:
-
-1. Create an OAuth application in your Sourcegraph instance following the instructions [here](/admin/oauth-apps#creating-an-oauth-app). (Note: you can use the `mcp` scope for MCP-only access, or `user:all` for full access)
-2. Use `mcp-remote` as a fallback with the following configuration:
-
-```json
-{
-	"sourcegraph": {
-		"type": "stdio",
-		"command": "npx",
-		"args": [
-			"mcp-remote",
-			"https://your-sourcegraph-instance.com/.api/mcp",
-			"3334",
-			"--static-oauth-client-info",
-			"{\"client_id\":\"<your-client-id>\"}",
-			"--static-oauth-client-metadata",
-			"{\"scope\":\"mcp\"}"
-		]
-	}
-}
-```
-
-<Callout type="info">
-  <ul>
-    <li>Replace `your-sourcegraph-instance.com` with your Sourcegraph instance URL and `<your-client-id>` with the ID of the client you registered.</li>
-    <li>When using the `mcp-remote` fallback, ensure the OAuth client has one of its redirect URIs set to `http://localhost:3334/oauth/callback`.</li>
-  </ul>
-</Callout>
-
-</Accordion>
-
-<Accordion title="Disabling Dynamic Client Registration">
-
-To disable DCR while leaving MCP available, set the following site configuration:
-
-```json
-{
-	"auth.idpDynamicClientRegistrationEnabled": false
-}
-```
-
-If `mcp.enabled` is `false`, DCR is also unavailable and the registration
-endpoint returns `404`.
-
-</Accordion>
-
-### Access Tokens
-
-Alternatively, include a [Sourcegraph access token](/cli/how-tos/creating-an-access-token) in the Authorization header:
-
-```
-Authorization: token YOUR_ACCESS_TOKEN
-```
-
-<Callout type="info">
-	Access tokens can use the `mcp` scope to restrict access to MCP endpoints
-	only.
-</Callout>
+See [MCP Authentication](/api/mcp/authentication) to choose and configure an authentication method.
 
 ## Availability and Access Control
 
 Admins can control MCP at three levels:
 
 - Site configuration: `mcp.enabled` enables or disables the MCP HTTP endpoints.
-- OAuth Dynamic Client Registration: `auth.idpDynamicClientRegistrationEnabled` controls whether OAuth clients can self-register; it is effectively disabled whenever `mcp.enabled` is `false`.
+- OAuth Dynamic Client Registration: `auth.idpDynamicClientRegistrationEnabled` controls whether OAuth clients can self-register. See [MCP Authentication](/api/mcp/authentication#disable-dynamic-client-registration) to disable DCR and configure pre-registered clients.
 - RBAC: users must have the `MCP#ACCESS` permission to use MCP.
 
 ### Site-Level Enablement
@@ -139,21 +75,6 @@ Use the `mcp.enabled` site configuration to turn the MCP server on or off for th
 
 `mcp.enabled` defaults to `true`. When set to `false`, requests to `/.api/mcp`
 and its subpaths return `404 no route`.
-
-### OAuth Dynamic Client Registration
-
-Use `auth.idpDynamicClientRegistrationEnabled` to control whether compatible
-OAuth clients can self-register against the Sourcegraph identity provider:
-
-```json
-{
-	"auth.idpDynamicClientRegistrationEnabled": true
-}
-```
-
-`auth.idpDynamicClientRegistrationEnabled` defaults to `true`, but it is
-treated as `false` whenever `mcp.enabled` is `false`. When DCR is unavailable,
-requests to `/.auth/idp/oauth/register` return `404 not found`.
 
 ### Restricting MCP with RBAC
 

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -499,6 +499,10 @@ export const navigation: NavigationItem[] = [
 				href: '/api/mcp',
 				sections: [
 					{
+						title: 'Authentication',
+						href: '/api/mcp/authentication'
+					},
+					{
 						title: 'Client integrations',
 						href: '/api/mcp/client-integrations'
 					}


### PR DESCRIPTION
The static OAuth client instructions currently live inside a collapsed manual setup section on the already long MCP page, making the supported DCR opt-out path difficult to discover. This gives MCP authentication its own concise page and links it from the navigation, MCP overview, and OAuth Apps documentation.

The new page distinguishes DCR, pre-registered/static OAuth clients, and access tokens. It documents the safe migration order—create and test a public, `mcp`-scoped client before disabling DCR—while retaining the `mcp-remote` fallback and clarifying the callback URI and effect on existing DCR clients and tokens.

Addresses https://linear.app/sourcegraph/issue/CPL-253/revive-documentation-for-static-oauth-clients-in-mcp