### PR TITLE
Point stale docs.sourcegraph.com links at sourcegraph.com/docs

### DIFF
--- a/docs/cli/references/abc/variables/delete.mdx
+++ b/docs/cli/references/abc/variables/delete.mdx
@@ -27,6 +27,6 @@ $ src abc variables delete [options] <workflow-instance-id> [<name> ...]
 | `--dump-requests` | Log GraphQL requests and responses to stdout | `false`|
 | `--get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false`|
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|
 | `--var` | Variable name to delete. Repeat for multiple names. | ``|

--- a/docs/cli/references/abc/variables/set.mdx
+++ b/docs/cli/references/abc/variables/set.mdx
@@ -33,6 +33,6 @@ $ src abc variables set [options] <workflow-instance-id> [<name>=<value> ...]
 | `--dump-requests` | Log GraphQL requests and responses to stdout | `false`|
 | `--get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false`|
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|
 | `--var` | Variable assignment in &lt;name&gt;=&lt;value&gt; form. Repeat to set multiple variables. | ``|

--- a/docs/cli/references/api.mdx
+++ b/docs/cli/references/api.mdx
@@ -41,6 +41,6 @@ $ src api [options] [variable=value ...]
 | `--get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false`|
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
 | `--query` | GraphQL query to execute, e.g. 'query \{ currentUser \{ username \} \}' (stdin otherwise) | ``|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|
 | `--vars` | GraphQL query variables to include as JSON string, e.g. '\{"var": "val", "var2": "val2"\}' | ``|

--- a/docs/cli/references/batch/apply.mdx
+++ b/docs/cli/references/batch/apply.mdx
@@ -25,7 +25,7 @@
 | `-text-only` | INTERNAL USE ONLY. EXPERIMENTAL. Switches off the TUI to only print JSON lines. | `false` |
 | `-timeout` | The maximum duration a single batch spec step can take. | `1h0m0s` |
 | `-tmp` | Directory for storing temporary data, such as log files. Default is /tmp. Can also be set with environment variable SRC_BATCH_TMP_DIR; if both are set, this flag will be used and not the environment variable. | `/tmp` |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 | `-v` | print verbose output | `false` |
 | `-workspace` | Workspace mode to use ("auto", "bind", or "volume") | `auto` |
@@ -76,7 +76,7 @@ Usage of 'src batch apply':
   -tmp string
     	Directory for storing temporary data, such as log files. Default is /tmp. Can also be set with environment variable SRC_BATCH_TMP_DIR; if both are set, this flag will be used and not the environment variable. (default "/tmp")
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
   -v	print verbose output

--- a/docs/cli/references/batch/new.mdx
+++ b/docs/cli/references/batch/new.mdx
@@ -10,7 +10,7 @@
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
 | `-skip-errors` | If true, errors encountered won't stop the program, but only log them. | `false` |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
 
@@ -29,7 +29,7 @@ Usage of 'src batch new':
   -skip-errors
     	If true, errors encountered won't stop the program, but only log them.
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/batch/preview.mdx
+++ b/docs/cli/references/batch/preview.mdx
@@ -25,7 +25,7 @@
 | `-text-only` | INTERNAL USE ONLY. EXPERIMENTAL. Switches off the TUI to only print JSON lines. | `false` |
 | `-timeout` | The maximum duration a single batch spec step can take. | `1h0m0s` |
 | `-tmp` | Directory for storing temporary data, such as log files. Default is /tmp. Can also be set with environment variable SRC_BATCH_TMP_DIR; if both are set, this flag will be used and not the environment variable. | `/tmp` |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 | `-v` | print verbose output | `false` |
 | `-workspace` | Workspace mode to use ("auto", "bind", or "volume") | `auto` |
@@ -76,7 +76,7 @@ Usage of 'src batch preview':
   -tmp string
     	Directory for storing temporary data, such as log files. Default is /tmp. Can also be set with environment variable SRC_BATCH_TMP_DIR; if both are set, this flag will be used and not the environment variable. (default "/tmp")
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
   -v	print verbose output

