### PR TITLE
Use local Sourcegraph mark asset

### DIFF
--- a/docs/integration/browser-extension/index.mdx
+++ b/docs/integration/browser-extension/index.mdx
@@ -15,9 +15,9 @@
 
 The Sourcegraph browser extension allows you to open repos, compare revisions and search code directly from Chrome's Omnibox for faster development on GitHub and GitHub Enterprise Server with support coming to GitLab, Phabricator, Bitbucket Server and Bitbucket Data Center in the future.
 
--   [Install Sourcegraph for Chrome](https://chrome.google.com/webstore/detail/sourcegraph/dgjhfomjieaadpoljlnidmbgkdffpack)
--   [Install Sourcegraph for Safari](https://apps.apple.com/us/app/sourcegraph-for-safari/id1543262193)
--   [Install Sourcegraph for Firefox](https://addons.mozilla.org/en-US/firefox/addon/sourcegraph-for-firefox)
+- [Install Sourcegraph for Chrome](https://chrome.google.com/webstore/detail/sourcegraph/dgjhfomjieaadpoljlnidmbgkdffpack)
+- [Install Sourcegraph for Safari](https://apps.apple.com/us/app/sourcegraph-for-safari/id1543262193)
+- [Install Sourcegraph for Firefox](https://addons.mozilla.org/en-US/firefox/addon/sourcegraph-for-firefox)
 
 <QuickLinks>
 	<QuickLink
@@ -39,9 +39,10 @@ The Sourcegraph browser extension allows you to open repos, compare revisions an
 <LinkCards>
 
 {' '}
+
 <LinkCard
 	href="https://about.sourcegraph.com/get-started?t=enterprise"
-	imgSrc="https://sourcegraph.com/.assets/img/sourcegraph-mark.svg"
+	imgSrc="/sourcegraph-mark.svg"
 	imgAlt="Sourcegraph"
 	title="Get single-tenant instance managed by Sourcegraph."
 	description="Sign up and get a 30 day free trial for your team."
@@ -51,10 +52,10 @@ The Sourcegraph browser extension allows you to open repos, compare revisions an
 
 ## How-tos
 
--   [Install across all Google Workspace users](/integration/browser-extension/how-tos/google-workspace)
--   [Add browser search engine shortcuts](/integration/browser-extension/how-tos/browser-search-engine)
--   [Troubleshoot common issues](/integration/browser-extension/how-tos/troubleshooting)
+- [Install across all Google Workspace users](/integration/browser-extension/how-tos/google-workspace)
+- [Add browser search engine shortcuts](/integration/browser-extension/how-tos/browser-search-engine)
+- [Troubleshoot common issues](/integration/browser-extension/how-tos/troubleshooting)
 
 ## References
 
--   [Privacy](/integration/browser-extension/references/privacy)
+- [Privacy](/integration/browser-extension/references/privacy)

--- a/docs/self-hosted/deploy/index.mdx
+++ b/docs/self-hosted/deploy/index.mdx
@@ -27,7 +27,7 @@ Best for a wide range of customers open to a Sourcegraph managed [Sourcegraph Cl
 
 <LinkCard
 	href="https://about.sourcegraph.com/get-started?t=enterprise"
-	imgSrc="https://sourcegraph.com/.assets/img/sourcegraph-mark.svg"
+	imgSrc="/sourcegraph-mark.svg"
 	imgAlt="Sourcegraph"
 	title="Get a single-tenant instance managed by Sourcegraph."
 	description="Sign up and get a 30 day free trial for your team."
@@ -39,7 +39,7 @@ Best for a wide range of customers open to a Sourcegraph managed [Sourcegraph Cl
 
 Multi-node, self hosted solution great for large enterprises and/or other orgs looking for the recommended, robust, and scalable deployment method
 
--   **Helm** (Preferred) utilizes pre-packaged charts for templating Sourcegraph deployments
+- **Helm** (Preferred) utilizes pre-packaged charts for templating Sourcegraph deployments
 
 <QuickLinks>
 	<QuickLink


### PR DESCRIPTION
Replace external Sourcegraph mark references with the repository-owned public asset. This us causing some weird coupling to the sourcegraph webapp build process.