### PR TITLE
Remove AMI and Kustomize from deployment overview

### DIFF
--- a/docs/self-hosted/deploy/index.mdx
+++ b/docs/self-hosted/deploy/index.mdx
@@ -16,8 +16,6 @@ Sourcegraph's recommended deployment methods are, in order:
 1. [Sourcegraph Cloud](#sourcegraph-cloud) - This provides a fully managed solution where Sourcegraph handles all of the maintenance, monitoring, and upgrading tasks to give you an optimal Sourcegraph experience while immediately getting the latest features into your users' hands. This solution does require your code hosts to be connected to the Sourcegraph managed environment.
 2. [Kubernetes Helm](#kubernetes) - Sourcegraph's Kubernetes deployment provides the most robust, scalable, and vetted self-hosted solution. This solution is ideal across many self-hosted customers capable of deploying a multi-node instance, and can be supported by all mainstream managed Kubernetes platforms.
 3. [Docker Compose](#docker-compose) - Docker Compose provides the preferred single-node deployment solution for Sourcegraph. It can be a good option when the complexities and flexibility provided by Kubernetes Helm are not needed.
-4. [Kubernetes Kustomize](#kubernetes) - Kustomize is planned for deprecation and will be sunset in a future release. Helm is Sourcegraph's preferred approach for Kubernetes deployments.
-5. [Machine Images](#machine-images) - Sourcegraph can be deployed using dedicated Machine Images for specific Cloud providers. This can be a simple solution in specific circumstances, though has its own considerations. If you are considering this path, please discuss with your account team.
 
 ### Sourcegraph Cloud
 
@@ -42,18 +40,12 @@ Best for a wide range of customers open to a Sourcegraph managed [Sourcegraph Cl
 Multi-node, self hosted solution great for large enterprises and/or other orgs looking for the recommended, robust, and scalable deployment method
 
 -   **Helm** (Preferred) utilizes pre-packaged charts for templating Sourcegraph deployments
--   **Kustomize** (Planned for deprecation) utilizes built-in features of kubectl for configuring Sourcegraph deployments. [Helm](#kubernetes) is the preferred Kubernetes deployment method.
 
 <QuickLinks>
 	<QuickLink
 		title="Helm"
 		icon="theming"
 		href="/self-hosted/deploy/kubernetes"
-	/>
-	<QuickLink
-		title="Kustomize"
-		icon="lightbulb"
-		href="/self-hosted/deploy/kubernetes/kustomize"
 	/>
 </QuickLinks>
 
@@ -77,36 +69,6 @@ Single-node, self hosted solution for enterprises looking for a simpler, non-Kub
 		href="/self-hosted/deploy/docker-compose"
 	/>
 </QuickLinks>
-
-### Machine Images
-
-Best for enterprises looking for a self-hosted solution on the Cloud provider of their choice.
-
-Machine images provide a pre-configured Sourcegraph instance that can be deployed in minutes with minimal effort. While they offer simplicity, they are designed as a standardized solution and do not support customization. Currently available on the following hosts:
-
-<Callout type="warning">
-**Note:** AWS AMI and machine image deployments will be sunset in [Sourcegraph 7.0.0](https://sourcegraph.com/changelog/releases/7.0).
-</Callout>
-
-<QuickLinks>
-	<QuickLink
-		title="Amazon Machine Image (AMI)"
-		icon="lightbulb"
-		href="/self-hosted/deploy/machine-images/aws-ami"
-	/>
-	<QuickLink
-		title="Google Compute Image"
-		icon="presets"
-		href="/self-hosted/deploy/machine-images/gce"
-	/>
-</QuickLinks>
-
-See [Sourcegraph Machine Images](/self-hosted/deploy/machine-images) for more information.
-
-<Callout type="note">
-	Deploying with machine images requires technical expertise and the ability
-	to maintain and manage your own infrastructure.
-</Callout>
 
 ### ARM / ARM64 support
 


### PR DESCRIPTION
## Summary

- remove Kubernetes Kustomize from the recommended deployment types
- remove the Kustomize quick link from the Kubernetes section
- remove the Machine Images section from the deployment overview