### PR TITLE
Keep legacy selectors connected to current versions

### DIFF
--- a/.agents/skills/publishing-docs-versions/SKILL.md
+++ b/.agents/skills/publishing-docs-versions/SKILL.md
@@ -20,9 +20,8 @@ Use this skill for the Sourcegraph docs repo release-version workflow: cutting l
   - `src/data/versions.ts`
   - `docs/legacy.mdx`
 - `src/data/versions.ts` on `origin/main` is the canonical dropdown list. The
-  current site exposes it through `/docs/api/versions`. Legacy selectors load
-  that manifest through the main branch's Vercel origin to avoid cross-subdomain
-  Cloudflare challenges.
+  current site exposes it through `https://sourcegraph.com/docs/api/versions`,
+  and legacy selectors load that manifest at runtime.
 - A legacy branch's bundled `src/data/versions.ts` is only a fallback. Its first
   entry identifies the archived site and must not have the `latest` label.
 - A legacy selector shows the current latest version, its selected archived

--- a/.agents/skills/publishing-docs-versions/SKILL.md
+++ b/.agents/skills/publishing-docs-versions/SKILL.md
@@ -20,10 +20,13 @@ Use this skill for the Sourcegraph docs repo release-version workflow: cutting l
   - `src/data/versions.ts`
   - `docs/legacy.mdx`
 - `src/data/versions.ts` on `origin/main` is the canonical dropdown list. The
-  current site exposes it through `/docs/api/versions`, and legacy selectors
-  load that manifest at runtime.
+  current site exposes it through `/docs/api/versions`. Legacy selectors load
+  that manifest through the main branch's Vercel origin to avoid cross-subdomain
+  Cloudflare challenges.
 - A legacy branch's bundled `src/data/versions.ts` is only a fallback. Its first
   entry identifies the archived site and must not have the `latest` label.
+- A legacy selector shows the current latest version, its selected archived
+  version, and older versions. It omits versions between latest and selected.
 
 ## Standard workflow for a new release
 

--- a/src/components/VersionSelector.tsx
+++ b/src/components/VersionSelector.tsx
@@ -14,7 +14,7 @@ import {Fragment, useEffect, useState} from 'react';
 
 const versionsUrl =
 	process.env.NEXT_PUBLIC_DOCS_VERSIONS_URL ??
-	'https://sourcegraph-docs-git-main-sourcegraph-f8c71130.vercel.app/docs/api/versions';
+	'https://sourcegraph.com/docs/api/versions';
 
 function isVersion(value: unknown): value is VersionI {
 	if (typeof value !== 'object' || value === null) return false;

--- a/src/components/VersionSelector.tsx
+++ b/src/components/VersionSelector.tsx
@@ -14,7 +14,7 @@ import {Fragment, useEffect, useState} from 'react';
 
 const versionsUrl =
 	process.env.NEXT_PUBLIC_DOCS_VERSIONS_URL ??
-	'https://sourcegraph.com/docs/api/versions';
+	'https://sourcegraph-docs-git-main-sourcegraph-f8c71130.vercel.app/docs/api/versions';
 
 function isVersion(value: unknown): value is VersionI {
 	if (typeof value !== 'object' || value === null) return false;
@@ -25,6 +25,23 @@ function isVersion(value: unknown): value is VersionI {
 		typeof version.url === 'string' &&
 		(version.label === undefined || typeof version.label === 'string')
 	);
+}
+
+function versionsForSite(remoteVersions: VersionI[]): VersionI[] {
+	const selectedIndex = remoteVersions.findIndex(
+		version => version.name === versions[0].name
+	);
+
+	if (selectedIndex === 0) return remoteVersions;
+	if (selectedIndex > 0) {
+		return [remoteVersions[0], ...remoteVersions.slice(selectedIndex)];
+	}
+
+	return [
+		remoteVersions[0],
+		{...versions[0], label: undefined},
+		...versions.slice(1)
+	];
 }
 
 export default function VersionSelector() {
@@ -57,16 +74,7 @@ export default function VersionSelector() {
 					return;
 				}
 
-				setAvailableVersions(
-					remoteVersions.some(
-						version => version.name === versions[0].name
-					)
-						? remoteVersions
-						: [
-								...remoteVersions,
-								{...versions[0], label: undefined}
-							]
-				);
+				setAvailableVersions(versionsForSite(remoteVersions));
 			})
 			.catch(() => {
 				// Keep this build's version list if the current site is unavailable.


### PR DESCRIPTION
## Summary

- read the canonical version manifest through the stable `main` Vercel origin, avoiding Cloudflare challenges on cross-subdomain browser requests
- keep the full version list on current docs while arranging legacy menus as latest, selected, then older versions
- document the manifest origin and legacy filtering behavior in the publishing skill

## Test plan

- `npx --yes pnpm@10.25.0 run build`
- browser-verified the Vercel manifest returns CORS JSON from a legacy origin
- browser-verified current docs retain the full list