### PR TITLE
fix/site: Fix broken tables of contents

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -9,6 +9,35 @@ import {searchMetadata} from './src/data/search';
 import GithubSlugger from 'github-slugger';
 import {visit} from 'unist-util-visit';
 
+// A fence opener/closer is a run of 3+ backticks or tildes at the start of a line.
+const regXFenceLine = /^\s*(`{3,}|~{3,})/;
+
+// Remove fenced code blocks so `# comment` lines inside them are not mistaken for
+// headings. Walks line by line: a naive /```[\s\S]*?```/ regex also matches inline
+// backtick runs in prose (e.g. `"true```), which flips every later fence pairing.
+function stripFencedCodeBlocks(markdown: string): string {
+	const keptLines: string[] = [];
+	let openFence: string | undefined;
+	for (const line of markdown.split('\n')) {
+		const fence = line.match(regXFenceLine)?.[1];
+		if (openFence) {
+			const closesOpenFence =
+				fence !== undefined &&
+				fence[0] === openFence[0] &&
+				fence.length >= openFence.length &&
+				line.trim() === fence;
+			if (closesOpenFence) {
+				openFence = undefined;
+			}
+		} else if (fence) {
+			openFence = fence;
+		} else {
+			keptLines.push(line);
+		}
+	}
+	return keptLines.join('\n');
+}
+
 export const Post = defineDocumentType(() => ({
 	name: 'Post',
 	filePathPattern: `**/*.mdx`,
@@ -28,17 +57,10 @@ export const Post = defineDocumentType(() => ({
 			type: 'json',
 			resolve: async doc => {
 				const regXHeader = /^ *(?<flag>#{1,6})\s+(?<content>.+)/gm;
-				const regXCodeBlock = /```[\s\S]*?```/g;
 				const slugger = new GithubSlugger();
 
-				// Ignore content within code blocks – No headings there
-				const bodyWithoutCodeBlocks = doc.body.raw.replace(
-					regXCodeBlock,
-					''
-				);
-
 				const headings = Array.from(
-					bodyWithoutCodeBlocks.matchAll(regXHeader)
+					stripFencedCodeBlocks(doc.body.raw).matchAll(regXHeader)
 				).map(({groups}) => {
 					const flag = groups?.flag;
 					// Handles headings with links eg:


### PR DESCRIPTION
Linear [FE-499: Fix doc site issues](https://linear.app/sourcegraph/issue/FE-499/fix-doc-site-issues)

## Problem

The right-hand TOC (`headings` computed field in `contentlayer.config.ts`) strips fenced code blocks with the non-greedy regex `/```[\s\S]*?```/g`, then treats any remaining `#` line as a heading.

Any inline triple-backtick run in prose is taken as a fence opener and flips every later fence pairing. `docs/batch-changes/batch-spec-yaml-reference.mdx` has two (`` `"true``` `` on line 376, `` `"*``` `` on line 709), so from there on the "inside/outside a fence" state is inverted: YAML `# comment` lines leak into the TOC as headings whose anchors don't exist, and real headings are dropped.

Live repro: https://sourcegraph.com/docs/batch-changes/batch-spec-yaml-reference has a TOC entry linking to `#do-not-meddle-in-the-affairs-of-wizards-for-they-are-subtle-and-quick-to-anger` (line 572 of the MDX, a YAML comment inside a fence). No element with that id exists. This page alone accounted for 14 of the broken anchors found by lychee in the investigation behind #1858.

## Before / after

TOC on `/batch-changes/batch-spec-yaml-reference`, local `next dev`, 1600px viewport.

| Before (`main`) | After (this PR) |
| --- | --- |
| <img src="https://ampcode.com/user-content/artifacts/ee9ba290aa34b608e52fa272b2abfdc0cf6484f93120fa42b2c1c31441aab30f-file.png" width="400"> | <img src="https://ampcode.com/user-content/artifacts/96b96b558b53a28b6f65f786485818bb28dce5812a8c32995a1725242f1ad6dd-file.png" width="400"> |

Before: 12 YAML comments (`if: is true, step always executes.`, `Mount a Python script and run the script`, `Do not meddle in the affairs of wizards…`) render as TOC entries with dead anchors, and every `changesetTemplate.*` heading except `.fork` is missing. After: the comments are gone and `steps.mount`, `importChangesets*`, `changesetTemplate*`, `Publishing only specific changesets` are back.

## Fix

Walk the body line by line: a fence opens on a line starting with 3+ backticks or tildes and closes on a line of the same character at least as long, matching how the MDX renderer treats fences. Also handles the ```` ```` ```` four-backtick fences in `cody/troubleshooting.mdx` and `code-navigation/writing-an-indexer.mdx` that contain literal ```` ``` ```` text.

## Verification

- Compared old vs new heading output across every `.mdx` under `docs/`: only `batch-spec-yaml-reference.mdx` changes — 12 bogus comment entries removed, 13 real headings restored.
- `npx contentlayer build`: generated `Post` for that page has 66 headings, 0 bogus, all `changesetTemplate.*` ids present.
- `npx tsc --noEmit` clean, `next lint` clean.

Follow-up from the link-check work in #1858.

## Amp threads

- [Broken table of contents side bar](https://ampcode.com/threads/T-01a07599-bfc6-773f-abc1-7e0cd96db912)
