### PR TITLE
fix/dev: Fix Orb setup to avoid false cold-start failure

### DIFF
--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -1,7 +1,6 @@
 services:
   docs:
     command: pnpm dev --hostname 0.0.0.0 --port "$PORT"
-    health: /
     portal:
       url: /
       title: Sourcegraph Docs


### PR DESCRIPTION
## Why

`amp orb services ensure` printed `docs: NOT RESPONDING (readiness check timed out after 10000ms)` on every fresh orb, even though the site came up fine ~30s later. `next dev` opens its port immediately, but contentlayer generation (521 docs) plus the first-page compile exceed Amp's fixed 10s readiness window, and `.amp/services.yaml` has no configurable timeout.

## Change

Remove `health: /` from `.amp/services.yaml`. Amp now treats the service as ready when the port accepts a connection, which `next dev` does within a couple of seconds. The browser waits for the first compile instead of `ensure` reporting a false failure.

Tradeoff: `ensure` now proves the server is listening, not that a page rendered. A build error shows up in the browser or `amp orb service logs docs` instead.

## Verified

In an orb: `ensure` now reports `docs: started, port 31414, listening` in ~8s, and the portal URL returns 200 for `/` and `/cody`.

## Amp threads

- [Docs deployment portals](https://ampcode.com/threads/T-01a07e6b-4d78-7569-bb05-289a9c52ec9f)
