### PR TITLE
docs: note coding agent step MCP and code access

### DIFF
--- a/docs/agentic-batch-changes/index.mdx
+++ b/docs/agentic-batch-changes/index.mdx
@@ -70,6 +70,11 @@ To get set up, just ask the agent for it in your agentic batch change. We recomm
 
 The coding agent step is a new native step type for Agentic Batch Changes that allows the agent to delegate non-deterministic or context-dependent changes for another coding agent to handle. Coding agent steps are automatically pre-configured with the [Sourcegraph MCP](/api/mcp).
 
+Within a coding agent step, the agent has:
+
+- **Full MCP access under your actor** — the [Sourcegraph MCP](/api/mcp) tools are available and authenticated as you, so the agent operates with your permissions.
+- **Access to the code being worked on** — the workspace's repository checkout is available to the agent as it makes changes.
+
 We currently support [Claude Code](https://claude.com/product/claude-code) and [Codex](https://openai.com/codex) as native coding agent steps.
 
 By default, coding agent LLM traffic is routed through the [Sourcegraph Model Provider](/model-provider). Site administrators can configure their own API keys to route traffic directly to Anthropic or OpenAI in **Administration → Batch Changes → Agents**. An optional `endpoint` field can be set for each agent to override the default provider URL.


### PR DESCRIPTION
Closes CPL-605

Expands the "Coding agent steps" section of the Agentic Batch Changes docs to
note two capabilities available inside a coding agent step:

- Full MCP access under your actor (Sourcegraph MCP tools authenticated as you).
- Access to the code being worked on (the workspace repository checkout).

[_Created by Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/352)