--- a/docs/cli/references/batch/remote.mdx
+++ b/docs/cli/references/batch/remote.mdx
@@ -15,7 +15,7 @@
 | `-n` | Alias for -namespace. |  |
 | `-namespace` | The user or organization namespace to place the batch change within. Default is the currently authenticated user. |  |
 | `-skip-errors` | If true, errors encountered won't stop the program, but only log them. | `false` |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
 
@@ -44,7 +44,7 @@ Usage of 'src batch remote':
   -skip-errors
     	If true, errors encountered won't stop the program, but only log them.
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 'src batch remote' runs a batch spec on the Sourcegraph instance.

--- a/docs/cli/references/batch/repositories.mdx
+++ b/docs/cli/references/batch/repositories.mdx
@@ -12,7 +12,7 @@
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
 | `-skip-errors` | If true, errors encountered won't stop the program, but only log them. | `false` |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
 
@@ -35,7 +35,7 @@ Usage of 'src batch repositories':
   -skip-errors
     	If true, errors encountered won't stop the program, but only log them.
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/batch/validate.mdx
+++ b/docs/cli/references/batch/validate.mdx
@@ -12,7 +12,7 @@
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
 | `-skip-errors` | If true, errors encountered won't stop the program, but only log them. | `false` |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
 
@@ -35,7 +35,7 @@ Usage of 'src batch validate':
   -skip-errors
     	If true, errors encountered won't stop the program, but only log them.
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/codeowners/create.mdx
+++ b/docs/cli/references/codeowners/create.mdx
@@ -24,5 +24,5 @@ $ src codeowners create [options]
 | `--get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false`|
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
 | `--repo` | The repository to attach the data to | ``|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|

--- a/docs/cli/references/codeowners/delete.mdx
+++ b/docs/cli/references/codeowners/delete.mdx
@@ -22,5 +22,5 @@ $ src codeowners delete [options]
 | `--get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false`|
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
 | `--repo` | The repository to delete the data for | ``|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|

--- a/docs/cli/references/codeowners/get.mdx
+++ b/docs/cli/references/codeowners/get.mdx
@@ -22,5 +22,5 @@ $ src codeowners get [options]
 | `--get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false`|
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
 | `--repo` | The repository to attach the data to | ``|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|

--- a/docs/cli/references/codeowners/update.mdx
+++ b/docs/cli/references/codeowners/update.mdx
@@ -24,5 +24,5 @@ $ src codeowners update [options]
 | `--get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false`|
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
 | `--repo` | The repository to attach the data to | ``|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|

--- a/docs/cli/references/config/edit.mdx
+++ b/docs/cli/references/config/edit.mdx
@@ -11,7 +11,7 @@
 | `-overwrite` | Overwrite the entire settings with the value given in -value (not just a single property). | `false` |
 | `-property` | The name of the settings property to set. |  |
 | `-subject` | The ID of the settings subject whose settings to edit. (default: authenticated user) |  |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 | `-value` | The value for the settings property (when used with -property). |  |
 | `-value-file` | Read the value from this file instead of from the -value command-line option. |  |
@@ -34,7 +34,7 @@ Usage of 'src config edit':
   -subject string
     	The ID of the settings subject whose settings to edit. (default: authenticated user)
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
   -value string

--- a/docs/cli/references/config/get.mdx
+++ b/docs/cli/references/config/get.mdx
@@ -10,7 +10,7 @@
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
 | `-subject` | The ID of the settings subject whose settings to get. (default: authenticated user) |  |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
 
@@ -29,7 +29,7 @@ Usage of 'src config get':
   -subject string
     	The ID of the settings subject whose settings to get. (default: authenticated user)
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/config/list.mdx
+++ b/docs/cli/references/config/list.mdx
@@ -10,7 +10,7 @@
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
 | `-subject` | The ID of the settings subject whose settings to list. (default: authenticated user) |  |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
 
