### PR TITLE
fix/links: Replace absolute self-links with relative links (67 links)

### DIFF
--- a/docs/admin/pings.mdx
+++ b/docs/admin/pings.mdx
@@ -241,7 +241,7 @@ Sourcegraph telemetry pings are handled by a goroutine running on Sourcegraph's 
 
 ### Misconfigured update.channel
 
-The most common scenario in which Sourcegraph stops sending pings is a change to the `update.channel` setting in an instance's [site config](https://sourcegraph.com/docs/admin/config/site-config)
+The most common scenario in which Sourcegraph stops sending pings is a change to the `update.channel` setting in an instance's [site config](/admin/config/site-config)
 
 ```
 "update.channel": "release",

--- a/docs/admin/repo/auth.mdx
+++ b/docs/admin/repo/auth.mdx
@@ -62,7 +62,7 @@ In Sourcegraph 5.1.0 and later, the insecure SSH rsa-sha1 signature algorithm is
 
 If you use an RSA SSH key to authenticate to your code host, you should ensure that your code host runs OpenSSL 7.2 or newer.
 
-If it is not possible to update the code host, you should generate a new ed25519 SSH key to use for authentication. This can be achieved by running `ssh-keygen -t ed25519`, and [configuring Sourcegraph](https://sourcegraph.com/docs/admin/repo/git-config) to use this new key.
+If it is not possible to update the code host, you should generate a new ed25519 SSH key to use for authentication. This can be achieved by running `ssh-keygen -t ed25519`, and [configuring Sourcegraph](/admin/repo/git-config) to use this new key.
 
 ### Error: `Host key verification failed`
 

--- a/docs/admin/repo/perforce.mdx
+++ b/docs/admin/repo/perforce.mdx
@@ -178,7 +178,7 @@ To ensure Sourcegraph handles host rules according to your requirements, you hav
 
 ##### Enforcing host rules
 
-If you want Sourcegraph to enforce host-specific permissions, you need to enable IP restriction enforcement in your [site configuration](https://sourcegraph.com/docs/admin/config/site-config):
+If you want Sourcegraph to enforce host-specific permissions, you need to enable IP restriction enforcement in your [site configuration](/admin/config/site-config):
 
 ```json
 {

--- a/docs/admin/search.mdx
+++ b/docs/admin/search.mdx
@@ -76,9 +76,9 @@ Sourcegraph indexes the code on the default branch of each repository. This spee
 
 To view which files are skipped during indexing, visit the repository settings page and click on **Indexing**.
 
-To force the indexer to include specific files (like `yarn.lock` or other large text files) that are otherwise skipped, add their file path or a glob pattern to the [search.largeFiles](https://sourcegraph.com/docs/admin/search#maximum-file-size) setting in your site configuration and reindex the repository. Note that files must still be valid UTF-8 to be indexed, even if added to `search.largeFiles`.
+To force the indexer to include specific files (like `yarn.lock` or other large text files) that are otherwise skipped, add their file path or a glob pattern to the [search.largeFiles](/admin/search#maximum-file-size) setting in your site configuration and reindex the repository. Note that files must still be valid UTF-8 to be indexed, even if added to `search.largeFiles`.
 
-For large deployments we recommend horizontally scaling indexed search. You can do this by adjusting the [number of replicas](https://sourcegraph.com/docs/admin/deploy/kubernetes/configure). Sourcegraph shards repository indexes across replicas. When the replica count changes Sourcegraph will slowly rebalance indexes to ensure availability of existing indexes.
+For large deployments we recommend horizontally scaling indexed search. You can do this by adjusting the [number of replicas](/self-hosted/deploy/kubernetes/configure). Sourcegraph shards repository indexes across replicas. When the replica count changes Sourcegraph will slowly rebalance indexes to ensure availability of existing indexes.
 
 The resource requirements for indexed search vary considerably based on the text contents of your repositories, but a good estimate is that the node should have enough memory to hold the entire text contents of the default branch of each repository.
 

--- a/docs/admin/telemetry/private-metadata-allowlist.mdx
+++ b/docs/admin/telemetry/private-metadata-allowlist.mdx
@@ -1,12 +1,12 @@
 # Private metadata allowlist
 
-This document lists all telemetry events that are allowed to export specific `privateMetadata` fields (from within [telemetry event parameters](https://sourcegraph.com/docs/admin/telemetry/protocol#telemetrygateway-v1-EventParameters)).
+This document lists all telemetry events that are allowed to export specific `privateMetadata` fields (from within [telemetry event parameters](/admin/telemetry/protocol#telemetrygateway-v1-EventParameters)).
 By default, `privateMetadata` is **never** exported from customers because it can contain arbitrarily-shaped data that may accidentally include sensitive or private contents.
 The specific events and properties listed below have been individually reviewed and approved for export.
 The implementation of each is monitored to ensure they contain only categorized, enumerated information.
 
 The only `metadata` we collect by default are non-sensitive numeric values.
-To learn more, refer to the [telemetry documentation](https://sourcegraph.com/docs/admin/telemetry).
+To learn more, refer to the [telemetry documentation](/admin/telemetry).
 
 | **Event feature** | **Event action** | **Allowed `privateMetadata` fields** |
 | :---------------- | :--------------- | :----------------------------------- |

--- a/docs/admin/telemetry/protocol.mdx
+++ b/docs/admin/telemetry/protocol.mdx
@@ -3,7 +3,7 @@
 
 This page contains the core schema for telemetry event data that gets exported from Sourcegraph.
 
-To learn more, refer to our [telemetry documentation](https://sourcegraph.com/docs/admin/telemetry).
+To learn more, refer to our [telemetry documentation](/admin/telemetry).
 
 ## Table of Contents
 

--- a/docs/code-navigation/private-maven-repository-configuration.mdx
+++ b/docs/code-navigation/private-maven-repository-configuration.mdx
@@ -28,7 +28,7 @@ To test and validate the Maven configuration, modify a single repository’s aut
 
 ### Set Up Executor Secrets
 
-Before triggering the indexing process, make sure the environment variables `$ARTIFACTORY_USER` and `$ARTIFACTORY_PASSWORD` are created as [Executor Secrets](https://sourcegraph.com/docs/admin/executors/executor-secrets).
+Before triggering the indexing process, make sure the environment variables `$ARTIFACTORY_USER` and `$ARTIFACTORY_PASSWORD` are created as [Executor Secrets](/admin/executors/executor-secrets).
 
 ### Trigger Indexing
 

--- a/docs/code-search/queries/examples.mdx
+++ b/docs/code-search/queries/examples.mdx
@@ -118,4 +118,4 @@ Regex searches are also useful when searching boundaries that are not delimited 
 repo:^github\.com/sourcegraph/ \bbtn-secondary\b
 ```
 
-More examples of regex searches are available [here](https://sourcegraph.com/docs/code-search/queries#regular-expression-search)
+More examples of regex searches are available [here](/code-search/queries#regular-expression-search)

--- a/docs/cody/capabilities/auto-edit.mdx
+++ b/docs/cody/capabilities/auto-edit.mdx
@@ -72,7 +72,7 @@ Site admins can opt their organization out of the auto-edit feature by disabling
 
 Auto-edit is available as default for Enterprise customers with [Sourcegraph Model Provider (Cody Gateway)](/model-provider) access. To configure auto-edit:
 
--   Add `fireworks::*` as an [allowed provider](https://sourcegraph.com/docs/cody/enterprise/model-configuration#model-filters)
+-   Add `fireworks::*` as an [allowed provider](/cody/enterprise/model-configuration#model-filters)
 
 The following example demonstrates how to add Fireworks as an allowed LLM provider:
 
@@ -125,7 +125,7 @@ Site admins can opt their organization out of the auto-edit feature by disabling
 
 Auto-edit is available as default for Enterprise customers with [Sourcegraph Model Provider (Cody Gateway)](/model-provider) access. To configure auto-edit:
 
--   Add `fireworks::*` as an [allowed provider](https://sourcegraph.com/docs/cody/enterprise/model-configuration#model-filters)
+-   Add `fireworks::*` as an [allowed provider](/cody/enterprise/model-configuration#model-filters)
 
 The following example demonstrates how to add Fireworks as an allowed LLM provider:
 
@@ -177,7 +177,7 @@ You can opt out and switch back to autocomplete by deselecting it from the Cody 
 
 Auto-edit is available as default for Enterprise customers with [Sourcegraph Model Provider (Cody Gateway)](/model-provider) access. To configure auto-edit:
 
--   Add `fireworks::*` as an [allowed provider](https://sourcegraph.com/docs/cody/enterprise/model-configuration#model-filters)
+-   Add `fireworks::*` as an [allowed provider](/cody/enterprise/model-configuration#model-filters)
 
 The following example demonstrates how to add Fireworks as an allowed LLM provider:
 

--- a/docs/cody/prompts-guide.mdx
+++ b/docs/cody/prompts-guide.mdx
@@ -104,7 +104,7 @@ You can learn more about context [here](/cody/core-concepts/context).
 
 @-mention local and current repositories are only available if you have your repository indexed. Enterprise and Enterprise Starter users can request their admins to add their local project for indexing to get access to @-mention context.
 
-Repository indexing is only available to supported [Code Hosts](https://sourcegraph.com/docs/admin/code-hosts), please reach out to your admins if you require assistance with indexing.
+Repository indexing is only available to supported [Code Hosts](/admin/code-hosts), please reach out to your admins if you require assistance with indexing.
 
 ## Selecting the right LLM
 

--- a/docs/cody/use-cases/vsc-tutorial.mdx
+++ b/docs/cody/use-cases/vsc-tutorial.mdx
@@ -39,7 +39,7 @@ You can also use the [Cody: Commands Menu](command:cody.menu.commands) which has
 
 **✨ Pro-tips for using Cody commands**
 
--   You can build your own [Custom Commands (Beta)](https://sourcegraph.com/docs/cody/custom-commands) with custom prompts, output into chat or perform code edits, and more.
+-   You can build your own [Custom Commands (Beta)](/cody/capabilities/prompts) with custom prompts, output into chat or perform code edits, and more.
 
 ## Edit Code
 
@@ -53,7 +53,7 @@ You can also use the default keyboard shortcut of `Opt+K`/`Alt+K`.
 
 -   You can open the 💡 menu, with an "Cody: Edit Code" option, by selecting any line of code and using the keyboard short `Command` `.` on macOS or `Ctrl` `.` on Windows & Linux.
 -   If you start an empty line and open the 💡 menu (using the keyboard short `Command` `.` on macOS or `Ctrl` `.` on Windows & Linux) you can use "Cody: Generate Code" to generate new lines of code based on instructions.
--   You define your own custom code editing commands using [Custom Commands (Beta)](https://sourcegraph.com/docs/cody/custom-commands), by setting the [`commands.<id>.mode` property](https://sourcegraph.com/docs/cody/capabilities/commands#commands-id-mode).
+-   You define your own custom code editing commands using [Custom Commands (Beta)](/cody/capabilities/prompts), by setting the [`commands.<id>.mode` property](/cody/capabilities/prompts).
 
 ## Explain Code
 

--- a/docs/self-hosted/observability/alerts.mdx
+++ b/docs/self-hosted/observability/alerts.mdx
@@ -5,7 +5,7 @@
 This document contains a complete reference of all alerts in Sourcegraph's monitoring, and next steps for when you find alerts that are firing.
 If your alert isn't mentioned here, or if the next steps don't help, [contact us](mailto:support@sourcegraph.com) for assistance.
 
-To learn more about Sourcegraph's alerting and how to set up alerts, see [our alerting guide](https://sourcegraph.com/docs/admin/observability/alerting).
+To learn more about Sourcegraph's alerting and how to set up alerts, see [our alerting guide](/self-hosted/observability/alerting).
 
 ## frontend: 99th_percentile_search_request_duration
 
@@ -244,7 +244,7 @@ Generated query for warning alert: `max((histogram_quantile(0.9, sum by (le) (ra
 - **Check that most repositories are indexed** by visiting https://sourcegraph.example.com/admin/repositories?filter=needs-index (it should show few or no results.)
 - **Kubernetes:** Check CPU usage of zoekt-webserver in the indexed-search pod, consider increasing CPU limits in the `indexed-search.Deployment.yaml` if regularly hitting max CPU utilization.
 - **Docker Compose:** Check CPU usage on the Zoekt Web Server dashboard, consider increasing `cpus:` of the zoekt-webserver container in `docker-compose.yml` if regularly hitting max CPU utilization.
-- This alert may indicate that your instance is struggling to process symbols queries on a monorepo, [learn more here](https://sourcegraph.com/docs/admin/monorepo).
+- This alert may indicate that your instance is struggling to process symbols queries on a monorepo, [learn more here](/admin/monorepo).
 - Learn more about the related dashboard panel in the [dashboards reference](dashboards#frontend-99th_percentile_search_codeintel_request_duration).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -279,7 +279,7 @@ Generated query for warning alert: `max((histogram_quantile(0.99, sum by (le) (r
 - **Check that most repositories are indexed** by visiting https://sourcegraph.example.com/admin/repositories?filter=needs-index (it should show few or no results.)
 - **Kubernetes:** Check CPU usage of zoekt-webserver in the indexed-search pod, consider increasing CPU limits in the `indexed-search.Deployment.yaml` if regularly hitting max CPU utilization.
 - **Docker Compose:** Check CPU usage on the Zoekt Web Server dashboard, consider increasing `cpus:` of the zoekt-webserver container in `docker-compose.yml` if regularly hitting max CPU utilization.
-- This alert may indicate that your instance is struggling to process symbols queries on a monorepo, [learn more here](https://sourcegraph.com/docs/admin/monorepo).
+- This alert may indicate that your instance is struggling to process symbols queries on a monorepo, [learn more here](/admin/monorepo).
 - Learn more about the related dashboard panel in the [dashboards reference](dashboards#frontend-90th_percentile_search_codeintel_request_duration).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -909,7 +909,7 @@ Generated query for warning alert: `max((sum by (name, job_name) (rate(src_perio
 **Next steps**
 
 - Increase SRC_PGSQL_MAX_OPEN together with giving more memory to the database if needed
-- Scale up Postgres memory/cpus - [see our scaling guide](https://sourcegraph.com/docs/admin/config/postgres-conf)
+- Scale up Postgres memory/cpus - [see our scaling guide](/self-hosted/postgres-conf)
 - If using GCP Cloud SQL, check for high lock waits or CPU usage in query insights
 - Learn more about the related dashboard panel in the [dashboards reference](dashboards#frontend-mean_blocked_seconds_per_conn_request).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -1397,7 +1397,7 @@ Generated query for critical alert: `min(((src_gitserver_disk_space_available / 
 **Next steps**
 
 - **Single container deployments (removed in 7.0.0):** The single-container deployment mode has been sunset. [Migrate to Docker Compose](../deploy/docker-compose/migrate).
-- **Kubernetes and Docker Compose:** Check that you are running a similar number of git server replicas and that their CPU/memory limits are allocated according to what is shown in the [Sourcegraph resource estimator](https://sourcegraph.com/docs/self-hosted/deploy/resource-estimator).
+- **Kubernetes and Docker Compose:** Check that you are running a similar number of git server replicas and that their CPU/memory limits are allocated according to what is shown in the [Sourcegraph resource estimator](/self-hosted/deploy/resource-estimator).
 - If your persistent volume is slow, you may want to provision more IOPS, usually by increasing the volume size.
 - More help interpreting this metric is available in the [dashboards reference](dashboards#gitserver-echo_command_duration_test).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -1688,7 +1688,7 @@ Generated query for critical alert: `max((max(max_over_time(src_conf_client_time
 **Next steps**
 
 - Increase SRC_PGSQL_MAX_OPEN together with giving more memory to the database if needed
-- Scale up Postgres memory/cpus - [see our scaling guide](https://sourcegraph.com/docs/admin/config/postgres-conf)
+- Scale up Postgres memory/cpus - [see our scaling guide](/self-hosted/postgres-conf)
 - If using GCP Cloud SQL, check for high lock waits or CPU usage in query insights
 - Learn more about the related dashboard panel in the [dashboards reference](dashboards#gitserver-mean_blocked_seconds_per_conn_request).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -2006,7 +2006,7 @@ Generated query for warning alert: `min((sum by (job) (pg_stat_activity_count{da
 
 **Next steps**
 
-- Consider increasing [max_connections](https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-MAX-CONNECTIONS) of the database instance, [learn more](https://sourcegraph.com/docs/admin/config/postgres-conf)
+- Consider increasing [max_connections](https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-MAX-CONNECTIONS) of the database instance, [learn more](/self-hosted/postgres-conf)
 - Learn more about the related dashboard panel in the [dashboards reference](dashboards#postgres-usage_connections_percentage).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2496,7 +2496,7 @@ Generated query for warning alert: `max((max by (instance) (clamp_min(time() - s
 **Next steps**
 
 - Increase SRC_PGSQL_MAX_OPEN together with giving more memory to the database if needed
-- Scale up Postgres memory/cpus - [see our scaling guide](https://sourcegraph.com/docs/admin/config/postgres-conf)
+- Scale up Postgres memory/cpus - [see our scaling guide](/self-hosted/postgres-conf)
 - If using GCP Cloud SQL, check for high lock waits or CPU usage in query insights
 - Learn more about the related dashboard panel in the [dashboards reference](dashboards#precise-code-intel-worker-mean_blocked_seconds_per_conn_request).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -2565,7 +2565,7 @@ Generated query for critical alert: `min((sum by (app) (up{app=~".*precise-code-
 **Next steps**
 
 - Increase SRC_PGSQL_MAX_OPEN together with giving more memory to the database if needed
-- Scale up Postgres memory/cpus - [see our scaling guide](https://sourcegraph.com/docs/admin/config/postgres-conf)
+- Scale up Postgres memory/cpus - [see our scaling guide](/self-hosted/postgres-conf)
 - If using GCP Cloud SQL, check for high lock waits or CPU usage in query insights
 - Learn more about the related dashboard panel in the [dashboards reference](dashboards#syntactic-indexing-mean_blocked_seconds_per_conn_request).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -3904,7 +3904,7 @@ Generated query for critical alert: `min((max by (name) (src_gitlab_rate_limit_r
 **Next steps**
 
 - **Enabled permissions for the first time:** Wait for few minutes and see if the number goes down.
-- **Otherwise:** Increase the API rate limit to [GitHub](https://sourcegraph.com/docs/admin/code_hosts/github#github-com-rate-limits), [GitLab](https://sourcegraph.com/docs/admin/code_hosts/gitlab#internal-rate-limits) or [Bitbucket Server](https://sourcegraph.com/docs/admin/code_hosts/bitbucket_server#internal-rate-limits).
+- **Otherwise:** Increase the API rate limit to [GitHub](/admin/code-hosts/github#rate-limits), [GitLab](/admin/code-hosts/gitlab#internal-rate-limits) or [Bitbucket Server](/admin/code-hosts/bitbucket-server#internal-rate-limits).
 - Learn more about the related dashboard panel in the [dashboards reference](dashboards#worker-perms_syncer_outdated_perms).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -4034,7 +4034,7 @@ Generated query for warning alert: `max((sum by (name, job_name) (rate(src_perio
 **Next steps**
 
 - Increase SRC_PGSQL_MAX_OPEN together with giving more memory to the database if needed
-- Scale up Postgres memory/cpus - [see our scaling guide](https://sourcegraph.com/docs/admin/config/postgres-conf)
+- Scale up Postgres memory/cpus - [see our scaling guide](/self-hosted/postgres-conf)
 - If using GCP Cloud SQL, check for high lock waits or CPU usage in query insights
 - Learn more about the related dashboard panel in the [dashboards reference](dashboards#worker-mean_blocked_seconds_per_conn_request).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -4648,7 +4648,7 @@ Generated query for warning alert: `max((sum by (name, job_name) (rate(src_perio
 **Next steps**
 
 - Increase SRC_PGSQL_MAX_OPEN together with giving more memory to the database if needed
-- Scale up Postgres memory/cpus - [see our scaling guide](https://sourcegraph.com/docs/admin/config/postgres-conf)
+- Scale up Postgres memory/cpus - [see our scaling guide](/self-hosted/postgres-conf)
 - If using GCP Cloud SQL, check for high lock waits or CPU usage in query insights
 - Learn more about the related dashboard panel in the [dashboards reference](dashboards#searcher-mean_blocked_seconds_per_conn_request).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -5575,7 +5575,7 @@ Generated query for warning alert: `max((max by (name) (container_memory_rss{nam
 
     - Enabling shard merging for Zoekt: Set SRC_ENABLE_SHARD_MERGING="1" for zoekt-indexserver. Use this option
 if your corpus of repositories has a high percentage of small, rarely updated repositories. See
-[documentation](https://sourcegraph.com/docs/code-search/features#shard-merging).
+[documentation](/admin/search#shard-merging).
     - Creating additional Zoekt replicas: This spreads all the shards out amongst more replicas, which
 means that each _individual_ replica will have fewer shards. This, in turn, decreases the
 amount of memory map areas that a _single_ replica can create (in order to load the shards into memory).
@@ -5866,7 +5866,7 @@ Generated query for warning alert: `max((sum by (rule_group) (rate(prometheus_ru
 **Next steps**
 
 - Check the Container monitoring (not available on server) panels and try increasing resources for Prometheus if necessary.
-- Ensure that your [`observability.alerts` configuration](https://sourcegraph.com/docs/admin/observability/alerting#setting-up-alerting) (in site configuration) is valid.
+- Ensure that your [`observability.alerts` configuration](/self-hosted/observability/alerting#setting-up-alerting) (in site configuration) is valid.
 - Check if the relevant alert integration service is experiencing downtime or issues.
 - Learn more about the related dashboard panel in the [dashboards reference](dashboards#prometheus-alertmanager_notification_latency).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -5898,7 +5898,7 @@ Generated query for warning alert: `max((sum by (integration) (rate(alertmanager
 
 **Next steps**
 
-- Ensure that your [`observability.alerts` configuration](https://sourcegraph.com/docs/admin/observability/alerting#setting-up-alerting) (in site configuration) is valid.
+- Ensure that your [`observability.alerts` configuration](/self-hosted/observability/alerting#setting-up-alerting) (in site configuration) is valid.
 - Check if the relevant alert integration service is experiencing downtime or issues.
 - Learn more about the related dashboard panel in the [dashboards reference](dashboards#prometheus-alertmanager_notification_failures).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -5931,7 +5931,7 @@ Generated query for warning alert: `max((sum by (integration) (rate(alertmanager
 **Next steps**
 
 - Check Prometheus logs for messages related to configuration loading.
-- Ensure any [custom configuration you have provided Prometheus](https://sourcegraph.com/docs/admin/observability/metrics#prometheus-configuration) is valid.
+- Ensure any [custom configuration you have provided Prometheus](/self-hosted/observability/metrics#prometheus-configuration) is valid.
 - More help interpreting this metric is available in the [dashboards reference](dashboards#prometheus-prometheus_config_status).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -5962,7 +5962,7 @@ Generated query for warning alert: `min((prometheus_config_last_reload_successfu
 
 **Next steps**
 
-- Ensure that your [`observability.alerts` configuration](https://sourcegraph.com/docs/admin/observability/alerting#setting-up-alerting) (in site configuration) is valid.
+- Ensure that your [`observability.alerts` configuration](/self-hosted/observability/alerting#setting-up-alerting) (in site configuration) is valid.
 - More help interpreting this metric is available in the [dashboards reference](dashboards#prometheus-alertmanager_config_status).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 

--- a/docs/self-hosted/observability/dashboards.mdx
+++ b/docs/self-hosted/observability/dashboards.mdx
@@ -4,7 +4,7 @@
 
 This document contains a complete reference on Sourcegraph's available dashboards, as well as details on how to interpret the panels and metrics.
 
-To learn more about Sourcegraph's metrics and how to view these dashboards, see [our metrics guide](https://sourcegraph.com/docs/admin/observability/metrics).
+To learn more about Sourcegraph's metrics and how to view these dashboards, see [our metrics guide](/self-hosted/observability/metrics).
 
 ## Frontend
 
@@ -16542,7 +16542,7 @@ max by (type) (ceil(rate(src_repo_perms_syncer_sync_errors_total[1m])))
 <p class="subtitle">Rate of users/repos scheduled for permissions sync</p>
 
 Indicates the per-minute rate at which users/repositories are scheduled for a permissions sync.
-More about repository permissions synchronization [here](https://sourcegraph.com/docs/admin/permissions/syncing#scheduling)
+More about repository permissions synchronization [here](/admin/permissions/syncing#scheduling)
 
 This panel has no related alerts.
 
@@ -26272,7 +26272,7 @@ sum by(job) (scrape_samples_post_metric_relabeling{job!=""})
 A high value here indicates Prometheus rule evaluation is taking longer than expected.
 It might indicate that certain rule groups are taking too long to evaluate, or Prometheus is underprovisioned.
 
-Rules that Sourcegraph ships with are grouped under `/sg_config_prometheus`. [Custom rules are grouped under `/sg_prometheus_addons`](https://sourcegraph.com/docs/admin/observability/metrics#prometheus-configuration).
+Rules that Sourcegraph ships with are grouped under `/sg_config_prometheus`. [Custom rules are grouped under `/sg_prometheus_addons`](/self-hosted/observability/metrics#prometheus-configuration).
 
 Refer to the [alerts reference](alerts#prometheus-prometheus_rule_eval_duration) for 1 alert related to this panel.
 
@@ -26296,7 +26296,7 @@ sum by(rule_group) (avg_over_time(prometheus_rule_group_last_duration_seconds[10
 
 <p class="subtitle">Failed prometheus rule evaluations over 5m by rule group</p>
 
-Rules that Sourcegraph ships with are grouped under `/sg_config_prometheus`. [Custom rules are grouped under `/sg_prometheus_addons`](https://sourcegraph.com/docs/admin/observability/metrics#prometheus-configuration).
+Rules that Sourcegraph ships with are grouped under `/sg_config_prometheus`. [Custom rules are grouped under `/sg_prometheus_addons`](/self-hosted/observability/metrics#prometheus-configuration).
 
 Refer to the [alerts reference](alerts#prometheus-prometheus_rule_eval_failures) for 1 alert related to this panel.
 

--- a/docs/self-hosted/updates/automatic.mdx
+++ b/docs/self-hosted/updates/automatic.mdx
@@ -10,7 +10,7 @@ The documentation below is preserved for users on Sourcegraph versions prior to 
 
 ## Historical Documentation (Sourcegraph 5.1 - 6.11.x)
 
-> Warning: Automatic upgrades to v5.10.0 will fail please upgrade to a v5.9.x version and perform a standard upgrade instead! See our [postgres 12 end of life](https://sourcegraph.com/docs/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice! This is one of the reasons the "Auto Upgrade" toggle is automatically turned off after a version change. This behavior is intentional—it’s designed to prevent users from unintentionally performing multi-version upgrades (MVUs) that span critical changes, such as major infrastructure updates like a PostgreSQL version upgrade.
+> Warning: Automatic upgrades to v5.10.0 will fail please upgrade to a v5.9.x version and perform a standard upgrade instead! See our [postgres 12 end of life](/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice! This is one of the reasons the "Auto Upgrade" toggle is automatically turned off after a version change. This behavior is intentional—it’s designed to prevent users from unintentionally performing multi-version upgrades (MVUs) that span critical changes, such as major infrastructure updates like a PostgreSQL version upgrade.
 
 From **Sourcegraph 5.1 through 6.11.x**, multi-version upgrades could be performed **automatically** as if they were a standard upgrade for the same deployment type. Automatic multi-version upgrades took the following general form:
 

--- a/docs/technical-changelog.mdx
+++ b/docs/technical-changelog.mdx
@@ -5455,9 +5455,9 @@ There were no reverts for this release
 > If you are required to continue on 6.0 release series, please upgrade to 6.0 Patch 2.
 
 > Attention - Postgres 12 is no longer supported! If upgrading from Sourcegraph version 5.9 or earlier, this release will update our included database container images from Postgres 12 to Postgres 16.
-> Customers are advised to have a database backup before upgrading. See our [postgres 12 end of life](https://sourcegraph.com/docs/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice for more information.
+> Customers are advised to have a database backup before upgrading. See our [postgres 12 end of life](/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice for more information.
 >
-> Also be sure to check your deployment type's [upgrade notes](http://sourcegraph.com/docs/admin/updates#instance-specific-procedures)!
+> Also be sure to check your deployment type's [upgrade notes](/self-hosted/updates#instance-specific-procedures)!
 
 ## v6.0.0
 
@@ -6148,9 +6148,9 @@ The following PRs were merged onto the previous release branch but could not be 
 # 5.11 Patch 5
 
 > Attention - If upgrading from Sourcegraph version 5.9 or earlier, this release will update our included database container images from Postgres 12 to Postgres 16.
-> Customers are advised to have a database backup before upgrading. See our [postgres 12 end of life](https://sourcegraph.com/docs/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice for more information.
+> Customers are advised to have a database backup before upgrading. See our [postgres 12 end of life](/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice for more information.
 >
-> Also be sure to check your deployment type's [upgrade notes](http://sourcegraph.com/docs/admin/updates#instance-specific-procedures)!
+> Also be sure to check your deployment type's [upgrade notes](/self-hosted/updates#instance-specific-procedures)!
 
 ## v5.11.6271
 
@@ -6181,9 +6181,9 @@ There were no reverts for this release
 # 5.11 Patch 4
 
 > Attention - If upgrading from Sourcegraph version 5.9 or earlier, this release will update our included database container images from Postgres 12 to Postgres 16.
-> Customers are advised to have a database backup before upgrading. See our [postgres 12 end of life](https://sourcegraph.com/docs/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice for more information.
+> Customers are advised to have a database backup before upgrading. See our [postgres 12 end of life](/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice for more information.
 >
-> Also be sure to check your deployment type's [upgrade notes](http://sourcegraph.com/docs/admin/updates#instance-specific-procedures)!
+> Also be sure to check your deployment type's [upgrade notes](/self-hosted/updates#instance-specific-procedures)!
 
 ## v5.11.5234
 
@@ -6223,9 +6223,9 @@ There were no reverts for this release
 # 5.11 Patch 3
 
 > Attention - If upgrading from Sourcegraph version 5.9 or earlier, this release will update our included database container images from Postgres 12 to Postgres 16.
-> Customers are advised to have a database backup before upgrading. See our [postgres 12 end of life](https://sourcegraph.com/docs/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice for more information.
+> Customers are advised to have a database backup before upgrading. See our [postgres 12 end of life](/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice for more information.
 >
-> Also be sure to check your deployment type's [upgrade notes](http://sourcegraph.com/docs/admin/updates#instance-specific-procedures)!
+> Also be sure to check your deployment type's [upgrade notes](/self-hosted/updates#instance-specific-procedures)!
 
 ## v5.11.4013
 
@@ -6274,9 +6274,9 @@ There were no reverts for this release
 # 5.11 Patch 2
 
 > Attention - If upgrading from Sourcegraph version 5.9 or earlier, this release will update our included database container images from Postgres 12 to Postgres 16.
-> Customers are advised to have a database backup before upgrading. See our [postgres 12 end of life](https://sourcegraph.com/docs/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice for more information.
+> Customers are advised to have a database backup before upgrading. See our [postgres 12 end of life](/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice for more information.
 >
-> Also be sure to check your deployment type's [upgrade notes](http://sourcegraph.com/docs/admin/updates#instance-specific-procedures)!
+> Also be sure to check your deployment type's [upgrade notes](/self-hosted/updates#instance-specific-procedures)!
 
 ## v5.11.3601
 
@@ -6303,9 +6303,9 @@ There were no reverts for this release
 # 5.11 Patch 1
 
 > Attention - If upgrading from Sourcegraph version 5.9 or earlier, this release will update our included database container images from Postgres 12 to Postgres 16.
-> Customers are advised to have a database backup before upgrading. See our [postgres 12 end of life](https://sourcegraph.com/docs/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice for more information.
+> Customers are advised to have a database backup before upgrading. See our [postgres 12 end of life](/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice for more information.
 >
-> Also be sure to check your deployment type's [upgrade notes](http://sourcegraph.com/docs/admin/updates#instance-specific-procedures)!
+> Also be sure to check your deployment type's [upgrade notes](/self-hosted/updates#instance-specific-procedures)!
 
 ## v5.11.2732
 
@@ -6340,9 +6340,9 @@ There were no reverts for this release
 # 5.11 Patch 0
 
 > Attention - If upgrading from Sourcegraph version 5.9 or earlier, this release will update our included database container images from Postgres 12 to Postgres 16.
-> Customers are advised to have a database backup before upgrading. See our [postgres 12 end of life](https://sourcegraph.com/docs/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice for more information.
+> Customers are advised to have a database backup before upgrading. See our [postgres 12 end of life](/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice for more information.
 >
-> Also be sure to check your deployment type's [upgrade notes](http://sourcegraph.com/docs/admin/updates#instance-specific-procedures)!
+> Also be sure to check your deployment type's [upgrade notes](/self-hosted/updates#instance-specific-procedures)!
 
 ## v5.11.0
 
@@ -6894,9 +6894,9 @@ The following PRs were merged onto the previous release branch but could not be 
 
 # 5.10 Patch 3
 
-> Warning: This release updates the database container images from Postgres 12 to Postgres 16, and begins using Wolfi based images. Customers are advised to have a database backup before upgrading! See our [postgres 12 end of life](https://sourcegraph.com/docs/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice!
+> Warning: This release updates the database container images from Postgres 12 to Postgres 16, and begins using Wolfi based images. Customers are advised to have a database backup before upgrading! See our [postgres 12 end of life](/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice!
 >
-> Also be sure to check your deployment type's [upgrade notes](http://sourcegraph.com/docs/admin/updates#instance-specific-procedures)!
+> Also be sure to check your deployment type's [upgrade notes](/self-hosted/updates#instance-specific-procedures)!
 
 ## v5.10.3940
 
@@ -6931,9 +6931,9 @@ There were no reverts for this release
 
 # 5.10 Patch 2
 
-> Warning: This release updates the database container images from Postgres 12 to Postgres 16, and begins using Wolfi based images. Customers are advised to have a database backup before upgrading! See our [postgres 12 end of life](https://sourcegraph.com/docs/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice!
+> Warning: This release updates the database container images from Postgres 12 to Postgres 16, and begins using Wolfi based images. Customers are advised to have a database backup before upgrading! See our [postgres 12 end of life](/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice!
 >
-> Also be sure to check your deployment type's [upgrade notes](http://sourcegraph.com/docs/admin/updates#instance-specific-procedures)!
+> Also be sure to check your deployment type's [upgrade notes](/self-hosted/updates#instance-specific-procedures)!
 
 ## v5.10.2832
 
@@ -6995,11 +6995,11 @@ There were no reverts for this release
 
 # 5.10 Patch 1
 
-> Warning: This release updates the database container images from Postgres 12 to Postgres 16, and begins using Wolfi based images. Customers are advised to take a database backup before upgrading! See our [Postgres 12 end of life](https://sourcegraph.com/docs/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice!
+> Warning: This release updates the database container images from Postgres 12 to Postgres 16, and begins using Wolfi based images. Customers are advised to take a database backup before upgrading! See our [Postgres 12 end of life](/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice!
 >
 > Warning: `automatic` upgrades will require setting the environment variable `SRC_AUTOUPGRADE_IGNORE_DRIFT=true` on the `sourcegraph-frontend` deployment/container.
 >
-> Also be sure to check your deployment type's [upgrade notes](http://sourcegraph.com/docs/admin/updates#instance-specific-procedures)!
+> Also be sure to check your deployment type's [upgrade notes](/self-hosted/updates#instance-specific-procedures)!
 
 ## v5.10.1164
 
@@ -7039,11 +7039,11 @@ There were no reverts for this release
 
 > Warning: Admins are advised to upgrade directly to v5.10.1164 circumventing this release.
 >
-> Warning: This release updates the database container images from Postgres 12 to Postgres 16, and begins using Wolfi based images. Customers are advised to have a database backup before upgrading! See our [postgres 12 end of life](https://sourcegraph.com/docs/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice!
+> Warning: This release updates the database container images from Postgres 12 to Postgres 16, and begins using Wolfi based images. Customers are advised to have a database backup before upgrading! See our [postgres 12 end of life](/self-hosted/postgres12-end-of-life-notice#postgres-12-end-of-life) notice!
 >
 > Warning: `automatic` and migrator `upgrade` command will not work for this release, please upgrade directly to `v5.10.1164`, or to a 5.9 version and conduct a standard upgrade using migrator's default `up` command!
 >
-> Also be sure to check your deployment type's [upgrade notes](http://sourcegraph.com/docs/admin/updates#instance-specific-procedures)!
+> Also be sure to check your deployment type's [upgrade notes](/self-hosted/updates#instance-specific-procedures)!
 
 ## v5.10.0
 
@@ -9700,7 +9700,7 @@ The following PRs were merged onto the previous release branch but could not be 
 -   Search: remove smart search logic [#64215](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/64215)Smart search is no longer supported in the Sourcegraph backend. Old searches that specify 'smart search' mode will be run in the default 'precise' mode. If your query now doesn't behave as expected, you can update it to use the new `patterntype:keyword`.
 -   Search: update Zoekt [#64238](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/64238)
     -   Added support for all Apex language extensions
-    -   Shard merging for Zoekt is now enabled by default. This reduces MEM requirements for Zoekt webserver and improves performance for some queries. See our [documentation](https://sourcegraph.com/docs/admin/search#shard-merging) for more information.
+    -   Shard merging for Zoekt is now enabled by default. This reduces MEM requirements for Zoekt webserver and improves performance for some queries. See our [documentation](/admin/search#shard-merging) for more information.
 -   Search: Add support to all Apex language extensions [#64194](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/64194)
 -   Search: Enable improved symbol parsing for large repos (when using Rockskip) [#63988](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/63988)
 
@@ -9928,7 +9928,7 @@ The following PRs were merged onto the previous release branch but could not be 
 -   Consolidate mocks for dbworker/store.Store type [#64294](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/64294)
 -   Consolidate mocks for uploads's Store type [#64286](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/64286)
 -   Move cmd/frontend/oneclickexport to cmd/frontend/internal/oneclickexport [#64069](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/64069)
--   Move authn into cmd/frontend [#63648](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/63648)GitLab code host connections were [able to sync permissions by mapping Sourcegraph users to GitLab users via the username property of an external OIDC or SAML provider](https://sourcegraph.com/docs/admin/code-hosts/gitlab#administrator-sudo-level-access-token) that is shared across Sourcegraph and GitLab. This integration stopped working a long time ago, and it has been removed in this release.
+-   Move authn into cmd/frontend [#63648](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/63648)GitLab code host connections were [able to sync permissions by mapping Sourcegraph users to GitLab users via the username property of an external OIDC or SAML provider](/admin/code-hosts/gitlab#administrator-sudo-level-access-token) that is shared across Sourcegraph and GitLab. This integration stopped working a long time ago, and it has been removed in this release.
 -   Replace calls to deprecated ioutil.TempFile [#64177](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/64177)
 
 #### Svelte
@@ -10616,7 +10616,7 @@ The following PRs were merged onto the previous release branch but could not be 
     -   For perforce depots, support searching within a specific changelist by specifying a ref like `context:global repo:^repo/name$@changelist/83854`
 -   Introduce database fields for github apps - Batch changes integration, and update database layer [#63577](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/63577)
 -   Sg: sqlite-backed local store for sg analytics [#63578](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/63578)
--   Search: remove keyword toggle [#63584](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/63584)The keyword search toggle has been removed from the search results page. [Keyword search](https://sourcegraph.com/docs/code-search/queries#keyword-search-default) is now enabled by default for all searches in the Sourcegraph web app.
+-   Search: remove keyword toggle [#63584](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/63584)The keyword search toggle has been removed from the search results page. [Keyword search](/code-search/queries#keyword-search-default) is now enabled by default for all searches in the Sourcegraph web app.
 -   Sg: one-time oauth login to persist user email for analytics [#63603](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/63603)
 -   Cody: Expose Sg modelconfig data via HTTP REST API [#63604](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/63604)Sourcegraph instances how expose an HTTP endpoint that authenticated users can call to get a list of LLM models supported by the Sourcegraph instance. In the future this will be used to allow Cody users to select the LLM model dynamically, based on what is currently available.
 -   Batches: use "keyword" as default pattern type [#63613](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/63613)
@@ -11765,7 +11765,7 @@ The following PRs were merged onto the previous release branch but could not be 
 -   Search Jobs switches the format of downloaded results from CSV to JSON. [#59619](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/59619)
 -   [Search Jobs](/code-search/types/search-jobs) is now in beta and enabled by default. It can be disabled in the site configuration by setting `experimentalFeatures.searchJobs: false`.
 -   The search input on the search homepage is now automatically focused when the page loads.
--   GRPC is now the only method for our internal APIs, and can not be disabled. All of corresponding the REST implementations have been removed. The vast majority of customers upgrading to 5.3 don't need to take any action - The change should be invisible. However, if you have restrictions on Sourcegraph’s internal (service to service) traffic, some firewall or security configurations may be necessary. You can downgrade to Sourcegraph 5.2 and disable gRPC while you troubleshoot / reach out to our customer support team. See [https://sourcegraph.com/docs/admin/updates/grpc](https://sourcegraph.com/docs/admin/updates/grpc) for more details. [#59093](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/59093)
+-   GRPC is now the only method for our internal APIs, and can not be disabled. All of corresponding the REST implementations have been removed. The vast majority of customers upgrading to 5.3 don't need to take any action - The change should be invisible. However, if you have restrictions on Sourcegraph’s internal (service to service) traffic, some firewall or security configurations may be necessary. You can downgrade to Sourcegraph 5.2 and disable gRPC while you troubleshoot / reach out to our customer support team. See the [Sourcegraph 5.3 gRPC configuration guide](https://5.3.sourcegraph.com/admin/updates/grpc) for more details. [#59093](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/59093)
 -   The default `count:` for search has been increased to 10000, significantly increasing the number of searches that are exhaustive by default. [#60114](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/60114)
 
 ### Fixed


### PR DESCRIPTION
## What

Rewrites every link to this site that was written as an absolute URL (`https://sourcegraph.com/docs/…`, `http://sourcegraph.com/docs/…`, `https://docs.sourcegraph.com/…`) as a relative link (`/admin/config/site-config`), in 15 files.

- 32 pointed at the current route: prefix dropped.
- 31 pointed at a moved page and only worked through `src/data/redirects.ts`: now link straight to the destination.
- 4 needed a hand fix: the `commands#commands-id-mode` and `features#shard-merging` anchors no longer exist, `github#github-com-rate-limits` became `#rate-limits`, and the deleted gRPC guide now links to its archived 5.3 page.

## Why

Absolute links leave the Vercel preview and the local dev server, and hide moved pages behind redirects. #1858 makes `dev/check-links.mjs` fail PRs that add them; this PR clears the backlog so that check starts from zero.

## Verification

`node dev/check-links.mjs --check-anchors --root <this branch>` with the checker from #1858: 0 absolute self-links left, and no new findings against `main` (317 → 250 pre-existing findings; the 67 removed are all self-links).

## Notes for reviewers

- Bare URLs in prose and code blocks (e.g. the `See https://docs.sourcegraph.com/admin/observability/tracing` cells in `docs/cli/references/*`) are not links and are untouched; #1851 covers those.
- `docs/admin/repo/perforce.mdx`, `docs/self-hosted/observability/alerts.mdx` and `dashboards.mdx` are synced from sourcegraph/sourcegraph (#1883); the same links need the same fix upstream or the next sync reverts them.
- `docs/technical-changelog.mdx` holds 31 of the links and is retired by #1888; if that lands first, take the deletion.
