### PR TITLE
Add syntactic Code Intel to object storage consumers

### DIFF
--- a/docs/self-hosted/deploy/kubernetes/index.mdx
+++ b/docs/self-hosted/deploy/kubernetes/index.mdx
@@ -240,7 +240,7 @@ The [using your own Redis](https://github.com/sourcegraph/deploy-sourcegraph-hel
 
 #### Using external object storage
 
-Follow the [managed object storage guidance](/self-hosted/external-services/object-storage#sourcegraph-bucket) to configure the shared Sourcegraph bucket. In your Helm overrides, apply the `SOURCEGRAPH_UPLOAD_*` environment variables to the `frontend`, `worker`, precise Code Intel (`precise-code-intel-worker`), `gitserver`, and `searcher` services.
+Follow the [managed object storage guidance](/self-hosted/external-services/object-storage#sourcegraph-bucket) to configure the shared Sourcegraph bucket. In your Helm overrides, apply the `SOURCEGRAPH_UPLOAD_*` environment variables to the `frontend`, `worker`, precise Code Intel (`precise-code-intel-worker`), syntactic Code Intel (`syntactic-code-intel-worker`), `gitserver`, and `searcher` services.
 
 If you provide credentials directly, store them in Kubernetes [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) created outside the Helm chart and reference those Secrets from the service environment variables. Disable the bundled object storage by setting `blobstore.enabled` to `false`.
 

--- a/docs/self-hosted/external-services/object-storage.mdx
+++ b/docs/self-hosted/external-services/object-storage.mdx
@@ -43,8 +43,9 @@ Set the following environment variables to target a GCS bucket for shared Source
 If you are running on GKE with Workload Identity, or otherwise relying on
 Application Default Credentials, you can omit the GCS credentials file
 variables. Grant the `roles/storage.objectAdmin` role to the service accounts used by
-the `frontend`, `worker`, `precise-code-intel-worker`, `gitserver`, and
-`searcher` services in a GKE environment.
+the `frontend`, `worker`, precise Code Intel (`precise-code-intel-worker`),
+syntactic Code Intel (`syntactic-code-intel-worker`), `gitserver`, and `searcher`
+services in a GKE environment.
 
 ### Using S3 for the Sourcegraph bucket
 
@@ -68,8 +69,9 @@ Set the following environment variables to target an S3 bucket for shared Source
 You don't need to set the `SOURCEGRAPH_UPLOAD_AWS_ACCESS_KEY_ID` environment
 variable when using `SOURCEGRAPH_UPLOAD_AWS_USE_EC2_ROLE_CREDENTIALS=true`
 because role credentials will be automatically resolved. Attach the IAM role
-to the EC2 instances hosting the `frontend`, `worker`,
-`precise-code-intel-worker`, `gitserver`, and `searcher` containers in a
+to the EC2 instances hosting the `frontend`, `worker`, precise Code Intel
+(`precise-code-intel-worker`), syntactic Code Intel
+(`syntactic-code-intel-worker`), `gitserver`, and `searcher` containers in a
 multi-node environment.
 
 ### Automatically provision the Sourcegraph bucket


### PR DESCRIPTION
Follow-up to #1862.

The canonical managed object-storage page and Kubernetes deployment page listed five `SOURCEGRAPH_UPLOAD_*` consumers and omitted syntactic Code Intel. This updates both pages to the authoritative six-service list:

- frontend
- worker
- precise Code Intel (`precise-code-intel-worker`)
- syntactic Code Intel (`syntactic-code-intel-worker`)
- gitserver
- searcher