@@ -29,7 +29,7 @@ Usage of 'src config list':
   -subject string
     	The ID of the settings subject whose settings to list. (default: authenticated user)
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/extensions/copy.mdx
+++ b/docs/cli/references/extensions/copy.mdx
@@ -10,7 +10,7 @@
 | `-extension-id` | The &lt;extID&gt; in https://sourcegraph.com/extensions/&lt;extID&gt; (e.g. sourcegraph/java) |  |
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
 
@@ -29,7 +29,7 @@ Usage of 'src extensions copy':
   -insecure-skip-verify
     	Skip validation of TLS certificates against trusted chains
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/extensions/delete.mdx
+++ b/docs/cli/references/extensions/delete.mdx
@@ -9,7 +9,7 @@
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
 | `-id` | The ID (GraphQL API ID, not extension ID) of the extension to delete. |  |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
 
@@ -26,7 +26,7 @@ Usage of 'src extensions delete':
   -insecure-skip-verify
     	Skip validation of TLS certificates against trusted chains
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/extensions/get.mdx
+++ b/docs/cli/references/extensions/get.mdx
@@ -10,7 +10,7 @@
 | `-f` | Format for the output, using the syntax of Go package text/template. (e.g. "\{\{.ExtensionID\}\}: \{\{.Manifest.Title\}\} (\{\{.RemoteURL\}\})" or "\{\{.\|json\}\}") | `{{.\|json}}` |
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
 
@@ -29,7 +29,7 @@ Usage of 'src extensions get':
   -insecure-skip-verify
     	Skip validation of TLS certificates against trusted chains
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/extensions/list.mdx
+++ b/docs/cli/references/extensions/list.mdx
@@ -11,7 +11,7 @@
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
 | `-query` | Returns extensions whose extension IDs match the query. (e.g. "myextension") |  |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
 
