### PR TITLE
Drop support for GitHub Enterprise Server versions below 3.2

### DIFF
--- a/docs/admin/code-hosts/github.mdx
+++ b/docs/admin/code-hosts/github.mdx
@@ -15,7 +15,11 @@ There are 2 ways to connect with GitHub:
 ## Supported versions
 
 -   GitHub.com
--   GitHub Enterprise v2.10 and newer
+-   GitHub Enterprise Server 3.2 and newer
+
+<Callout type="warning">
+	Sourcegraph no longer supports GitHub Enterprise Server versions 3.1 and below, which have been discontinued since June 3, 2022.
+</Callout>
 
 ## Using a GitHub App
 

--- a/docs/admin/code-hosts/github.mdx
+++ b/docs/admin/code-hosts/github.mdx
@@ -15,7 +15,7 @@ There are 2 ways to connect with GitHub:
 ## Supported versions
 
 -   GitHub.com
--   GitHub Enterprise Server 3.2 and newer
+-   GitHub Enterprise Server 3.2 and later
 
 <Callout type="warning">
 	Sourcegraph no longer supports GitHub Enterprise Server versions 3.1 and below, which have been discontinued since June 3, 2022.

--- a/docs/batch-changes/requirements.mdx
+++ b/docs/batch-changes/requirements.mdx
@@ -15,7 +15,7 @@ While the latest version of the Sourcegraph server is always recommended, **vers
 Batch Changes is compatible with the following code hosts:
 
 -   Github.com
--   GitHub Enterprise 2.20 and later
+-   GitHub Enterprise Server 3.2 and later
 -   GitLab 12.7 and later (burndown charts are only supported with 13.2 and later)
 -   Bitbucket Server 5.7 and later, Bitbucket Data Center 7.6 and later
 -   Bitbucket Cloud (bitbucket.org)
@@ -24,6 +24,10 @@ Batch Changes is compatible with the following code hosts:
 -   Perforce (Beta)
 
 For Sourcegraph to interface with these, admins and users must first [configure credentials](/batch-changes/configuring-credentials) for each relevant code host.
+
+<Callout type="warning">
+	Sourcegraph no longer supports GitHub Enterprise Server versions 3.1 and below, which have been discontinued since June 3, 2022.
+</Callout>
 
 <Callout type="warning">
 	Currently, for customers on an instance of GitHub Enterprise Cloud that uses


### PR DESCRIPTION
For CPL-693

Closes CPL-694

We're dropping support for GitHub Enterprise Server versions below 3.2.