### PR TITLE
docs/observability: add Microsoft Teams alert notifier

### DIFF
--- a/docs/self-hosted/observability/alerting.mdx
+++ b/docs/self-hosted/observability/alerting.mdx
@@ -64,7 +64,7 @@ Once configured, Sourcegraph alerts will automatically be routed to the appropri
 
 #### Microsoft Teams
 
-Create a Microsoft Teams Workflow using [Post to a channel when a webhook request is received](https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498), then copy its signed Workflow URL.
+In a standard Microsoft Teams channel, create a Workflow using the [Send webhook alerts to a channel](https://support.microsoft.com/en-us/workflows/send-messages-in-teams-using-incoming-webhooks) template. Choose the generic template described as allowing anyone to send updates. Do not use variants restricted to users in your organization or specific people because they require OAuth authentication and aren't compatible with Alertmanager's unauthenticated webhook request. Save the Workflow, then copy its complete signed URL.
 
 ```json
 "observability.alerts": [

--- a/docs/self-hosted/observability/alerting.mdx
+++ b/docs/self-hosted/observability/alerting.mdx
@@ -62,6 +62,25 @@ Once configured, Sourcegraph alerts will automatically be routed to the appropri
 
 > NOTE: Learn more about generating a [Slack incoming webhook URL](https://api.slack.com/messaging/webhooks)
 
+#### Microsoft Teams
+
+Create a Microsoft Teams Workflow using [Post to a channel when a webhook request is received](https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498), then copy its signed Workflow URL.
+
+```json
+"observability.alerts": [
+  {
+    "level": "critical",
+    "notifier": {
+      "type": "msteams",
+      // Complete signed Microsoft Teams Workflow URL
+      "url": "https://example.logic.azure.com/workflows/.../triggers/manual/paths/invoke?...&sig=..."
+    }
+  }
+]
+```
+
+> NOTE: This integration uses a Teams Workflow, not the legacy Microsoft 365 (formerly Office 365) Incoming Webhook connector. No separate token is required. Treat the signed Workflow URL as a secret.
+
 #### PagerDuty
 
 ```json


### PR DESCRIPTION
Microsoft Teams users need clear setup guidance for routing Sourcegraph observability alerts to a channel without relying on retired legacy connectors. This adds a Microsoft Teams example alongside the existing notifier configurations, using a Teams Workflow, the `msteams` notifier type, and its complete signed URL. It also calls out that no separate token is required and that the URL must be treated as a secret.

Related product change: https://github.com/sourcegraph/sourcegraph/pull/14405

Linear: https://linear.app/sourcegraph/issue/SVC-2528/add-microsoft-teams-support-for-observability-alerts
