### PR TITLE
Pin pnpm 10.25.0 and Node 20.x in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
 	"name": "sourcegraph-docs",
 	"version": "0.1.0",
 	"private": true,
+	"packageManager": "pnpm@10.25.0",
+	"engines": {
+		"node": "20.x"
+	},
 	"scripts": {
 		"dev": "next dev",
 		"build": "next build",


### PR DESCRIPTION
Vercel's build log says `Using pnpm@9.x based on project creation date`, while `.tool-versions` pins pnpm 10.25.0 and Node 20.19.6. Adding `packageManager` and `engines` makes Vercel (and Corepack) use the same versions as local development.

Verified locally with pnpm 10.25.0 / Node 20.19.6: `pnpm install --frozen-lockfile` and `pnpm build` both succeed. pnpm 10 skips dependency postinstall scripts by default (it lists contentlayer, esbuild, protobufjs, unrs-resolver as ignored); the build does not need any of them.

Watch the Vercel preview build log on this PR for `Using pnpm@10`.

Part of the Vercel audit in #1905 (task 3).
