### PR TITLE
chore/spelling: Recommend Code Spell Checker VS Code extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+	"recommendations": ["streetsidesoftware.code-spell-checker"]
+}


### PR DESCRIPTION
Adds `.vscode/extensions.json` recommending `streetsidesoftware.code-spell-checker`, so VS Code prompts contributors to install it when they open the repo.

Pairs with the cspell PR check in #1853: the extension reads the same `cspell.json`, so writers see spelling errors in the editor before CI does.

## Amp threads

- [Add spell checker extension](https://ampcode.com/threads/T-01a083c0-6c69-720c-9c18-b157a686fe57)
