### PR TITLE
fix/site: Strip basePath from 404 page referrer link

### DIFF
--- a/src/components/NotFoundLinks.tsx
+++ b/src/components/NotFoundLinks.tsx
@@ -22,20 +22,35 @@ function nearestExistingAncestor(
 	return null;
 }
 
-// The page the user came from on a fresh page load, only when it is on this
-// site. document.referrer does not change on client-side navigations, so
-// those are covered by usePreviousPathname instead.
-function sameOriginReferrer(): URL | null {
+// Production serves the docs under /docs (basePath in next.config.js).
+const basePath = process.env.NEXT_PUBLIC_DOCS_BASE_PATH || '';
+
+interface PageLink {
+	href: string;
+	pathname: string;
+}
+
+// The docs page the user came from on a fresh page load. document.referrer
+// keeps the basePath, which next/link adds again, so strip it here; pages on
+// the same origin outside the docs (sourcegraph.com/pricing) do not count.
+// document.referrer does not change on client-side navigations, so those are
+// covered by usePreviousPathname instead.
+function docsReferrer(): PageLink | null {
 	if (!document.referrer) return null;
 	const referrer = new URL(document.referrer);
-	return referrer.origin === window.location.origin ? referrer : null;
+	if (referrer.origin !== window.location.origin) return null;
+	if (!referrer.pathname.startsWith(`${basePath}/`)) return null;
+	const pathname = referrer.pathname.slice(basePath.length);
+	// The home link already covers the root.
+	if (pathname === '/') return null;
+	return {href: pathname + referrer.search + referrer.hash, pathname};
 }
 
 export function NotFoundLinks({pagePaths}: {pagePaths: string[]}) {
 	const pathname = usePathname();
 	const previousPathname = usePreviousPathname();
 	const [ancestor, setAncestor] = useState<string | null>(null);
-	const [referrer, setReferrer] = useState<URL | null>(null);
+	const [referrer, setReferrer] = useState<PageLink | null>(null);
 	const pagePathSet = useMemo(() => new Set(pagePaths), [pagePaths]);
 
 	// Both values depend on the browser URL, which the statically prerendered
@@ -43,7 +58,7 @@ export function NotFoundLinks({pagePaths}: {pagePaths: string[]}) {
 	// mismatch.
 	useEffect(() => {
 		setAncestor(nearestExistingAncestor(pathname, pagePathSet));
-		setReferrer(sameOriginReferrer());
+		setReferrer(docsReferrer());
 	}, [pathname, pagePathSet]);
 
 	// The previous pathname may itself have been a 404.
@@ -54,14 +69,9 @@ export function NotFoundLinks({pagePaths}: {pagePaths: string[]}) {
 
 	// Prefer the in-app history over document.referrer, which goes stale on
 	// client-side navigations.
-	const backLink = previousPage
+	const backLink: PageLink | null = previousPage
 		? {href: previousPage, pathname: previousPage}
-		: referrer
-			? {
-					href: referrer.pathname + referrer.search + referrer.hash,
-					pathname: referrer.pathname
-				}
-			: null;
+		: referrer;
 
 	// Skip the up link when it would repeat the back link.
 	const upLink =

--- a/src/components/NotFoundLinks.tsx
+++ b/src/components/NotFoundLinks.tsx
@@ -33,7 +33,7 @@ interface PageLink {
 // The docs page the user came from on a fresh page load. document.referrer
 // keeps the basePath, which next/link adds again, so strip it here; pages on
 // the same origin outside the docs (sourcegraph.com/pricing) do not count.
-// document.referrer does not change on client-side navigations, so those are
+// document.referrer does not change on client-side navigation, so those are
 // covered by usePreviousPathname instead.
 function docsReferrer(): PageLink | null {
 	if (!document.referrer) return null;


### PR DESCRIPTION
Follow-up to #1887, found while smoke-testing production after today's merges.

## Problem

On production the 404 page's "Go back to" link (built from `document.referrer`) rendered as **Go back to /docs/cli** with href **/docs/docs/cli**. `document.referrer` keeps the `/docs` basePath and `next/link` adds it again. The same code would also link a same-origin non-docs referrer (`sourcegraph.com/pricing`) into the docs.

Vercel previews serve at the root with an empty basePath, so #1887's preview could not show this.

## Fix

Strip `NEXT_PUBLIC_DOCS_BASE_PATH` from the referrer pathname; ignore referrers outside the docs and the docs root (the home link already covers it).

## Verification

Local production build (`VERCEL_ENV=production pnpm build && pnpm start`, Node 20) checked with headless Chrome on `/docs/cli/references/prompts` (a removed page):

| Referrer | Before | After |
|---|---|---|
| `/docs/cli` | Go back to /docs/cli → `/docs/docs/cli` | Go back to /cli → `/docs/cli` |
| `/docs/cli?x=1` | – | Go back to /cli → `/docs/cli?x=1` |
| `/pricing` (same origin, not docs) | Go back to /pricing → `/docs/pricing` | no back link |
| `/docs/` (root) | Go back to /docs/ → `/docs/docs/` | no back link |
| none | no back link | no back link |

"Go up to /cli/references" and "Go back home" unchanged in every case. Client-side navigation to a 404 (which uses `usePreviousPathname`, not the referrer) was already correct on production and is untouched.

`npx tsc --noEmit` (my file clean; pre-existing `contentlayer/generated` errors before a build), `next lint`, and prettier pass.

## Amp thread

- [Merge PRs in series and smoke-test production](https://ampcode.com/threads/T-01a08e26-0c39-723b-95ad-65455002f541)

Co-authored-by: Amp <amp@ampcode.com>