### PR TITLE
docs/executors: AWS nested virtualization on non-metal instances

### DIFF
--- a/docs/self-hosted/executors/deploy-executors-binary.mdx
+++ b/docs/self-hosted/executors/deploy-executors-binary.mdx
@@ -17,7 +17,9 @@ In order to run executors on your machine, a few things need to be set up correc
 
 If [Firecracker isolation will be used](/self-hosted/executors/firecracker): _(recommended)_
 
--   The host has to support KVM (for AWS that means a [metal instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html), on GCP that means [enabling nested virtualization](https://cloud.google.com/compute/docs/instances/nested-virtualization/enabling))
+-   The host has to support KVM:
+    -   On AWS, this can be a [metal instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html) or a non-bare-metal instance that supports [nested virtualization](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-ec2-nested-virtualization.html). Nested virtualization is supported on the following Intel-based (amd64) families: `C8i`, `M8i`, `R8i`, `C8id`, `M8id`, `R8id`, `C8i-flex`, `M8i-flex`, `R8i-flex`, `X8i`, `C7i`, `M7i`, `R7i`, `C7i-flex`, `M7i-flex`, and `I7i`.
+    -   On GCP, this means [enabling nested virtualization](https://cloud.google.com/compute/docs/instances/nested-virtualization/enabling).
 -   The following additional dependencies need to be installed:
     -   `dmsetup`
     -   `losetup`


### PR DESCRIPTION
AWS now supports nested virtualization (KVM) on virtualized EC2 instances, so a bare-metal `.metal` instance is no longer required to run Firecracker-isolated executors. This updates the executor binary deploy prerequisites to reflect that and lists the supported Intel-based (amd64) instance families. The AWS and GCP KVM guidance is also split into separate sub-bullets for readability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)