### PR TITLE
docs/docs: Fix notice style overrides example

### DIFF
--- a/docs/admin/config/settings.mdx
+++ b/docs/admin/config/settings.mdx
@@ -208,11 +208,9 @@ Notices can be added in global, organization, or user settings. The `notices` se
     "dismissible": true,
     "variant": "danger",
     "styleOverrides": {
-      "styleOverrides": {
-        "backgroundColor": "#7f1d1d",
-        "textColor": "#fecaca",
-        "textCentered": true
-      }
+      "backgroundColor": "#7f1d1d",
+      "textColor": "#fecaca",
+      "textCentered": true
     }
   }
 ]


### PR DESCRIPTION
The notices settings example currently nests `styleOverrides` inside another `styleOverrides` object, but the settings schema expects the style fields directly inside the first object. This could lead users to copy a configuration whose overrides are ignored.

Remove the duplicate nesting so the example matches the supported settings shape.

Related to https://github.com/sourcegraph/sourcegraph/pull/14628#discussion_r3864019760.