### PR TITLE
docs/self-hosted: fix typo in Kubernetes troubleshooting page

### DIFF
--- a/docs/self-hosted/deploy/kubernetes/troubleshoot.mdx
+++ b/docs/self-hosted/deploy/kubernetes/troubleshoot.mdx
@@ -91,7 +91,7 @@ Make sure the namespace of the ingress-controller is `ingress-nginx`. See the [T
 
 #### Healthcheck failing with Strconv.Atoi: parsing `{$portName}`: invalid syntax error
 
-This can occur when the Readiness or Liveness probe is referring to a port that is not defined. Please ensure the port name is consistent with upstream. Foe example:
+This can occur when the Readiness or Liveness probe is referring to a port that is not defined. Please ensure the port name is consistent with upstream. For example:
 
 ```yaml
 ports:


### PR DESCRIPTION
Fixes `Foe example` → `For example` on the Kubernetes troubleshooting page.

Also serves as the live test target for #1874: that workflow was dispatched by hand against this PR's preview deployment, and the "Preview links for changed pages" comment below is its output.

## Amp threads

- [Address PR 1874 feedback](https://ampcode.com/threads/T-01a08573-3d6c-7491-ac34-61b4800612a8)