@@ -32,7 +32,7 @@ Usage of 'src extensions list':
   -query string
     	Returns extensions whose extension IDs match the query. (e.g. "myextension")
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/extensions/publish.mdx
+++ b/docs/cli/references/extensions/publish.mdx
@@ -12,7 +12,7 @@
 | `-git-head` | Override the current git commit for the bundle. (default: uses `git rev-parse head`) |  |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
 | `-manifest` | The extension manifest file. | `package.json` |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-url` | Override the URL for the bundle. (example: set to http://localhost:1234/myext.js for local dev with parcel) |  |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
@@ -36,7 +36,7 @@ Usage of 'src extensions publish':
   -manifest string
     	The extension manifest file. (default "package.json")
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -url string
     	Override the URL for the bundle. (example: set to http://localhost:1234/myext.js for local dev with parcel)
   -user-agent-telemetry

--- a/docs/cli/references/extsvc/create.mdx
+++ b/docs/cli/references/extsvc/create.mdx
@@ -10,7 +10,7 @@
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
 | `-kind` | kind of the external service to create |  |
 | `-name` | exact name of the external service to create |  |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
 
@@ -29,7 +29,7 @@ Usage of 'src extsvc create':
   -name string
     	exact name of the external service to create
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/extsvc/edit.mdx
+++ b/docs/cli/references/extsvc/edit.mdx
@@ -12,7 +12,7 @@
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
 | `-name` | exact name of the external service to edit |  |
 | `-rename` | when specified, renames the external service |  |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
 
@@ -35,7 +35,7 @@ Usage of 'src extsvc edit':
   -rename string
     	when specified, renames the external service
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/extsvc/list.mdx
+++ b/docs/cli/references/extsvc/list.mdx
@@ -10,7 +10,7 @@
 | `-first` | Return only the first n external services. | `1000` |
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
 
@@ -29,7 +29,7 @@ Usage of 'src extsvc list':
   -insecure-skip-verify
     	Skip validation of TLS certificates against trusted chains
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/login.mdx
+++ b/docs/cli/references/login.mdx
@@ -35,5 +35,5 @@ $ src login [command options] [SOURCEGRAPH_URL]
 | `--dump-requests` | Log GraphQL requests and responses to stdout | `false`|
 | `--get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false`|
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|

--- a/docs/cli/references/lsp.mdx
+++ b/docs/cli/references/lsp.mdx
@@ -8,7 +8,7 @@
 | `-dump-requests` | Log GraphQL requests and responses to stdout | `false` |
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
 
@@ -50,7 +50,7 @@ Usage of 'src lsp':
   -insecure-skip-verify
     	Skip validation of TLS certificates against trusted chains
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/orgs/create.mdx
+++ b/docs/cli/references/orgs/create.mdx
@@ -23,5 +23,5 @@ $ src orgs create [options]
 | `--get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false`|
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
 | `--name` | The new organization's name. (required) | ``|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|

--- a/docs/cli/references/orgs/delete.mdx
+++ b/docs/cli/references/orgs/delete.mdx
@@ -30,5 +30,5 @@ $ src orgs delete [options]
 | `--get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false`|
 | `--id` | The ID of the organization to delete. | ``|
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|

--- a/docs/cli/references/orgs/get.mdx
+++ b/docs/cli/references/orgs/get.mdx
@@ -26,6 +26,6 @@ $ src orgs get [options]
 | `--get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false`|
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
 | `--name` | Look up organization by name. (e.g. "abc-org") | ``|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|
 | `-f` | Format for the output, using the syntax of Go package text/template. (e.g. "\{\{.ID\}\}: \{\{.Name\}\} (\{\{.DisplayName\}\})") \| `"\{\{.\\|json\}\}"`|

--- a/docs/cli/references/orgs/list.mdx
+++ b/docs/cli/references/orgs/list.mdx
@@ -27,6 +27,6 @@ $ src orgs list [options]
 | `--get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false`|
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
 | `--query` | Returns organizations whose names match the query. (e.g. "alice") | ``|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|
 | `-f` | Format for the output, using the syntax of Go package text/template. (e.g. "\{\{.ID\}\}: \{\{.Name\}\} (\{\{.DisplayName\}\})" or "\{\{.\|json\}\}") \| `"\{\{.Name\}\}"`|

--- a/docs/cli/references/orgs/members/add.mdx
+++ b/docs/cli/references/orgs/members/add.mdx
@@ -22,6 +22,6 @@ $ src orgs members add [options]
 | `--get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false`|
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
 | `--org-id` | ID of organization to which to add member. (required) | ``|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|
 | `--username` | Username of user to add as member. (required) | ``|

--- a/docs/cli/references/orgs/members/remove.mdx
+++ b/docs/cli/references/orgs/members/remove.mdx
@@ -22,6 +22,6 @@ $ src orgs members remove [options]
 | `--get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false`|
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
 | `--org-id` | ID of organization from which to remove member. (required) | ``|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|
 | `--user-id` | ID of user to remove as member. (required) | ``|

--- a/docs/cli/references/prompts/create.mdx
+++ b/docs/cli/references/prompts/create.mdx
@@ -77,5 +77,5 @@ src prompts create \
 | `-dump-requests`        | Log GraphQL requests and responses to stdout                                                                      |
 | `-get-curl`             | Print the curl command for executing this query and exit (WARNING: includes printing your access token!)          |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains                                                        |
-| `-trace`                | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing                       |
+| `-trace`                | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing                       |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/delete.mdx
+++ b/docs/cli/references/prompts/delete.mdx
@@ -28,5 +28,5 @@ src prompts delete UHJvbXB0OjE=
 | `-dump-requests`        | Log GraphQL requests and responses to stdout                                                                      |
 | `-get-curl`             | Print the curl command for executing this query and exit (WARNING: includes printing your access token!)          |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains                                                        |
-| `-trace`                | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing                       |
+| `-trace`                | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing                       |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/export.mdx
+++ b/docs/cli/references/prompts/export.mdx
@@ -42,5 +42,5 @@ src prompts export -o filtered-prompts.json -tags="python,data-science,ml"
 | `-dump-requests`        | Log GraphQL requests and responses to stdout                                                                      |
 | `-get-curl`             | Print the curl command for executing this query and exit (WARNING: includes printing your access token!)          |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains                                                        |
-| `-trace`                | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing                       |
+| `-trace`                | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing                       |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/get.mdx
+++ b/docs/cli/references/prompts/get.mdx
@@ -24,5 +24,5 @@ src prompts get UHJvbXB0OjE=
 | `-dump-requests`        | Log GraphQL requests and responses to stdout                                                                      |
 | `-get-curl`             | Print the curl command for executing this query and exit (WARNING: includes printing your access token!)          |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains                                                        |
-| `-trace`                | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing                       |
+| `-trace`                | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing                       |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/import.mdx
+++ b/docs/cli/references/prompts/import.mdx
@@ -43,5 +43,5 @@ src prompts import -i prompts.json -dry-run -skip-existing
 | `-dump-requests`        | Log GraphQL requests and responses to stdout                                                                      |
 | `-get-curl`             | Print the curl command for executing this query and exit (WARNING: includes printing your access token!)          |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains                                                        |
-| `-trace`                | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing                       |
+| `-trace`                | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing                       |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/list.mdx
+++ b/docs/cli/references/prompts/list.mdx
@@ -75,5 +75,5 @@ src prompts list -query="Go" -recommended-only -include-drafts=false -json
 | `-dump-requests`        | Log GraphQL requests and responses to stdout                                                                      |
 | `-get-curl`             | Print the curl command for executing this query and exit (WARNING: includes printing your access token!)          |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains                                                        |
-| `-trace`                | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing                       |
+| `-trace`                | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing                       |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/tags/create.mdx
+++ b/docs/cli/references/prompts/tags/create.mdx
@@ -30,7 +30,7 @@ src prompts tags create python
 | `-dump-requests`        | Log GraphQL requests and responses to stdout                                                                      |
 | `-get-curl`             | Print the curl command for executing this query and exit (WARNING: includes printing your access token!)          |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains                                                        |
-| `-trace`                | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing                       |
+| `-trace`                | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing                       |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |
 
 ## Notes

--- a/docs/cli/references/prompts/tags/delete.mdx
+++ b/docs/cli/references/prompts/tags/delete.mdx
@@ -28,5 +28,5 @@ src prompts tags delete UHJvbXB0VGFnOjE=
 | `-dump-requests`        | Log GraphQL requests and responses to stdout                                                                      |
 | `-get-curl`             | Print the curl command for executing this query and exit (WARNING: includes printing your access token!)          |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains                                                        |
-| `-trace`                | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing                       |
+| `-trace`                | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing                       |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/tags/get.mdx
+++ b/docs/cli/references/prompts/tags/get.mdx
@@ -27,5 +27,5 @@ src prompts tags get machine-learning
 | `-dump-requests`        | Log GraphQL requests and responses to stdout                                                                      |
 | `-get-curl`             | Print the curl command for executing this query and exit (WARNING: includes printing your access token!)          |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains                                                        |
-| `-trace`                | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing                       |
+| `-trace`                | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing                       |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/tags/list.mdx
+++ b/docs/cli/references/prompts/tags/list.mdx
@@ -47,5 +47,5 @@ src prompts tags list -query="python" -limit=5
 | `-dump-requests`        | Log GraphQL requests and responses to stdout                                                                      |
 | `-get-curl`             | Print the curl command for executing this query and exit (WARNING: includes printing your access token!)          |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains                                                        |
-| `-trace`                | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing                       |
+| `-trace`                | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing                       |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/tags/update.mdx
+++ b/docs/cli/references/prompts/tags/update.mdx
@@ -31,5 +31,5 @@ src prompts tags update -name="golang-updated" UHJvbXB0VGFnOjE=
 | `-dump-requests`        | Log GraphQL requests and responses to stdout                                                                      |
 | `-get-curl`             | Print the curl command for executing this query and exit (WARNING: includes printing your access token!)          |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains                                                        |
-| `-trace`                | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing                       |
+| `-trace`                | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing                       |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/prompts/update.mdx
+++ b/docs/cli/references/prompts/update.mdx
@@ -65,5 +65,5 @@ src prompts update \
 | `-dump-requests`        | Log GraphQL requests and responses to stdout                                                                      |
 | `-get-curl`             | Print the curl command for executing this query and exit (WARNING: includes printing your access token!)          |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains                                                        |
-| `-trace`                | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing                       |
+| `-trace`                | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing                       |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default: true) |

--- a/docs/cli/references/repos/add-metadata.mdx
+++ b/docs/cli/references/repos/add-metadata.mdx
@@ -11,7 +11,7 @@
 | `-key` | The name of the  metadata key to add (required) |  |
 | `-repo` | The ID of the repo to add the key-value pair metadata to (required if -repo-name is not specified) |  |
 | `-repo-name` | The name of the repo to add the key-value pair metadata to (required if -repo is not specified) |  |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 | `-value` | The  metadata value associated with the  metadata key. Defaults to null. |  |
 
@@ -33,7 +33,7 @@ Usage of 'src repos add-metadata':
   -repo-name string
     	The name of the repo to add the key-value pair metadata to (required if -repo is not specified)
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
   -value string

--- a/docs/cli/references/repos/delete-metadata.mdx
+++ b/docs/cli/references/repos/delete-metadata.mdx
@@ -11,7 +11,7 @@
 | `-key` | The name of the  metadata key to be deleted (required) |  |
 | `-repo` | The ID of the repo with the key-value pair metadata to be deleted (required if -repo-name is not specified) |  |
 | `-repo-name` | The name of the repo to add the key-value pair metadata to (required if -repo is not specified) |  |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
 
@@ -32,7 +32,7 @@ Usage of 'src repos delete-metadata':
   -repo-name string
     	The name of the repo to add the key-value pair metadata to (required if -repo is not specified)
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/repos/delete.mdx
+++ b/docs/cli/references/repos/delete.mdx
@@ -8,7 +8,7 @@
 | `-dump-requests` | Log GraphQL requests and responses to stdout | `false` |
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
 
@@ -23,7 +23,7 @@ Usage of 'src repos delete'
   -insecure-skip-verify
     	Skip validation of TLS certificates against trusted chains
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/repos/get.mdx
+++ b/docs/cli/references/repos/get.mdx
@@ -10,7 +10,7 @@
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
 | `-name` | The name of the repository. (required) |  |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
 
@@ -29,7 +29,7 @@ Usage of 'src repos get':
   -name string
     	The name of the repository. (required)
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/repos/list.mdx
+++ b/docs/cli/references/repos/list.mdx
@@ -18,7 +18,7 @@
 | `-not-indexed` | Include repositories that do not have a text search index. | `true` |
 | `-order-by` | How to order the results; possible choices are: "name", "created-at" | `name` |
 | `-query` | Returns repositories whose names match the query. (e.g. "myorg/") |  |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
 
@@ -53,7 +53,7 @@ Usage of 'src repos list':
   -query string
     	Returns repositories whose names match the query. (e.g. "myorg/")
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/repos/update-metadata.mdx
+++ b/docs/cli/references/repos/update-metadata.mdx
@@ -11,7 +11,7 @@
 | `-key` | The name of the metadata key to be updated (required) |  |
 | `-repo` | The ID of the repo with the metadata key to be updated (required if -repo-name is not specified) |  |
 | `-repo-name` | The name of the repo to add the key-value pair metadata to (required if -repo is not specified) |  |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 | `-value` | The new metadata value of the metadata key to be set. Defaults to null. |  |
 
@@ -33,7 +33,7 @@ Usage of 'src repos update-metadata':
   -repo-name string
     	The name of the repo to add the key-value pair metadata to (required if -repo is not specified)
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
   -value string

--- a/docs/cli/references/search-jobs/cancel.mdx
+++ b/docs/cli/references/search-jobs/cancel.mdx
@@ -20,7 +20,7 @@ Usage of 'src search-jobs cancel':
   -json
         Output results as JSON for programmatic access
   -trace
-        Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+        Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
         Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/search-jobs/create.mdx
+++ b/docs/cli/references/search-jobs/create.mdx
@@ -20,7 +20,7 @@ Usage of 'src search-jobs create':
   -json
         Output results as JSON for programmatic access
   -trace
-        Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+        Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
         Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/search-jobs/delete.mdx
+++ b/docs/cli/references/search-jobs/delete.mdx
@@ -18,7 +18,7 @@ Usage of 'src search-jobs delete':
   -json
         Output results as JSON for programmatic access
   -trace
-        Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+        Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
         Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/search-jobs/get.mdx
+++ b/docs/cli/references/search-jobs/get.mdx
@@ -20,7 +20,7 @@ Usage of 'src search-jobs get':
   -json
         Output results as JSON for programmatic access
   -trace
-        Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+        Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
         Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/search-jobs/list.mdx
+++ b/docs/cli/references/search-jobs/list.mdx
@@ -26,7 +26,7 @@ Usage of 'src search-jobs list':
   -order-by string
         Sort search jobs by a sortable field (QUERY, CREATED_AT, STATE) (default "CREATED_AT")
   -trace
-        Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+        Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
         Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/search-jobs/logs.mdx
+++ b/docs/cli/references/search-jobs/logs.mdx
@@ -22,7 +22,7 @@ Usage of 'src search-jobs logs':
   -out string
         File path to save the logs (optional)
   -trace
-        Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+        Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
         Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/search-jobs/restart.mdx
+++ b/docs/cli/references/search-jobs/restart.mdx
@@ -20,7 +20,7 @@ Usage of 'src search-jobs restart':
   -json
         Output results as JSON for programmatic access
   -trace
-        Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+        Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
         Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/search-jobs/results.mdx
+++ b/docs/cli/references/search-jobs/results.mdx
@@ -22,7 +22,7 @@ Usage of 'src search-jobs results':
   -out string
         File path to save the results (optional)
   -trace
-        Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+        Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
         Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 

--- a/docs/cli/references/search.mdx
+++ b/docs/cli/references/search.mdx
@@ -13,7 +13,7 @@
 | `-json` | Whether or not to output results as JSON. | `false` |
 | `-less` | Pipe output to 'less -R' (only if stdout is terminal, and not json flag). | `true` |
 | `-stream` | Consume results as stream. Streaming search only supports a subset of flags and parameters: trace, insecure-skip-verify, display, json. | `false` |
-| `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
+| `-trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false` |
 | `-user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true` |
 
 
