### PR TITLE
docs: remove outdated entitlement types

### DIFF
--- a/docs/admin/entitlements.mdx
+++ b/docs/admin/entitlements.mdx
@@ -11,10 +11,8 @@ Entitlements can be set as a global default: default entitlements are granted to
 Each entitlement has a detailed usage view to help administrators understand how users are using the entitlement, and reset entitlement usage for specific users.
 
 <Callout type="note">
-	Entitlements currently support [Deep Search](/deep-search) and [smart hover
-	summaries](/code-navigation/smart-hover). If you would like to request
-	entitlement support for a feature, please reach out at
-	support@sourcegraph.com.
+	If you would like to request entitlement support for a feature, please reach
+	out at support@sourcegraph.com.
 </Callout>
 
 <Callout type="note">


### PR DESCRIPTION
## Summary

- remove the outdated statement that entitlements only support Deep Search and smart hover summaries
- retain the support contact information

## Testing

- `git diff --check`