### PR TITLE
docs/observability: Remove stale log15 examples

### DIFF
--- a/docs/admin/auth/index.mdx
+++ b/docs/admin/auth/index.mdx
@@ -517,7 +517,7 @@ To use an authentication proxy to authenticate users to Sourcegraph, add the fol
 
 Replace `X-Forwarded-User` with the name of the HTTP header added by the authentication proxy that contains the user's username.
 
-Ensure that the HTTP proxy is not setting its own `Authorization` header on the request. Sourcegraph rejects requests with unrecognized `Authorization` headers and prints the error log `lvl=eror msg="Invalid Authorization header." err="unrecognized HTTP Authorization request header scheme (supported values: token, token-sudo)"`.
+Ensure that the HTTP proxy is not setting its own `Authorization` header on the request. Sourcegraph ignores `Authorization` headers with an unrecognized scheme (anything other than `token`, `token-sudo`, or `Bearer`), and records an [audit log](/admin/audit-log) entry for the `auth.accessToken` entity with `action: "failed"` and `reason: "invalid Authorization header"`.
 
 For pusher/oauth2_proxy, use the `-pass-basic-auth false` option to prevent it from sending the `Authorization` header.
 

--- a/docs/self-hosted/observability/logs.mdx
+++ b/docs/self-hosted/observability/logs.mdx
@@ -14,7 +14,7 @@ A Sourcegraph service's log level is configured via the environment variable `SR
 -   `error`: Errors only.
 -   `none`: Silence all log output.
 
-The legacy values `dbug`, `eror`, and `crit` are still accepted (`crit` maps to `error`). Unrecognized values fall back to `warn`.
+Unrecognized values fall back to `warn`.
 
 Learn more about how to apply these environment variables in [docker-compose](/self-hosted/deploy/docker-compose/#set-environment-variables) deployments.
 

--- a/docs/self-hosted/observability/logs.mdx
+++ b/docs/self-hosted/observability/logs.mdx
@@ -8,11 +8,13 @@ Note: For request logs, see [Outbound request log](/admin/outbound-request-log).
 
 A Sourcegraph service's log level is configured via the environment variable `SRC_LOG_LEVEL`. The valid values (from most to least verbose) are:
 
--   `dbug`: Debug. Output all logs. Default in cluster deployments.
+-   `debug`: Output all logs. Default in cluster deployments.
 -   `info`: Informational.
 -   `warn`: Warning. Default in Docker deployments.
--   `eror`: Error.
--   `crit`: Critical.
+-   `error`: Errors only.
+-   `none`: Silence all log output.
+
+The legacy values `dbug`, `eror`, and `crit` are still accepted (`crit` maps to `error`). Unrecognized values fall back to `warn`.
 
 Learn more about how to apply these environment variables in [docker-compose](/self-hosted/deploy/docker-compose/#set-environment-variables) deployments.
 

--- a/docs/self-hosted/observability/troubleshooting.mdx
+++ b/docs/self-hosted/observability/troubleshooting.mdx
@@ -41,13 +41,7 @@ environment.
 
 Observed state: Sourcegraph instance does not react to any updates to code hosts and no cloning is happening.
 The cause of this state could be worker queries that are too large for the limits of the running Postgres DB.
-One symptom is seeing a line like the one below in the worker logs:
-
-```text
-t=2020-05-28T18:41:02+0000 lvl=eror msg=Syncer error="syncer.sync.store.upsert-repos: delete: driver: bad connection
-```
-
-or seeing the same error in the "Code host status panel" (Clicking the cloud icon).
+One symptom is seeing repo syncer errors ending in `driver: bad connection` in the worker logs, or the same error in the "Code host status panel" (Clicking the cloud icon).
 
 The fix is to increase the memory on Postgres DB which will increase certain Postgres-internal limits and will allow
 the queries from worker to go through.


### PR DESCRIPTION
Sourcegraph replaced \`inconshreveable/log15\` with [sourcegraph/log](https://github.com/sourcegraph/log) years ago, so nothing prints \`lvl=eror\` anymore. Three docs still show it.

- **\`self-hosted/observability/logs.mdx\`**: list the canonical \`SRC_LOG_LEVEL\` values (\`debug\`, \`info\`, \`warn\`, \`error\`, \`none\`) per [levels.go](https://github.com/sourcegraph/log/blob/main/levels.go), and note that unknown values fall back to \`warn\`. The legacy \`dbug\`/\`eror\`/\`crit\` spellings are still accepted by the code but are no longer documented.
- **\`self-hosted/observability/troubleshooting.mdx\`**: drop the 2020 log15 sample line. The \`syncer.sync.store.upsert-repos\` error string no longer exists either; keep the scenario and describe the \`driver: bad connection\` symptom in prose.
- **\`admin/auth/index.mdx\`**: the \`Invalid Authorization header\` log15 error is gone. Per [\`cmd/frontend/internal/auth/accesstoken/auth.go\`](https://github.com/sourcegraph/sourcegraph/blob/main/cmd/frontend/internal/auth/accesstoken/auth.go), an unrecognized \`Authorization\` scheme is now ignored and recorded as an \`auth.accessToken\` / \`failed\` audit log entry with \`reason: "invalid Authorization header"\`.

## Amp threads

- [Cspell word list review](https://ampcode.com/threads/T-01a082f4-e864-769b-8269-46847abcd228)
