### PR TITLE
docs: Simplify inner-loop Agentic Batch Changes coding agent docs

### DIFF
--- a/docs/agentic-batch-changes/index.mdx
+++ b/docs/agentic-batch-changes/index.mdx
@@ -77,7 +77,7 @@ Within a coding agent step, the agent has:
 
 We currently support [Claude Code](https://claude.com/product/claude-code) and [Codex](https://openai.com/codex) as native coding agent steps.
 
-By default, coding agent LLM traffic is routed through the [Sourcegraph Model Provider](/model-provider). Site administrators can configure their own API keys to route traffic directly to Anthropic or OpenAI in **Administration → Batch Changes → Agents**. An optional `endpoint` field can be set for each agent to override the default provider URL.
+By default, coding agent LLM traffic is routed through the [Sourcegraph Model Provider](/model-provider).
 
 Note that Agentic Batch Changes does not use coding agent steps for every task. For deterministic changes, the agent will opt to write a script - or even an entire program - to efficiently apply some, or all, of the target changes.
 


### PR DESCRIPTION
See: https://docs.google.com/document/d/1kS0Rxl24qlbtNHguW3ld8yigX4BuqmhHsBlEtV4Kx3I/edit?disco=AAACFwCeQeE

The generated site configuration reference is intentionally unchanged, we'll have to take care of that separately.