### PR TITLE
docs: document API integration usage headers

### DIFF
--- a/docs/api/index.mdx
+++ b/docs/api/index.mdx
@@ -30,3 +30,14 @@ For diagnostics use cases, the [Sourcegraph GraphQL debug API](/api/graphql/) is
     reach out at support@sourcegraph.com.</p>
 
 </Callout>
+
+## Tracking integration usage
+
+If you'd like our help breaking down and analyzing API usage across different integrations, include some or all of the following headers in your requests:
+
+- `X-Requested-With: <your-app-name>/<version>` — a stable identifier for the calling integration
+- `X-Sourcegraph-API-Client-Name: <caller-name>` — the caller's name, for example, `my-integration`
+- `X-Sourcegraph-API-Client-Feature: <feature-or-tool>` — the feature or tool making the request, so that different call sites from the same integration are distinguishable
+- `X-Sourcegraph-API-Client-Version: <version>` — the integration's build or version
+
+When an API request triggers a [telemetry](/admin/telemetry/) event, Sourcegraph includes the values of these headers in the event.


### PR DESCRIPTION
## Summary

- document request headers that identify API integrations, features, and versions
- explain how emitted telemetry events capture these values
- link to the telemetry documentation

## Verification

- cross-checked header parsing and telemetry behavior against the Sourcegraph implementation using Deep Search
- `git diff --check`