### PR TITLE
Remove Code Finder MCP beta badge

### DIFF
--- a/docs/api/mcp/index.mdx
+++ b/docs/api/mcp/index.mdx
@@ -328,7 +328,7 @@ The MCP server provides these tools for code exploration and analysis:
 
 </details>
 
-### Code Finder <Badge className="ml-1 align-middle">Beta</Badge>
+### Code Finder
 
 Code Finder is an agentic tool that sits between plain search and Deep Search: it runs its own internal search loop to locate the code relevant to a task, then returns the matching file paths and line ranges with a brief explanation. Unlike `deepsearch`, it runs synchronously and is designed for quickly finding relevant code in a repository you already know, rather than open-ended research across many repositories.
 


### PR DESCRIPTION
GA launch is today, so the beta badge should be removed.