### PR TITLE
docs: document RBAC credit usage controls

### DIFF
--- a/docs/beta-and-experimental/index.mdx
+++ b/docs/beta-and-experimental/index.mdx
@@ -54,6 +54,6 @@ Billing depends on the feature.
 - Some **Experimental** and **Beta** features, when they graduate to general availability (GA), may be billable with credits.
     - Before credit consumption begins for a given feature, Sourcegraph will provide advance notice identifying the applicable credit pricing and how usage will be measured against your credit pool.
     - Your credit pool stays unchanged, except that any credit-billable GA features you use after receiving that notice will be billed against the pool at their then-current rates.
-- Admins can [configure limits](/admin/entitlements) on the use of credit-consuming features
+- Admins will be able to use either [entitlements](/admin/entitlements) to configure usage limits or [role-based access control (RBAC)](/admin/access-control) to restrict access, or both, to control the use of credit-consuming features.
 
 To learn more about credits and billing, please reach out to your account manager or [support@sourcegraph.com](mailto:support@sourcegraph.com).

--- a/docs/beta-and-experimental/index.mdx
+++ b/docs/beta-and-experimental/index.mdx
@@ -54,6 +54,6 @@ Billing depends on the feature.
 - Some **Experimental** and **Beta** features, when they graduate to general availability (GA), may be billable with credits.
     - Before credit consumption begins for a given feature, Sourcegraph will provide advance notice identifying the applicable credit pricing and how usage will be measured against your credit pool.
     - Your credit pool stays unchanged, except that any credit-billable GA features you use after receiving that notice will be billed against the pool at their then-current rates.
-- Admins will be able to use either [entitlements](/admin/entitlements) to configure usage limits or [role-based access control (RBAC)](/admin/access-control) to restrict access, or both, to control the use of credit-consuming features.
+- Admins will be able to restrict spend via [entitlements](/admin/entitlements), [role-based access control (RBAC)](/admin/access-control), or other authoritative methods.
 
 To learn more about credits and billing, please reach out to your account manager or [support@sourcegraph.com](mailto:support@sourcegraph.com).

--- a/docs/deep-search/index.mdx
+++ b/docs/deep-search/index.mdx
@@ -134,22 +134,18 @@ Deep Search streams its responses using [Server-Sent Events (SSE)](https://en.wi
 
 If your Sourcegraph instance sits behind a reverse proxy, load balancer, or ingress controller, you must ensure the timeout for connections to Sourcegraph is set to at least **5 minutes**. The default timeout for many proxies (often 30–60 seconds) will cause in-progress Deep Search responses to be cut off prematurely.
 
+## Credit consumption
+
+Deep Search consumes credits from your Sourcegraph subscription's credit balance.
+
+Customers can request access to [Enterprise Portal](/admin/enterprise-portal#deep-search-usage-monitoring) to monitor Deep Search credit consumption.
+
 ## Managing usage
 
-Deep Search usage is managed on two levels:
+Sourcegraph administrators can manage Deep Search usage with:
 
-- **Quotas**, which refers to billed Deep Search usage. These are determined by the purchased Sourcegraph subscription.
-- [**Entitlements**](/admin/entitlements), which refers to administrator-controlled limits on how much Deep Search users can consume.
-
-### Monitoring quota consumption
-
-Customers can request access to [Enterprise Portal](/admin/enterprise-portal#deep-search-usage-monitoring) to monitor usage of Deep Search quota.
-
-### Entitlements
-
-Sourcegraph administrators can configure entitlements for their users, for example "60 Deep Search per hour", in `/site-admin/entitlements`.
-
-To learn more, refer to [Entitlements](/admin/entitlements) and the [Deep Search entitlements changelog post](https://sourcegraph.com/changelog/deep-search-entitlements).
+- [**Entitlements**](/admin/entitlements), which set how much Deep Search users can consume. For example, administrators can configure "60 Deep Search per hour" in `/site-admin/entitlements`. To learn more, refer to the [Deep Search entitlements changelog post](https://sourcegraph.com/changelog/deep-search-entitlements).
+- [**Role-based access control (RBAC)**](/admin/access-control), which restricts who can use Deep Search, either alongside entitlements or instead of them.
 
 ## Integrations and APIs
 


### PR DESCRIPTION
## Summary

- document RBAC as an alternative or complement to entitlements for credit-consuming features
- separate Deep Search credit consumption from usage management guidance
- link directly to the RBAC access control documentation

## Test plan

- `./node_modules/.bin/prettier --check docs/deep-search/index.mdx docs/beta-and-experimental/index.mdx`
- `node dev/check-links.mjs`
- `git diff --check`