@@ -38,7 +38,7 @@ Usage of 'src search':
   -stream
     	Consume results as stream. Streaming search only supports a subset of flags and parameters: trace, insecure-skip-verify, display, json.
   -trace
-    	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
+    	Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing
   -user-agent-telemetry
     	Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph (default true)
 
@@ -63,7 +63,7 @@ Other tips:
 
   Force color output on (not on by default when piped to other programs) by setting COLOR=t
 
-  Query syntax: https://docs.sourcegraph.com/code_search/reference/queries
+  Query syntax: https://sourcegraph.com/docs/code_search/reference/queries
 
   Be careful with search strings including negation: a search with an initial
   negated term may be parsed as a flag rather than as a search string. You can

--- a/docs/cli/references/users/create.mdx
+++ b/docs/cli/references/users/create.mdx
@@ -23,6 +23,6 @@ $ src users create [options]
 | `--get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false`|
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
 | `--reset-password-url` | Print the reset password URL to manually send to the new user. | `false`|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|
 | `--username` | The new user's username. | ``|

--- a/docs/cli/references/users/delete.mdx
+++ b/docs/cli/references/users/delete.mdx
@@ -30,5 +30,5 @@ $ src users delete [options]
 | `--get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false`|
 | `--id` | The ID of the user to delete. | ``|
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|

