### PR TITLE
executor: add `executor install batch-exec` instructions

### DIFF
--- a/docs/self-hosted/executors/deploy-executors-binary.mdx
+++ b/docs/self-hosted/executors/deploy-executors-binary.mdx
@@ -212,11 +212,14 @@ If you are using Firecracker (requires KVM):
 executor install all
 ```
 
-If you are **not** using Firecracker (Docker-only mode), install only `src-cli`:
+If you are **not** using Firecracker (Docker-only mode), install `src-cli` and `batch-exec`:
 
 ```bash
 executor install src-cli
+executor install batch-exec
 ```
+
+> Note: `batch-exec` is an internal binary used by executors. The executor will automatically download a matching binary.
 
 You can run `executor install --help` to see all available install targets.
 


### PR DESCRIPTION
Companion fix to https://linear.app/sourcegraph/issue/SVC-2509/fix-single-binary-executor-install-to-include-batch-exec