### PR TITLE
docs/executors: remove outdated k8s-native same-node requirement

### DIFF
--- a/docs/self-hosted/executors/deploy-executors-kubernetes.mdx
+++ b/docs/self-hosted/executors/deploy-executors-kubernetes.mdx
@@ -136,33 +136,14 @@ or [installing the binary](/self-hosted/executors/deploy-executors-binary) direc
 
 ### Job Scheduling
 
-> Note: Kubernetes has a max of 110 pods per node. If you run into this limit, you can lower the number of Job Pods running on a node by setting the environment variable `EXECUTOR_MAXIMUM_NUM_JOBS`.
-
-Executors deployed on Kubernetes require Jobs to be scheduled on the same Node as the Executor. This is to ensure that
-Jobs are able to access the same Persistence Volume as the Executor.
-
-To ensure that Jobs are scheduled on the same Node as the Executor, the following environment variables can be set,
+The following environment variables can be used to constrain which nodes Job Pods are scheduled on,
 
 -   `EXECUTOR_KUBERNETES_NODE_NAME`
 -   `EXECUTOR_KUBERNETES_NODE_SELECTOR`
 -   `EXECUTOR_KUBERNETES_NODE_REQUIRED_AFFINITY_MATCH_EXPRESSIONS`
 -   `EXECUTOR_KUBERNETES_NODE_REQUIRED_AFFINITY_MATCH_FIELDS`
 
-#### Node Name
-
-Using the [Downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/#downwardapi-fieldRef), the
-property `spec.nodeName` can be used to set the `EXECUTOR_KUBERNETES_NODE_NAME` environment variable.
-
-```yaml
-- name: EXECUTOR_KUBERNETES_NODE_NAME
-  valueFrom:
-      fieldRef:
-          fieldPath: spec.nodeName
-```
-
-This ensures that the Job is scheduled on the same Node as the Executor.
-
-However, if the node does not have enough resources to run the Job, the Job will not be scheduled.
+For example, use `EXECUTOR_KUBERNETES_NODE_SELECTOR` to restrict Jobs to a dedicated node pool.
 
 ### Firewall Rules
 

--- a/docs/self-hosted/executors/executors-troubleshooting.mdx
+++ b/docs/self-hosted/executors/executors-troubleshooting.mdx
@@ -227,8 +227,7 @@ Verify that the machine type in use is of type `.metal` (e.g. `M5.metal`).
 ## Kubernetes Job Scheduling
 
 There are a few environment variables available that can be used to determine which node an Executor Job Pod will be
-scheduled in. The Job Pods need to be scheduled in the same node as the Executor Pod (in order to mount the
-Persistence Volume Claim).
+scheduled in.
 
 The following environment variables can be used to determine where the Job Pods will be scheduled.
 


### PR DESCRIPTION
Native Kubernetes executor Job pods no longer need to be co-located on the same node as the Executor pod — that requirement was removed when the single-job-pod runtime (with `emptyDir` workspaces) became the default, so Job pods now schedule across any node in the cluster. This removes the stale same-node scheduling guidance (including the `spec.nodeName` Downward API co-location example) from the deployment guide and the troubleshooting page, and drops the 110-pods-per-node note that only applied under the old co-location constraint. The `EXECUTOR_KUBERNETES_NODE_*` env vars are now framed as optional scheduling constraints rather than a co-location requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)