--- a/docs/cli/references/users/get.mdx
+++ b/docs/cli/references/users/get.mdx
@@ -22,7 +22,7 @@ $ src users get [options]
 | `--email` | Look up user by email. (e.g. "alice@sourcegraph.com") | ``|
 | `--get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false`|
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|
 | `--username` | Look up user by username. (e.g. "alice") | ``|
 | `-f` | Format for the output, using the syntax of Go package text/template. (e.g. "\{\{.ID\}\}: \{\{.Username\}\} (\{\{.DisplayName\}\})") \| `"\{\{.\\|json\}\}"`|

--- a/docs/cli/references/users/list.mdx
+++ b/docs/cli/references/users/list.mdx
@@ -32,6 +32,6 @@ $ src users list [options]
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
 | `--query` | Returns users whose names match the query. (e.g. "alice") | ``|
 | `--tag` | Returns users with the given tag. | ``|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|
 | `-f` | Format for the output, using the syntax of Go package text/template. (e.g. "\{\{.ID\}\}: \{\{.Username\}\} (\{\{.DisplayName\}\})" or "\{\{.\|json\}\}") \| `"\{\{.Username\}\}"`|

--- a/docs/cli/references/users/prune.mdx
+++ b/docs/cli/references/users/prune.mdx
@@ -28,5 +28,5 @@ $ src users prune [options]
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
 | `--remove-admin` | prune admin accounts | `false`|
 | `--remove-null-users` | removes users with no last active value | `false`|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|

