### PR TITLE
fix/site: Search results link to current instance

### DIFF
--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -1,9 +1,25 @@
 import {useEffect, useState} from 'react';
 import {searchMetadata} from '../../data/search';
 import {DocSearch} from './docsearch/DocSearch';
+import type {DocSearchHit} from './docsearch/types';
 import './docsearch/docsearch.css';
 
 // import '@docsearch/css';
+
+// The Algolia crawler indexes production, so every hit URL is absolute
+// (https://sourcegraph.com/docs/...). Rewrite them to root-relative paths so
+// results resolve against whichever deployment is being viewed (Vercel
+// preview, local dev, or prod) instead of always jumping to prod.
+const PROD_DOCS_URL_PREFIX = 'https://sourcegraph.com/docs';
+const basePath = process.env.NEXT_PUBLIC_DOCS_BASE_PATH || '';
+
+const toLocalUrl = (url: string): string =>
+	url.startsWith(PROD_DOCS_URL_PREFIX)
+		? basePath + url.slice(PROD_DOCS_URL_PREFIX.length)
+		: url;
+
+const transformItems = (items: DocSearchHit[]): DocSearchHit[] =>
+	items.map(item => ({...item, url: toLocalUrl(item.url)}));
 
 const getInitialQuery = () => {
 	if (typeof window !== 'undefined' && window?.location?.href) {
@@ -32,6 +48,7 @@ export const Search = () => {
 			apiKey={algoliaConfig.apiKey}
 			initialQuery={initialQuery}
 			maxResultsPerGroup={algoliaConfig.maxResultsPerGroup}
+			transformItems={transformItems}
 		/>
 	);
 };


### PR DESCRIPTION
## Problem

On a Vercel preview deployment (or local dev), searching for something, then clicking on a search result always takes you to `https://sourcegraph.com/docs/...` instead of the matching page on the deployment you're viewing.

Cause: the Algolia crawler indexes prod, so every hit's `url` is an absolute prod URL. The vendored DocSearch renders it verbatim in `Hit.tsx` (`<a href={hit.url}>`) and returns it from `getItemUrl` (Enter-key navigation), so nothing ever makes it relative to the current origin.

## Fix

Pass a `transformItems` to `DocSearch` in `src/components/search/Search.tsx` that rewrites `https://sourcegraph.com/docs/<path>` → `${NEXT_PUBLIC_DOCS_BASE_PATH}/<path>`. `NEXT_PUBLIC_DOCS_BASE_PATH` is already `/docs` in production and `''` elsewhere (see `next.config.js`), so:

- prod: `/docs/batch-changes/view-batch-changes#viewing-batch-changes` (same target as today)
- preview / local: `/batch-changes/view-batch-changes#viewing-batch-changes`, resolved against the current origin

`transformItems` runs before `saveRecentSearch`, so recent/favorite searches persisted in localStorage get the rewritten URL too. URLs that don't start with the prod prefix are left untouched.

## Not changed

- Index content: results still reflect what the crawler last saw on prod. Pages added/renamed only in a PR won't show up in search (or may 404 on the preview). Only the link target is localized.
- No Algolia/crawler config changes.

## Verification

Tested on the preview deployment `https://sourcegraph-docs-c9sonegt9-sourcegraph-f8c71130.vercel.app`:

- Searched "batch changes"; result anchors render with relative hrefs that resolve to the **preview** origin, e.g. `/batch-changes/view-batch-changes#viewing-batch-changes` → `https://sourcegraph-docs-c9sonegt9-sourcegraph-f8c71130.vercel.app/batch-changes/view-batch-changes#viewing-batch-changes`.
- Pressing Enter on the first result navigated to that preview URL (page title "Viewing Batch Changes - Sourcegraph docs", `<h1>` "Viewing Batch Changes"), not to `sourcegraph.com/docs`.
- Recent-searches localStorage entry stored the relative URL `/batch-changes/view-batch-changes#viewing-batch-changes`.

Production behavior (`/docs/<path>` prefix) is unchanged

## Amp threads

- [Preview search URLs](https://ampcode.com/threads/T-01a07e6c-cddd-72b1-b3bf-98ad32f9d55a)