### PR TITLE
Update supported OpenAI models

### DIFF
--- a/docs/cody/capabilities/supported-models.mdx
+++ b/docs/cody/capabilities/supported-models.mdx
@@ -43,9 +43,7 @@ Cody supports a variety of cutting-edge large language models for use in chat an
 | OpenAI | [GPT-4.1](https://platform.openai.com/docs/models/gpt-4.1) | ✅ | ✅ |
 | OpenAI | [GPT-4o-mini](https://platform.openai.com/docs/models#gpt-4o-mini) | ✅ | ✅ |
 | OpenAI | [GPT-4.1-mini](https://platform.openai.com/docs/models/gpt-4.1-mini) | ✅ | ✅ |
-| OpenAI | [GPT-4.1-nano](https://platform.openai.com/docs/models/gpt-4.1-nano) | ✅ | ✅ |
 | OpenAI | [o3](https://platform.openai.com/docs/models#o3) | ✅ | ❌ |
-| OpenAI | [o4-mini](https://platform.openai.com/docs/models/o4-mini) | ✅ | ❌ |
 
 <Callout type="note">
 	While Gemini models support vision capabilities, Cody clients do not
@@ -62,7 +60,6 @@ Cody uses a set of models for autocomplete which are suited for the low latency 
 | Fireworks.ai | DeepSeek V2 Lite Base | ✅ | US Iowa |
 | Fireworks.ai | Autoedits Fine-Tune DeepSeek Coder V2 | ✅ | US Iowa |
 | Fireworks.ai | NLS Query Translator | ✅ | US Iowa |
-| OpenAI | [GPT-4.1-nano](https://platform.openai.com/docs/models/gpt-4.1-nano) | ✅ | global |
 
 
 


### PR DESCRIPTION
## Summary

- remove GPT-4.1-nano from the supported chat and autocomplete model lists
- remove o4-mini from the supported chat model list
- align the docs with sourcegraph/sourcegraph commit [6946b7f66e7](https://github.com/sourcegraph/sourcegraph/commit/6946b7f66e7f57ab7152382d8a9b7b80f7487b31)

## Test plan

- ran `git diff --check`
- confirmed GPT-4.1-nano and o4-mini no longer appear on the supported-models page