--- a/docs/cli/references/users/tag.mdx
+++ b/docs/cli/references/users/tag.mdx
@@ -33,6 +33,6 @@ $ src users tag [options]
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
 | `--remove` | Remove the tag. (default: add the tag) | `false`|
 | `--tag` | The tag to set on the user. | ``|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|
 | `--user-id` | The ID of the user to tag. | ``|

--- a/docs/cli/references/validate.mdx
+++ b/docs/cli/references/validate.mdx
@@ -9,7 +9,7 @@
 
 EXPERIMENTAL: 'validate' is an experimental command in the 'src' tool.
 
-Please visit https://docs.sourcegraph.com/admin/validation for documentation of the validate command.
+Please visit https://sourcegraph.com/docs/admin/validation for documentation of the validate command.
 
 Usage:
 

--- a/docs/cli/references/version.mdx
+++ b/docs/cli/references/version.mdx
@@ -22,5 +22,5 @@ $ src version [options]
 | `--dump-requests` | Log GraphQL requests and responses to stdout | `false`|
 | `--get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false`|
 | `--insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false`|
-| `--trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false`|
+| `--trace` | Log the trace ID for requests. See https://sourcegraph.com/docs/admin/observability/tracing | `false`|
 | `--user-agent-telemetry` | Include the operating system and architecture in the User-Agent sent with requests to Sourcegraph | `true`|


### PR DESCRIPTION
`docs.sourcegraph.com` is no longer the docs host. This rewrites the remaining absolute references to their `sourcegraph.com/docs` equivalents.

The rewrite is purely mechanical — only the host portion changes (`docs.sourcegraph.com/<path>` becomes `sourcegraph.com/docs/<path>`). Paths that were reorganised since (for example `admin/observability/tracing` and `batch_changes/references/troubleshooting`) are already covered by permanent redirects in the docs site's redirect map, so the rewritten links resolve.

In `src-cli`, `CHANGELOG.md` is deliberately left alone: those entries are a historical record. In the docs repo the change is scoped to `docs/cli/references/**`, which is generated from `src-cli` by `src doc` — the companion `src-cli` changeset fixes the generator's source strings so the docs stay correct after the next regeneration.

[_Created by a Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/453)