### PR TITLE
docs: update Kubernetes object storage guidance

### DIFF
--- a/docs/self-hosted/deploy/kubernetes/index.mdx
+++ b/docs/self-hosted/deploy/kubernetes/index.mdx
@@ -238,65 +238,11 @@ redisStore:
 
 The [using your own Redis](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples/external-redis) example demonstrates this approach.
 
-#### Using external Object Storage
+#### Using external object storage
 
-To use an external Object Storage service (S3-compatible services, or GCS), first review our [general recommendations](/self-hosted/external-services/object-storage). Then review the following example and adjust to your use case.
+Follow the [managed object storage guidance](/self-hosted/external-services/object-storage#sourcegraph-bucket) to configure the shared Sourcegraph bucket. In your Helm overrides, apply the `SOURCEGRAPH_UPLOAD_*` environment variables to the `frontend`, `worker`, precise Code Intel (`precise-code-intel-worker`), `gitserver`, and `searcher` services.
 
-<Callout type="note">
-	See
-	[override.yaml](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples/external-object-storage/override.yaml)
-	for an example override file. The example assumes the use of AWS S3. You may
-	configure the environment variables accordingly for your own use case based
-	on our [general
-	recommendations](/self-hosted/external-services/object-storage).
-</Callout>
-
-If you provide credentials with an access key / secret key, we recommend storing the credentials in [Secrets] created outside the helm chart and managed in a secure manner. An example Secret is shown here:
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-    name: sourcegraph-s3-credentials
-data:
-    # notes: secrets data has to be base64-encoded
-    PRECISE_CODE_INTEL_UPLOAD_AWS_ACCESS_KEY_ID: ''
-    PRECISE_CODE_INTEL_UPLOAD_AWS_SECRET_ACCESS_KEY: ''
-```
-
-In your [override.yaml](https://github.com/sourcegraph/deploy-sourcegraph-helm/tree/main/charts/sourcegraph/examples/external-object-storage/override.yaml), reference this Secret and the necessary environment variables:
-
-```yaml
-blobstore:
-    enabled: false # Disable deployment of the built-in object storage
-
-# we use YAML anchors and alias to keep override file clean
-objectStorageEnv: &objectStorageEnv
-    PRECISE_CODE_INTEL_UPLOAD_BACKEND:
-        value: S3 # external object storage type, one of "S3" or "GCS"
-    PRECISE_CODE_INTEL_UPLOAD_BUCKET:
-        value: lsif-uploads # external object storage bucket name
-    PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT:
-        value: https://s3.us-east-1.amazonaws.com
-    PRECISE_CODE_INTEL_UPLOAD_AWS_REGION:
-        value: us-east-1
-    PRECISE_CODE_INTEL_UPLOAD_AWS_ACCESS_KEY_ID:
-        secretKeyRef: # Pre-existing secret, not created by this chart
-            name: sourcegraph-s3-credentials
-            key: PRECISE_CODE_INTEL_UPLOAD_AWS_ACCESS_KEY_ID
-    PRECISE_CODE_INTEL_UPLOAD_AWS_SECRET_ACCESS_KEY:
-        secretKeyRef: # Pre-existing secret, not created by this chart
-            name: sourcegraph-s3-credentials
-            key: PRECISE_CODE_INTEL_UPLOAD_AWS_SECRET_ACCESS_KEY
-
-frontend:
-    env:
-        <<: *objectStorageEnv
-
-preciseCodeIntel:
-    env:
-        <<: *objectStorageEnv
-```
+If you provide credentials directly, store them in Kubernetes [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) created outside the Helm chart and reference those Secrets from the service environment variables. Disable the bundled object storage by setting `blobstore.enabled` to `false`.
 
 #### Using SSH to clone repositories
 


### PR DESCRIPTION
The Kubernetes deployment page still documented the legacy, code-intel-specific `PRECISE_CODE_INTEL_UPLOAD_*` configuration, applied it to only two services, and linked to an `override.yaml` example that no longer exists. This conflicted with the current shared Sourcegraph bucket guidance.