### PR TITLE
docs: document Code Finder revision parameter

### DIFF
--- a/docs/api/mcp/index.mdx
+++ b/docs/api/mcp/index.mdx
@@ -342,6 +342,7 @@ Code Finder usage is metered against your instance's entitlement. When the quota
 **Parameters:**
 
 - `task` - The task or query to research and answer (required)
+- `revision` - Branch, tag, or commit to search (optional; defaults to the repository's default branch). When set, `task` must identify a repository.
 
 **Use cases:** Locating the files and line ranges relevant to a task before making changes, finding where a feature is implemented, gathering focused context for an AI agent
 


### PR DESCRIPTION
## Summary

- document the optional MCP Code Finder `revision` parameter
- describe accepted revisions, default behavior, and repository scoping requirement

Supports sourcegraph/sourcegraph#15132.

## Validation

- `node_modules/.bin/prettier --config ./prettier.config.js --check docs/api/mcp/index.mdx`
- `git diff --check`