### PR TITLE
chore/dev: Add Amp Orb setup

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Runs on every orb wake. Nothing to authenticate or reconnect; just confirm the
+# toolchain from .agents/setup still resolves so a broken snapshot fails loudly.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+eval "$("$HOME/.local/bin/mise" -C "$repo_root" env -s bash)"
+node --version
+pnpm --version

--- a/.agents/setup
+++ b/.agents/setup
@@ -30,7 +30,9 @@ EOF
 fi
 
 step "Install dependencies"
-pnpm install --frozen-lockfile
+# CI=true: without a TTY, pnpm otherwise aborts if a stale snapshot's
+# node_modules was built by a different pnpm version and must be recreated.
+CI=true pnpm install --frozen-lockfile
 
 step "Write orb agent guidance"
 mkdir -p "$HOME/.config/amp"

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Prepares a fresh Amp orb: the Node and pnpm versions pinned in .tool-versions,
+# then the pnpm dependencies. Idempotent: Amp reruns it on stale snapshots.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+step() { printf '\n==> %s (%s)\n' "$1" "$(date +%T)"; }
+
+mise_bin="$HOME/.local/bin/mise"
+step "Install mise"
+if [ ! -x "$mise_bin" ]; then
+	curl -fsSL https://mise.run | sh
+fi
+
+step "Install pinned toolchain from .tool-versions"
+"$mise_bin" install --yes
+# The installer cannot change this running script's environment.
+eval "$("$mise_bin" env -s bash)"
+
+step "Expose the toolchain to login shells"
+profile_marker="# sourcegraph/docs: pinned Node and pnpm from mise"
+if ! grep -Fqx "$profile_marker" "$HOME/.bash_profile" 2>/dev/null; then
+	cat >>"$HOME/.bash_profile" <<EOF
+
+$profile_marker
+[ -d "$repo_root" ] && eval "\$("$mise_bin" -C "$repo_root" env -s bash)"
+EOF
+fi
+
+step "Install dependencies"
+pnpm install --frozen-lockfile
+
+step "Write orb agent guidance"
+mkdir -p "$HOME/.config/amp"
+cat >"$HOME/.config/amp/AGENTS.md" <<'EOF'
+# Inside the Orb
+
+- Node and pnpm come from mise (`.tool-versions`); `.agents/setup` puts them on PATH for login shells. Use `pnpm`, not `npm`.
+- Dev server: `amp orb services ensure` starts `pnpm dev` from `.amp/services.yaml` and returns a portal link.
+EOF
+
+step "Done: node $(node --version), pnpm $(pnpm --version)"

--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -1,0 +1,7 @@
+services:
+  docs:
+    command: pnpm dev --hostname 0.0.0.0 --port "$PORT"
+    health: /
+    portal:
+      url: /
+      title: Sourcegraph Docs

--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,7 @@ public/changelog.rss
 # env file
 .env
 
+# amp orb portal state
+.amp/portals/
+
 public/technical-changelog.rss


### PR DESCRIPTION
Linear [FE-499: Fix doc site issues](https://linear.app/sourcegraph/issue/FE-499/fix-doc-site-issues)

Prepares the repo for Amp orbs so fresh orbs start with the pinned toolchain and dependencies installed instead of reinstalling them every thread.

## Changes

- `.agents/setup`: installs mise, the Node 20.19.6 / pnpm 10.25.0 pinned in `.tool-versions`, and `pnpm install --frozen-lockfile`. Appends a marker-guarded `mise env` hook to `~/.bash_profile` so login shells (the agent and supervised services) get the pinned toolchain from any directory. Writes short orb guidance to `~/.config/amp/AGENTS.md`.
- `.agents/resume`: on each wake, confirms the toolchain still resolves so a broken snapshot fails loudly.
- `.amp/services.yaml`: declares `pnpm dev` as the `docs` service so `amp orb services ensure` gives a portal link.
- `.gitignore`: ignores generated `.amp/portals/`.

## Verification (real orb, Debian 12, project `sourcegraph/standalone-docs`)

- Cold `.agents/setup`: exit 0, 10.0s. Warm rerun: exit 0, 1.05s; profile marker present exactly once.
- Clean login shell (`env -i ... /bin/bash -lc`) from repo root and from `/tmp`: `node` v20.19.6 and `pnpm` 10.25.0 from mise; `gh`, `amp`, `bun` still on PATH.
- `.agents/resume`: exit 0, 0.17s from repo root and from `/tmp`.
- `amp orb services ensure`: `docs` service healthy (HTTP 200) after Contentlayer generated 521 documents; service PATH starts with the mise Node 20.19.6 bin dir.
- Local macOS smoke test with a throwaway `HOME`: same results.

## Notes for reviewers

- Pre-existing, not changed here: pnpm 10 skips postinstall scripts for `sharp`, `esbuild`, `contentlayer`, `canvas`, `protobufjs`, `unrs-resolver` because `package.json` has no `pnpm.onlyBuiltDependencies`. Dev server works regardless.
- Changing `.agents/setup` does not invalidate the existing project snapshot by itself; the next refresh (72h) or `amp projects snapshots delete sourcegraph/standalone-docs` picks it up.

## Amp threads

- [Orb setup](https://ampcode.com/threads/T-01a07559-806b-70af-a96d-7281168ade61)
- [Verify orb-setup scripts in a real orb](https://ampcode.com/threads/T-01a0755e-80f1-75ec-9ff0-f13560edd0de)
