### PR TITLE
fix/links: Fix broken heading links (19 reworded, Cody / Batch Changes / Code Insights)

### DIFF
--- a/docs/batch-changes/batch-spec-templating.mdx
+++ b/docs/batch-changes/batch-spec-templating.mdx
@@ -4,7 +4,7 @@
 	Understand how to use templating to make your batch changes more powerful.
 </p>
 
-[Certain fields](#fields-with-template-support) in a [batch spec YAML](/batch-changes/batch-spec-yaml-reference) support templating to create even more powerful and performant batch changes. Templating in a batch spec uses the delimiters `${{` and `}}`. Inside the delimiters, [template variables](#template-variables) and [template helper functions](#template-helpers-functions) may be used to produce a text value.
+[Certain fields](#fields-with-template-support) in a [batch spec YAML](/batch-changes/batch-spec-yaml-reference) support templating to create even more powerful and performant batch changes. Templating in a batch spec uses the delimiters `${{` and `}}`. Inside the delimiters, [template variables](#template-variables) and [template helper functions](#template-helper-functions) may be used to produce a text value.
 
 ## Example batch spec with templating
 
@@ -117,7 +117,7 @@ The following template variables are available in the fields under `changesetTem
 -   `${{ replace "a/b/c/d" "/" "-" }}` - Replaces occurrences of the second argument in the first one with the last one
 -   `${{ split repository.name "/" }}` - Splits the first argument into a list of strings at each occurrence of the last argument
 -   `${{ matches repository.name "github.com/my-org/terra*" }}` - Matches the first argument against the glob pattern in the second argument, returning true/false
--   `${{ "${{ repository.name }}" }}` - Outputs the inner expression as a literal string, for example, to [ignore the inner set of `${{ }}`](/batch-changes/faq#how-can-i-use-github-expression-syntax---literally-in-my-batch-spec)
+-   `${{ "${{ repository.name }}" }}` - Outputs the inner expression as a literal string, for example, to [ignore the inner set of `${{ }}`](/batch-changes/faq#github-expression-syntax)
 
 The features of Go's [`text/template`](https://golang.org/pkg/text/template/) package are also available, including conditionals and loops, since it is the underlying templating engine.
 
@@ -286,7 +286,7 @@ steps:
       container: golang
 ```
 
-Combine the [template helper functions](#template-helpers-functions) with the helper functions built into Go's [`text/template`](https://pkg.go.dev/text/template) library:
+Combine the [template helper functions](#template-helper-functions) with the helper functions built into Go's [`text/template`](https://pkg.go.dev/text/template) library:
 
 ```yaml
 changesetTemplate:

--- a/docs/batch-changes/batch-spec-templating.mdx
+++ b/docs/batch-changes/batch-spec-templating.mdx
@@ -117,7 +117,7 @@ The following template variables are available in the fields under `changesetTem
 -   `${{ replace "a/b/c/d" "/" "-" }}` - Replaces occurrences of the second argument in the first one with the last one
 -   `${{ split repository.name "/" }}` - Splits the first argument into a list of strings at each occurrence of the last argument
 -   `${{ matches repository.name "github.com/my-org/terra*" }}` - Matches the first argument against the glob pattern in the second argument, returning true/false
--   `${{ "${{ repository.name }}" }}` - Outputs the inner expression as a literal string, for example, to [ignore the inner set of `${{ }}`](/batch-changes/faq#github-expression-syntax)
+-   `${{ "${{ repository.name }}" }}` - Outputs the inner expression as a literal string, for example, to [ignore the inner set of `${{ }}`](/batch-changes/faq#how-can-i-use-github-expression-syntax---literally-in-my-batch-spec)
 
 The features of Go's [`text/template`](https://golang.org/pkg/text/template/) package are also available, including conditionals and loops, since it is the underlying templating engine.
 

--- a/docs/batch-changes/batch-spec-yaml-reference.mdx
+++ b/docs/batch-changes/batch-spec-yaml-reference.mdx
@@ -367,7 +367,7 @@ The value the output should be set to.
 
 ## `steps.outputs.<name>.format`
 
-The format of the corresponding [`steps.outputs.<name>.value`](#outputs-value). When this is set to something other than `text`, it will be parsed as the given format.
+The format of the corresponding [`steps.outputs.<name>.value`](#stepsoutputsnamevalue). When this is set to something other than `text`, it will be parsed as the given format.
 
 Possible values: `text`, `yaml`, `json`. Default is `text`.
 

--- a/docs/batch-changes/configuring-credentials.mdx
+++ b/docs/batch-changes/configuring-credentials.mdx
@@ -304,7 +304,7 @@ When Sourcegraph is configured to [clone repositories using SSH via the `gitURLT
 
 EXPERIMENTAL: Using GitHub Apps to authenticate Batch Changes is currently experimental, and there may still be some rough edges.
 
-GitHub apps follow the same concepts as [personal and global access tokens](#types-of-access-tokens-used-by-batch-changes).
+GitHub apps follow the same concepts as [personal and global access tokens](#types-of-credentials-used-by-batch-changes).
 
 ### Limitations
 

--- a/docs/batch-changes/create-a-batch-change.mdx
+++ b/docs/batch-changes/create-a-batch-change.mdx
@@ -64,7 +64,7 @@ The library contains examples that you can apply right into your batch spec if y
 
 ### Executing your batch spec
 
-When the spec is ready to run, ensure the [preview](/batch-changes/create-a-batch-change#previewing-workspaces) is up to date and then click **Run batch spec**. This takes you to the execution screen. On this page, you see:
+When the spec is ready to run, ensure the [preview](/batch-changes/create-a-batch-change#previewing-batch-spec-and-workspaces) is up to date and then click **Run batch spec**. This takes you to the execution screen. On this page, you see:
 
 -   Run statistics at the top
 -   All the workspaces, including status and diff stat, in the left panel

--- a/docs/batch-changes/faq.mdx
+++ b/docs/batch-changes/faq.mdx
@@ -143,7 +143,7 @@ To tell Sourcegraph not to evaluate `${{ }}` like a regular [template delimiter]
 ${{ "${{ leave me alone! }}" }}
 ```
 
-Remember the context in which the inner `${{ }}` will be evaluated, and be sure to escape characters as appropriate. Check out the cheat sheet for an [example](/batch-changes/batch-spec-cheat-sheet#write-a-github-actions-workflow-that-includes-github-expression-syntax) within a shell script.
+Remember the context in which the inner `${{ }}` will be evaluated, and be sure to escape characters as appropriate. Check out the cheat sheet for an [example](/batch-changes/batch-spec-cheat-sheet#github-expression-syntax) within a shell script.
 
 ## How is commit author determined for commits produced from Batch Changes?
 

--- a/docs/batch-changes/faq.mdx
+++ b/docs/batch-changes/faq.mdx
@@ -143,7 +143,7 @@ To tell Sourcegraph not to evaluate `${{ }}` like a regular [template delimiter]
 ${{ "${{ leave me alone! }}" }}
 ```
 
-Remember the context in which the inner `${{ }}` will be evaluated, and be sure to escape characters as appropriate. Check out the cheat sheet for an [example](/batch-changes/batch-spec-cheat-sheet#github-expression-syntax) within a shell script.
+Remember the context in which the inner `${{ }}` will be evaluated, and be sure to escape characters as appropriate. Check out the cheat sheet for an [example](/batch-changes/batch-spec-cheat-sheet#write-a-github-actions-workflow-that-includes-github-expression-syntax) within a shell script.
 
 ## How is commit author determined for commits produced from Batch Changes?
 

--- a/docs/batch-changes/handling-errored-changesets.mdx
+++ b/docs/batch-changes/handling-errored-changesets.mdx
@@ -56,7 +56,7 @@ src batch apply -f YOUR_BATCH_SPEC.batch.yaml
 	more information on these commands.
 </Callout>
 
-Examples of errors that requires [manual retrying](#manual-retrying-by-re-applying-the-batch-change-spec) are as follows:
+Examples of errors that requires [manual retrying](#manual-retrying-of-errored-changesets) are as follows:
 
 -   No [Batch Changes credentials](/batch-changes/configuring-credentials) have been set up for the affected code host
 -   The configured code host connection needs a different type of credentials (for example, with SSH keys)

--- a/docs/batch-changes/reexecuting-batch-specs-multiple-times.mdx
+++ b/docs/batch-changes/reexecuting-batch-specs-multiple-times.mdx
@@ -28,7 +28,7 @@ Whenever [Sourcegraph CLI](/cli/) re-executes the same batch spec, it checks a *
 Whether a cached result can be used is dependent on multiple things:
 
 -   The repository's default branch's revision didn't change (because if new commits have been pushed to the repository, re-executing the `steps` might lead to different results)
--   The `steps` themselves didn't change, including all their inputs, such as [`steps.env`](/batch-changes/batch-spec-yaml-reference#environmentarray), and the `steps.run` field (which can change between executions if it uses [templating](/batch-changes/batch-spec-templating) and is dynamically built from search results)
+-   The `steps` themselves didn't change, including all their inputs, such as [`steps.env`](/batch-changes/batch-spec-yaml-reference#stepsenv), and the `steps.run` field (which can change between executions if it uses [templating](/batch-changes/batch-spec-templating) and is dynamically built from search results)
 
 That also means that [Sourcegraph CLI](/cli/) can use cached results when re-executing a **changed batch spec**, as long as the changes didn't affect the `steps` and the results they produce.
 

--- a/docs/code-insights/explanations/automatically-generated-data-series.mdx
+++ b/docs/code-insights/explanations/automatically-generated-data-series.mdx
@@ -48,5 +48,5 @@ Any matches that return values over a 100 characters will be truncated. This is 
 
 ### Regular expression capture group resources
 
--   [Example regular expressions for common use cases](/code-insights/references/common-use-cases#automatic-version-and-pattern-tracking)
+-   [Example regular expressions for common use cases](/code-insights/references/common-use-cases#versions-and-patterns)
 -   [General additional capture groups documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges)

--- a/docs/code-insights/explanations/code-insights-filters.mdx
+++ b/docs/code-insights/explanations/code-insights-filters.mdx
@@ -21,7 +21,7 @@ If you combine both filters, the inclusion pattern will be applied first, then t
 
 ### `context:` Query-based search context filters
 
-You can use a [query-based search context](/code-search/working/search-contexts#beta-query-based-search-contexts) to filter your insights to only results matching repositories that match the `repo:` or `-repo:` filter of the query-based context.
+You can use a [query-based search context](/code-search/working/search-contexts#query-based-search-contexts) to filter your insights to only results matching repositories that match the `repo:` or `-repo:` filter of the query-based context.
 
 You can use this to filter multiple insights to a group of repositories that need only be maintained in one location. When you update a context that's being used as a filter, the next time you load the page, the filtered insight will reflect the updated context.
 As with explicit `repo:` filters, only repository regex expressions are allowed: you cannot specify repository revisions or predicate filters.

--- a/docs/code-insights/how-tos/creating-a-custom-dashboard-of-code-insights.mdx
+++ b/docs/code-insights/how-tos/creating-a-custom-dashboard-of-code-insights.mdx
@@ -12,7 +12,7 @@ Click "Create new dashboard" in the top right corner and name your dashboard. Da
 
 ## 3. Select a visibility level
 
-Set a visibility level for your dashboard. Dashboards [respect insights' permissions](/code-insights/explanations/viewing-code-insights#dashboard-visibility-respects-insights-visibility), so don't create an organization-shared dashboard if you have private insights you want to attach to it.
+Set a visibility level for your dashboard. Dashboards [respect insights' permissions](/code-insights/explanations/viewing-code-insights#dashboard-visibility), so don't create an organization-shared dashboard if you have private insights you want to attach to it.
 
 -   Private: visible only to you
 -   Shared with [an organization](/admin/organizations): visible to everyone in the organization

--- a/docs/code-insights/how-tos/filtering-an-insight.mdx
+++ b/docs/code-insights/how-tos/filtering-an-insight.mdx
@@ -28,9 +28,9 @@ Examples:
 
 ### 3. Or, filter to include a reusable group of repositories using a query-based search context
 
-In the `context:` field of the filter panel, you can use a [query-based search context](/code-search/working/search-contexts#beta-query-based-search-contexts) to filter your insights to only results matching repositories that match the query-based context's `repo:` filter.
+In the `context:` field of the filter panel, you can use a [query-based search context](/code-search/working/search-contexts#query-based-search-contexts) to filter your insights to only results matching repositories that match the query-based context's `repo:` filter.
 
-First, if you haven't already created a search context, create a [query-based search context](/code-search/working/search-contexts#beta-query-based-search-contexts). You can define any group of repos using the syntax `repo:(^github\.com/sourcegraph/sourcegraph$|^github\.com/sourcegraph/about$...)`.
+First, if you haven't already created a search context, create a [query-based search context](/code-search/working/search-contexts#query-based-search-contexts). You can define any group of repos using the syntax `repo:(^github\.com/sourcegraph/sourcegraph$|^github\.com/sourcegraph/about$...)`.
 
 Then, in the context field, reference the search context's name, usually `@owner/name-of-context`.
 

--- a/docs/code-insights/language-insight-quickstart.mdx
+++ b/docs/code-insights/language-insight-quickstart.mdx
@@ -4,7 +4,7 @@ Get started and create your first [language code insight](/code-insights/) in 5 
 
 ## Introduction
 
-> This quickstart guide assumes that **you have already completed [step 1, enabling the feature flag](/code-insights/quickstart#1-enable-the-experimental-feature-flag)**, on the main code insights quickstart guide.
+> This quickstart guide assumes that **you have already completed [step 1, enabling the feature flag](/code-insights/quickstart#1-if-need-be-enable-the-experimental-feature-flag)**, on the main code insights quickstart guide.
 
 In this guide, you'll create a Sourcegraph language code insight that shows the percentage of lines of code in a repository by language.
 

--- a/docs/code-insights/references/common-use-cases.mdx
+++ b/docs/code-insights/references/common-use-cases.mdx
@@ -4,7 +4,7 @@ Here are some common use cases for Code Insights and example data series queries
 
 For all use cases, you can also explore your insight by [filtering repositories in real time](/code-insights/how-tos/filtering-an-insight) or add any [Sourcegraph search filter](/code-search/queries/language#search-pattern) to the data series query to filter by language, directory, or content. Currently, the sample queries using commit and diff searches are only supported for insights running over explicit lists of specific repositories.
 
-_The sample queries below make the assumption you [do not want to search fork or archived](/code-insights/references/common-reasons-code-insights-may-not-match-search-results#not-including-fork-no-and-archived-no-in-your-insight-query) repositories. You can include those flags if you do._
+_The sample queries below make the assumption you [do not want to search fork or archived](/code-insights/references/common-reasons-code-insights-may-not-match-search-results#for-versions-pre-340-not-including-forkno-and-archivedno-in-your-insight-query) repositories. You can include those flags if you do._
 
 ## Popular
 

--- a/docs/cody/capabilities/agentic-context-fetching.mdx
+++ b/docs/cody/capabilities/agentic-context-fetching.mdx
@@ -65,7 +65,7 @@ Agentic context fetching is enabled by default. It uses LLM reflection and basic
 
 You can disable agentic context in your extension settings using `cody.agenticContext`.
 
-Terminal access for Enterprise users is disabled by default. To enable it, set the `agentic-chat-cli-tool-experimental` feature flag [terminal access](#terminal-commands).
+Terminal access for Enterprise users is disabled by default. To enable it, set the `agentic-chat-cli-tool-experimental` feature flag [terminal access](#terminal-access).
 
 ## MCP support
 

--- a/docs/cody/capabilities/chat.mdx
+++ b/docs/cody/capabilities/chat.mdx
@@ -88,7 +88,7 @@ Image upload support varies by client. Check the [feature parity reference](/cod
 
 Cody allows you to select the LLM you want to use for your chat, which is optimized for speed versus accuracy. Enterprise users with the new [model configuration](/cody/enterprise/model-configuration) can use the LLM selection dropdown to choose a chat model.
 
-You can read about these supported LLM models [here](/cody/capabilities/supported-models#chat-and-commands).
+You can read about these supported LLM models [here](/cody/capabilities/supported-models#chat-and-prompts).
 
 ## Smart Apply and Execute code suggestions
 

--- a/docs/cody/clients/cody-with-sourcegraph.mdx
+++ b/docs/cody/clients/cody-with-sourcegraph.mdx
@@ -41,7 +41,7 @@ The chat interface with your Code Search queries opens parallel to your query se
 
 ## Chat with Cody on the web interface
 
-The feature set for the Cody chat is the same as the IDE extensions. Your previous chats can be viewed from the **History** tab. Claude 3.5 Sonnet is selected as the default chat model. You can change this LLM model based on your use case to optimize speed, accuracy, or cost. Enterprise users with the new [model configuration](/cody/enterprise/model-configuration) can use the LLM selection dropdown to choose a chat model. You can read about these supported LLM models [here](/cody/capabilities/supported-models#chat-and-commands).
+The feature set for the Cody chat is the same as the IDE extensions. Your previous chats can be viewed from the **History** tab. Claude 3.5 Sonnet is selected as the default chat model. You can change this LLM model based on your use case to optimize speed, accuracy, or cost. Enterprise users with the new [model configuration](/cody/enterprise/model-configuration) can use the LLM selection dropdown to choose a chat model. You can read about these supported LLM models [here](/cody/capabilities/supported-models#chat-and-prompts).
 
 To help you automate your key tasks in your development workflow, you get **[Prompts](/cody/capabilities/prompts)**. If you are a part of an organization on Sourcegraph.com or a self-hosted Sourcegraph instance, you can view these pre-built Prompts created by your teammates. On the contrary, you can create your Prompts via the **Prompt Library** from your Sourcegraph instance.
 

--- a/docs/cody/clients/install-jetbrains.mdx
+++ b/docs/cody/clients/install-jetbrains.mdx
@@ -159,7 +159,7 @@ Enterprise users can leverage the full power of the Sourcegraph search engine as
 
 <Callout type="info">
 	{' '}
-	Read more about [Context fetching mechanisms](/cody/core-concepts/context/#context-fetching-mechanism)
+	Read more about [Context fetching mechanisms](/cody/core-concepts/context#cody-context-fetching-features)
 	in detail.
 </Callout>
 

--- a/docs/cody/clients/install-vscode.mdx
+++ b/docs/cody/clients/install-vscode.mdx
@@ -195,7 +195,7 @@ Enterprise users can use the full power of the Sourcegraph search engine as Cody
 
 <Callout type="info">
 	{' '}
-	Read more about [Context fetching mechanism](/cody/core-concepts/context/#context-fetching-mechanism)
+	Read more about [Context fetching mechanism](/cody/core-concepts/context#cody-context-fetching-features)
 	in detail.
 </Callout>
 


### PR DESCRIPTION
Linear [FE-499: Fix doc site issues](https://linear.app/sourcegraph/issue/FE-499/fix-doc-site-issues)

Smaller, more easily reviewed subset of fixes from https://github.com/sourcegraph/docs/pull/1861

`#anchor` links under `docs/cody/, docs/batch-changes/ and docs/code-insights/` whose target heading was reworded. The section still exists; the link now uses the current heading's slug.

Review: for each row, the new heading should be the same topic as the old anchor's words. Rows where the heading was replaced rather than renamed (e.g. several anchors collapsed onto one `#configuration` or `#upgrade-types` section) are the ones worth a second look.

Left alone on purpose: `/batch-changes/faq#how-can-i-use-github-expression-syntax---literally-in-my-batch-spec` and `/batch-changes/batch-spec-cheat-sheet#write-a-github-actions-workflow-that-includes-github-expression-syntax` — #1861 changed them, but they work: the headings contain a link and the checker slugged only the link text (fixed in #1858).

Held back: two links in `docs/batch-changes/batch-spec-yaml-reference.mdx` and `docs/batch-changes/site-admin-configuration.mdx` share lines with fixes in #1864; they go there instead.

Checker findings (`npm run check-links -- --check-anchors`, from #1858, with its heading-slug fix): 278 on main → 259 on this branch.

## Verification

The docs site serves its not-found page with HTTP 200 (fix in progress), so status codes prove nothing. Instead, every changed link was fetched on this PR's Vercel preview and the rendered HTML checked for two `id`s: the target page's own first heading (taken from its MDX source — the 404 page never has it) and the link's `#fragment`. Script: `node dev/verify-links-live.mjs --site <preview-url>`, coming in #1858.

Old links point at the current production site so you can see the breakage; new links point at the preview and land on the heading.

Checked 19 changed links against https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app: 19 resolve, 0 fail.
Page rendered = the target page's first heading id is present (the 404 page never has it); Anchor = the #fragment is an id on the page. Old links point at the current site.

<details><summary>All 19 links</summary>

| File containing the link | Old link (broken today) | New link (preview) | Page rendered | Anchor found |
|--------------------------|-------------------------|--------------------|---------------|--------------|
| `docs/batch-changes/batch-spec-templating.mdx` | [`#template-helpers-functions`](https://sourcegraph.com/docs/batch-changes/batch-spec-templating#template-helpers-functions) | [`#template-helper-functions`](https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app/batch-changes/batch-spec-templating#template-helper-functions) | ✅ | ✅ |
| `docs/batch-changes/batch-spec-templating.mdx` | [`#template-helpers-functions`](https://sourcegraph.com/docs/batch-changes/batch-spec-templating#template-helpers-functions) | [`#template-helper-functions`](https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app/batch-changes/batch-spec-templating#template-helper-functions) | ✅ | ✅ |
| `docs/batch-changes/batch-spec-yaml-reference.mdx` | [`#outputs-value`](https://sourcegraph.com/docs/batch-changes/batch-spec-yaml-reference#outputs-value) | [`#stepsoutputsnamevalue`](https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app/batch-changes/batch-spec-yaml-reference#stepsoutputsnamevalue) | ✅ | ✅ |
| `docs/batch-changes/configuring-credentials.mdx` | [`#types-of-access-tokens-used-by-batch-changes`](https://sourcegraph.com/docs/batch-changes/configuring-credentials#types-of-access-tokens-used-by-batch-changes) | [`#types-of-credentials-used-by-batch-changes`](https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app/batch-changes/configuring-credentials#types-of-credentials-used-by-batch-changes) | ✅ | ✅ |
| `docs/batch-changes/create-a-batch-change.mdx` | [`/batch-changes/create-a-batch-change#previewing-workspaces`](https://sourcegraph.com/docs/batch-changes/create-a-batch-change#previewing-workspaces) | [`/batch-changes/create-a-batch-change#previewing-batch-spec-and-workspaces`](https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app/batch-changes/create-a-batch-change#previewing-batch-spec-and-workspaces) | ✅ | ✅ |
| `docs/batch-changes/handling-errored-changesets.mdx` | [`#manual-retrying-by-re-applying-the-batch-change-spec`](https://sourcegraph.com/docs/batch-changes/handling-errored-changesets#manual-retrying-by-re-applying-the-batch-change-spec) | [`#manual-retrying-of-errored-changesets`](https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app/batch-changes/handling-errored-changesets#manual-retrying-of-errored-changesets) | ✅ | ✅ |
| `docs/batch-changes/reexecuting-batch-specs-multiple-times.mdx` | [`/batch-changes/batch-spec-yaml-reference#environmentarray`](https://sourcegraph.com/docs/batch-changes/batch-spec-yaml-reference#environmentarray) | [`/batch-changes/batch-spec-yaml-reference#stepsenv`](https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app/batch-changes/batch-spec-yaml-reference#stepsenv) | ✅ | ✅ |
| `docs/code-insights/explanations/automatically-generated-data-series.mdx` | [`/code-insights/references/common-use-cases#automatic-version-and-pattern-tracking`](https://sourcegraph.com/docs/code-insights/references/common-use-cases#automatic-version-and-pattern-tracking) | [`/code-insights/references/common-use-cases#versions-and-patterns`](https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app/code-insights/references/common-use-cases#versions-and-patterns) | ✅ | ✅ |
| `docs/code-insights/explanations/code-insights-filters.mdx` | [`/code-search/working/search-contexts#beta-query-based-search-contexts`](https://sourcegraph.com/docs/code-search/working/search-contexts#beta-query-based-search-contexts) | [`/code-search/working/search-contexts#query-based-search-contexts`](https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app/code-search/working/search-contexts#query-based-search-contexts) | ✅ | ✅ |
| `docs/code-insights/how-tos/creating-a-custom-dashboard-of-code-insights.mdx` | [`/code-insights/explanations/viewing-code-insights#dashboard-visibility-respects-insights-visibility`](https://sourcegraph.com/docs/code-insights/explanations/viewing-code-insights#dashboard-visibility-respects-insights-visibility) | [`/code-insights/explanations/viewing-code-insights#dashboard-visibility`](https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app/code-insights/explanations/viewing-code-insights#dashboard-visibility) | ✅ | ✅ |
| `docs/code-insights/how-tos/filtering-an-insight.mdx` | [`/code-search/working/search-contexts#beta-query-based-search-contexts`](https://sourcegraph.com/docs/code-search/working/search-contexts#beta-query-based-search-contexts) | [`/code-search/working/search-contexts#query-based-search-contexts`](https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app/code-search/working/search-contexts#query-based-search-contexts) | ✅ | ✅ |
| `docs/code-insights/how-tos/filtering-an-insight.mdx` | [`/code-search/working/search-contexts#beta-query-based-search-contexts`](https://sourcegraph.com/docs/code-search/working/search-contexts#beta-query-based-search-contexts) | [`/code-search/working/search-contexts#query-based-search-contexts`](https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app/code-search/working/search-contexts#query-based-search-contexts) | ✅ | ✅ |
| `docs/code-insights/language-insight-quickstart.mdx` | [`/code-insights/quickstart#1-enable-the-experimental-feature-flag`](https://sourcegraph.com/docs/code-insights/quickstart#1-enable-the-experimental-feature-flag) | [`/code-insights/quickstart#1-if-need-be-enable-the-experimental-feature-flag`](https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app/code-insights/quickstart#1-if-need-be-enable-the-experimental-feature-flag) | ✅ | ✅ |
| `docs/code-insights/references/common-use-cases.mdx` | [`/code-insights/references/common-reasons-code-insights-may-not-match-search-results#not-including-fork-no-and-archived-no-in-your-insight-query`](https://sourcegraph.com/docs/code-insights/references/common-reasons-code-insights-may-not-match-search-results#not-including-fork-no-and-archived-no-in-your-insight-query) | [`/code-insights/references/common-reasons-code-insights-may-not-match-search-results#for-versions-pre-340-not-including-forkno-and-archivedno-in-your-insight-query`](https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app/code-insights/references/common-reasons-code-insights-may-not-match-search-results#for-versions-pre-340-not-including-forkno-and-archivedno-in-your-insight-query) | ✅ | ✅ |
| `docs/cody/capabilities/agentic-context-fetching.mdx` | [`#terminal-commands`](https://sourcegraph.com/docs/cody/capabilities/agentic-context-fetching#terminal-commands) | [`#terminal-access`](https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app/cody/capabilities/agentic-context-fetching#terminal-access) | ✅ | ✅ |
| `docs/cody/capabilities/chat.mdx` | [`/cody/capabilities/supported-models#chat-and-commands`](https://sourcegraph.com/docs/cody/capabilities/supported-models#chat-and-commands) | [`/cody/capabilities/supported-models#chat-and-prompts`](https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app/cody/capabilities/supported-models#chat-and-prompts) | ✅ | ✅ |
| `docs/cody/clients/cody-with-sourcegraph.mdx` | [`/cody/capabilities/supported-models#chat-and-commands`](https://sourcegraph.com/docs/cody/capabilities/supported-models#chat-and-commands) | [`/cody/capabilities/supported-models#chat-and-prompts`](https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app/cody/capabilities/supported-models#chat-and-prompts) | ✅ | ✅ |
| `docs/cody/clients/install-jetbrains.mdx` | [`/cody/core-concepts/context/#context-fetching-mechanism`](https://sourcegraph.com/docs/cody/core-concepts/context#context-fetching-mechanism) | [`/cody/core-concepts/context#cody-context-fetching-features`](https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app/cody/core-concepts/context#cody-context-fetching-features) | ✅ | ✅ |
| `docs/cody/clients/install-vscode.mdx` | [`/cody/core-concepts/context/#context-fetching-mechanism`](https://sourcegraph.com/docs/cody/core-concepts/context#context-fetching-mechanism) | [`/cody/core-concepts/context#cody-context-fetching-features`](https://sourcegraph-docs-git-fix-reworded-a-b4e9fa-sourcegraph-f8c71130.vercel.app/cody/core-concepts/context#cody-context-fetching-features) | ✅ | ✅ |

</details>

## Amp threads

- [Docs - Fix broken heading links](https://ampcode.com/threads/T-01a07623-9d65-7356-96b8-2bebb31ffa5a)
