### PR TITLE
feat/site: Add navigation links on 404 page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,4 +1,8 @@
-import Link from 'next/link';
+import {NotFoundLinks} from '@/components/NotFoundLinks';
+import {allPosts} from 'contentlayer/generated';
+
+// Preview pages 404 without ?preview, so they are not valid targets.
+const pagePaths = allPosts.filter(post => !post.preview).map(post => post.url);
 
 export default function NotFound() {
 	return (
@@ -13,12 +17,7 @@ export default function NotFound() {
 				<p className="mt-2 text-sm text-slate-500 dark:text-dark-paragraph-text">
 					Sorry, we couldn’t find the page you’re looking for.
 				</p>
-				<Link
-					href="/"
-					className="mt-8 text-sm font-medium text-slate-900 dark:text-white"
-				>
-					Go back home
-				</Link>
+				<NotFoundLinks pagePaths={pagePaths} />
 			</div>
 		</div>
 	);

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import {PreviousPathnameProvider} from '@/components/PreviousPathname';
 import {ThemeProvider, useTheme} from 'next-themes';
 import {useEffect} from 'react';
 
@@ -31,7 +32,7 @@ export function Providers({children}: {children: React.ReactNode}) {
 	return (
 		<ThemeProvider attribute="class" disableTransitionOnChange>
 			<ThemeWatcher />
-			{children}
+			<PreviousPathnameProvider>{children}</PreviousPathnameProvider>
 		</ThemeProvider>
 	);
 }

--- a/src/components/NotFoundLinks.tsx
+++ b/src/components/NotFoundLinks.tsx
@@ -3,7 +3,7 @@
 import {usePreviousPathname} from '@/components/PreviousPathname';
 import Link from 'next/link';
 import {usePathname} from 'next/navigation';
-import {useEffect, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 
 const linkClassName =
 	'text-sm font-medium text-slate-900 hover:underline dark:text-white';
@@ -36,20 +36,27 @@ export function NotFoundLinks({pagePaths}: {pagePaths: string[]}) {
 	const previousPathname = usePreviousPathname();
 	const [ancestor, setAncestor] = useState<string | null>(null);
 	const [referrer, setReferrer] = useState<URL | null>(null);
+	const pagePathSet = useMemo(() => new Set(pagePaths), [pagePaths]);
 
 	// Both values depend on the browser URL, which the statically prerendered
 	// 404 page does not know, so resolve them after mount to avoid a hydration
 	// mismatch.
 	useEffect(() => {
-		setAncestor(nearestExistingAncestor(pathname, new Set(pagePaths)));
+		setAncestor(nearestExistingAncestor(pathname, pagePathSet));
 		setReferrer(sameOriginReferrer());
-	}, [pathname, pagePaths]);
+	}, [pathname, pagePathSet]);
+
+	// The previous pathname may itself have been a 404.
+	const previousPage =
+		previousPathname && pagePathSet.has(previousPathname)
+			? previousPathname
+			: null;
 
 	return (
 		<div className="mt-8 flex flex-col gap-3">
-			{previousPathname ? (
-				<Link href={previousPathname} className={linkClassName}>
-					Go back to {previousPathname}
+			{previousPage ? (
+				<Link href={previousPage} className={linkClassName}>
+					Go back to {previousPage}
 				</Link>
 			) : (
 				referrer && (

--- a/src/components/NotFoundLinks.tsx
+++ b/src/components/NotFoundLinks.tsx
@@ -52,22 +52,33 @@ export function NotFoundLinks({pagePaths}: {pagePaths: string[]}) {
 			? previousPathname
 			: null;
 
+	// Prefer the in-app history over document.referrer, which goes stale on
+	// client-side navigations.
+	const backLink = previousPage
+		? {href: previousPage, pathname: previousPage}
+		: referrer
+			? {
+					href: referrer.pathname + referrer.search + referrer.hash,
+					pathname: referrer.pathname
+				}
+			: null;
+
+	// Skip the up link when it would repeat the back link.
+	const upLink =
+		ancestor && ancestor !== backLink?.pathname.replace(/\/$/, '')
+			? ancestor
+			: null;
+
 	return (
 		<div className="mt-8 flex flex-col gap-3">
-			{previousPage ? (
-				<Link href={previousPage} className={linkClassName}>
-					Go back to {previousPage}
+			{backLink && (
+				<Link href={backLink.href} className={linkClassName}>
+					Go back to {backLink.pathname}
 				</Link>
-			) : (
-				referrer && (
-					<a href={referrer.href} className={linkClassName}>
-						Go back to {referrer.pathname}
-					</a>
-				)
 			)}
-			{ancestor && (
-				<Link href={ancestor} className={linkClassName}>
-					Go up to {ancestor}
+			{upLink && (
+				<Link href={upLink} className={linkClassName}>
+					Go up to {upLink}
 				</Link>
 			)}
 			<Link href="/" className={linkClassName}>

--- a/src/components/NotFoundLinks.tsx
+++ b/src/components/NotFoundLinks.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import Link from 'next/link';
+import {usePathname} from 'next/navigation';
+import {useEffect, useState} from 'react';
+
+const linkClassName =
+	'text-sm font-medium text-slate-900 hover:underline dark:text-white';
+
+// Closest ancestor of `pathname` that is a real docs page, excluding the root
+// (the home link always covers that).
+function nearestExistingAncestor(
+	pathname: string,
+	pagePaths: Set<string>
+): string | null {
+	const segments = pathname.split('/').filter(Boolean);
+	for (let depth = segments.length - 1; depth > 0; depth--) {
+		const candidate = `/${segments.slice(0, depth).join('/')}`;
+		if (pagePaths.has(candidate)) return candidate;
+	}
+	return null;
+}
+
+// The page the user came from, only when it is on this site.
+function sameOriginReferrer(): URL | null {
+	if (!document.referrer) return null;
+	const referrer = new URL(document.referrer);
+	return referrer.origin === window.location.origin ? referrer : null;
+}
+
+export function NotFoundLinks({pagePaths}: {pagePaths: string[]}) {
+	const pathname = usePathname();
+	const [ancestor, setAncestor] = useState<string | null>(null);
+	const [referrer, setReferrer] = useState<URL | null>(null);
+
+	// Both values depend on the browser URL, which the statically prerendered
+	// 404 page does not know, so resolve them after mount to avoid a hydration
+	// mismatch.
+	useEffect(() => {
+		setAncestor(nearestExistingAncestor(pathname, new Set(pagePaths)));
+		setReferrer(sameOriginReferrer());
+	}, [pathname, pagePaths]);
+
+	return (
+		<div className="mt-8 flex flex-col gap-3">
+			{referrer && (
+				<a href={referrer.href} className={linkClassName}>
+					Go back to {referrer.pathname}
+				</a>
+			)}
+			{ancestor && (
+				<Link href={ancestor} className={linkClassName}>
+					Go up to {ancestor}
+				</Link>
+			)}
+			<Link href="/" className={linkClassName}>
+				Go back home
+			</Link>
+		</div>
+	);
+}

--- a/src/components/NotFoundLinks.tsx
+++ b/src/components/NotFoundLinks.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import {usePreviousPathname} from '@/components/PreviousPathname';
 import Link from 'next/link';
 import {usePathname} from 'next/navigation';
 import {useEffect, useState} from 'react';
@@ -21,7 +22,9 @@ function nearestExistingAncestor(
 	return null;
 }
 
-// The page the user came from, only when it is on this site.
+// The page the user came from on a fresh page load, only when it is on this
+// site. document.referrer does not change on client-side navigations, so
+// those are covered by usePreviousPathname instead.
 function sameOriginReferrer(): URL | null {
 	if (!document.referrer) return null;
 	const referrer = new URL(document.referrer);
@@ -30,6 +33,7 @@ function sameOriginReferrer(): URL | null {
 
 export function NotFoundLinks({pagePaths}: {pagePaths: string[]}) {
 	const pathname = usePathname();
+	const previousPathname = usePreviousPathname();
 	const [ancestor, setAncestor] = useState<string | null>(null);
 	const [referrer, setReferrer] = useState<URL | null>(null);
 
@@ -43,10 +47,16 @@ export function NotFoundLinks({pagePaths}: {pagePaths: string[]}) {
 
 	return (
 		<div className="mt-8 flex flex-col gap-3">
-			{referrer && (
-				<a href={referrer.href} className={linkClassName}>
-					Go back to {referrer.pathname}
-				</a>
+			{previousPathname ? (
+				<Link href={previousPathname} className={linkClassName}>
+					Go back to {previousPathname}
+				</Link>
+			) : (
+				referrer && (
+					<a href={referrer.href} className={linkClassName}>
+						Go back to {referrer.pathname}
+					</a>
+				)
 			)}
 			{ancestor && (
 				<Link href={ancestor} className={linkClassName}>

--- a/src/components/PreviousPathname.tsx
+++ b/src/components/PreviousPathname.tsx
@@ -5,27 +5,55 @@ import {createContext, useContext, useEffect, useState} from 'react';
 
 const PreviousPathnameContext = createContext<string | null>(null);
 
-// Remembers the pathname the user was on before the current one. Lives in the
-// root layout, which React keeps mounted across client-side navigations, so
-// the 404 page can link back to the page whose link was broken. Null on a
-// fresh page load.
+interface Visited {
+	current: string;
+	previous: string | null;
+}
+
+// Kept in sessionStorage (per tab) so it survives full page loads, e.g. when
+// the user edits the URL bar, which sends no referrer.
+const storageKey = 'docs.visitedPathnames';
+
+function readVisited(): Visited | null {
+	try {
+		const raw = window.sessionStorage.getItem(storageKey);
+		return raw ? (JSON.parse(raw) as Visited) : null;
+	} catch {
+		return null;
+	}
+}
+
+function writeVisited(visited: Visited) {
+	try {
+		window.sessionStorage.setItem(storageKey, JSON.stringify(visited));
+	} catch {
+		// Storage unavailable; the in-memory value still covers client-side navigations.
+	}
+}
+
+// Remembers the pathname the user was on before the current one, so the 404
+// page can link back to the page whose link was broken. Lives in the root
+// layout, which React keeps mounted across client-side navigations. Null when
+// this tab has not visited another docs page.
 export function PreviousPathnameProvider({
 	children
 }: {
 	children: React.ReactNode;
 }) {
 	const pathname = usePathname();
-	const [visited, setVisited] = useState<{
-		current: string;
-		previous: string | null;
-	}>({current: pathname, previous: null});
+	const [visited, setVisited] = useState<Visited>({
+		current: pathname,
+		previous: null
+	});
 
 	useEffect(() => {
-		setVisited(visited =>
-			visited.current === pathname
-				? visited
-				: {current: pathname, previous: visited.current}
-		);
+		const stored = readVisited() ?? {current: pathname, previous: null};
+		const next =
+			stored.current === pathname
+				? stored
+				: {current: pathname, previous: stored.current};
+		writeVisited(next);
+		setVisited(next);
 	}, [pathname]);
 
 	return (

--- a/src/components/PreviousPathname.tsx
+++ b/src/components/PreviousPathname.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import {usePathname} from 'next/navigation';
+import {createContext, useContext, useEffect, useState} from 'react';
+
+const PreviousPathnameContext = createContext<string | null>(null);
+
+// Remembers the pathname the user was on before the current one. Lives in the
+// root layout, which React keeps mounted across client-side navigations, so
+// the 404 page can link back to the page whose link was broken. Null on a
+// fresh page load.
+export function PreviousPathnameProvider({
+	children
+}: {
+	children: React.ReactNode;
+}) {
+	const pathname = usePathname();
+	const [visited, setVisited] = useState<{
+		current: string;
+		previous: string | null;
+	}>({current: pathname, previous: null});
+
+	useEffect(() => {
+		setVisited(visited =>
+			visited.current === pathname
+				? visited
+				: {current: pathname, previous: visited.current}
+		);
+	}, [pathname]);
+
+	return (
+		<PreviousPathnameContext.Provider value={visited.previous}>
+			{children}
+		</PreviousPathnameContext.Provider>
+	);
+}
+
+export const usePreviousPathname = () => useContext(PreviousPathnameContext);


### PR DESCRIPTION
## What

The 404 page only offered "Go back home". It now also shows, when applicable:

- **Go back to `<path>`** — the docs page the user was on before this one
- **Go up to `<path>`** — the closest ancestor of the requested URL that is a real docs page (preview pages excluded). Omitted when that ancestor is the root (the home link covers it) or is the same page as the back link.

## Before

- Only see a clickable link to the home page, which is almost never where I want to go

<img width="551" height="362" alt="image" src="https://github.com/user-attachments/assets/b14f9ac8-ba90-4234-9203-bbacc4c96a57" />

## After

- Also see a link back to the previous page I was on
- If there's also a valid parent page, which is different than the previous page, then show that as an option as well (useful because we have so many broken links / redirects to old subpages, and the content's likely been moved to the parent page, or another page I can click to from the parent page)

<img width="1268" height="605" alt="image" src="https://github.com/user-attachments/assets/a0c16b6e-7d8e-477a-907e-3bab297f6dc9" />

