### PR TITLE
Move static redirects out of middleware

### DIFF
--- a/dev/check-links.mjs
+++ b/dev/check-links.mjs
@@ -219,11 +219,11 @@ function buildPathMap() {
 	};
 }
 
-// Source route -> destination of src/data/redirects.ts. The middleware uses the
-// first rule whose source equals the requested path, so first entry wins here too.
+// Source route -> destination of src/data/redirects.js. The first rule whose
+// source equals the requested path wins here too.
 function loadRedirects() {
 	const redirects = new Map();
-	const source = fs.readFileSync(path.join(ROOT_DIR, 'src/data/redirects.ts'), 'utf-8');
+	const source = fs.readFileSync(path.join(ROOT_DIR, 'src/data/redirects.js'), 'utf-8');
 	const ruleRegex = /source:\s*(['"])(.*?)\1,\s*destination:\s*(['"])(.*?)\3/gs;
 	for (const [, , from, , to] of source.matchAll(ruleRegex)) {
 		if (!redirects.has(from)) redirects.set(from, to);

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,30 @@
 const {withContentlayer} = require('next-contentlayer');
 const {execSync} = require('child_process');
+const {updatedRedirectsData} = require('./src/data/redirects.js');
 /** @type {import('next').NextConfig} */
+
+function createStaticRedirects() {
+	const seenSources = new Set();
+	const redirects = [];
+
+	for (const redirect of updatedRedirectsData) {
+		if (
+			redirect.source.includes('#') ||
+			redirect.source.includes('?') ||
+			seenSources.has(redirect.source)
+		) {
+			continue;
+		}
+
+		seenSources.add(redirect.source);
+		redirects.push({...redirect, permanent: false});
+	}
+
+	return redirects;
+}
+
+const staticRedirects = createStaticRedirects();
+console.log(`Configured ${staticRedirects.length} static redirects`);
 
 const nextConfig = {
 	reactStrictMode: true,
@@ -15,7 +39,11 @@ const nextConfig = {
 	env: {
 		NEXT_PUBLIC_DOCS_BASE_PATH:
 			process.env.VERCEL_ENV === 'production' ? '/docs' : ''
-	}
+	},
+	redirects: async () => staticRedirects,
+	rewrites: async () => ({
+		beforeFiles: [{source: '/:path*.md', destination: '/api/md/:path*'}]
+	})
 };
 
 module.exports = async () => {

--- a/src/data/redirects.js
+++ b/src/data/redirects.js
@@ -1,5 +1,3 @@
-import {TECHNICAL_CHANGELOG_RSS_URL} from './constants';
-
 const redirectsData = [
 	{
 		source: '/integration/img/disable_extension.png',
@@ -5839,7 +5837,7 @@ const redirectsData = [
 	// This redirect preserves existing RSS subscriptions
 	{
 		source: '/technical-changelog.rss',
-		destination: TECHNICAL_CHANGELOG_RSS_URL
+		destination: 'https://sourcegraph.com/changelog/technical-changelog.rss'
 	},
 	// Self-hosted update pages moved to /changelog/self-hosted/
 	{

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,7 +4,7 @@ import docsConfig from '../docs.config.js';
 
 import {TECHNICAL_CHANGELOG_RSS_URL} from './data/constants';
 
-const {updatedRedirectsData} = require('./data/redirects.ts');
+const {updatedRedirectsData} = require('./data/redirects.js');
 
 function createRedirectUrl(
 	request: NextRequest,
@@ -58,24 +58,6 @@ function createRedirectUrl(
 export function middleware(request: NextRequest) {
 	const path = request.nextUrl.pathname;
 	const pathWithoutBase = path.replace('/docs', '');
-
-	// Handle .md suffix - return raw markdown
-	if (pathWithoutBase.endsWith('.md')) {
-		const docPath = pathWithoutBase.replace(/\.md$/, '');
-		const url = request.nextUrl.clone();
-		url.pathname = `/api/md${docPath}`;
-		return NextResponse.rewrite(url);
-	}
-
-	// Handle base redirects from redirects.ts
-	const redirect = updatedRedirectsData.find(
-		(r: any) => r.source === pathWithoutBase
-	);
-	if (redirect) {
-		return NextResponse.redirect(
-			createRedirectUrl(request, redirect.destination, path)
-		);
-	}
 
 	// Handle latest version without path - redirect to main docs
 	const latestVersionOnlyMatch = pathWithoutBase.match(
@@ -146,5 +128,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-	matcher: ['/((?!api/md|_next/static|_next/image|assets|favicon.ico|sw.js).*)']
+	matcher: ['/v/:path*', '/@:path*', '/changelog.rss']
 };


### PR DESCRIPTION
## What changed

- `next.config.js` now gives 732 static redirects to Next.js. Vercel serves these from its routing layer, so a redirect does not invoke a function.
- Middleware now matches only `/v/...`, `/@...`, and `/changelog.rss`. An ordinary page view no longer invokes the edge middleware or scans the redirects array.
- A `beforeFiles` rewrite handles `.md` requests without middleware.
- The redirects data is plain CommonJS so both Next config and middleware can load it.

## Request handling

Next.js checks a request in this order: headers → redirects → middleware → `beforeFiles` rewrites → filesystem routes → `afterFiles` rewrites → dynamic routes → fallback rewrites. Config redirects therefore finish before middleware and are deployed as Vercel routes rather than function code.

The matcher decides which requests can invoke middleware. Narrowing it removes one edge invocation from every ordinary page view while retaining code for version-aware and changelog redirects.

Next automatically prefixes redirect sources and relative destinations with `basePath`. Production therefore gets `/docs`; previews do not. The old middleware always added `/docs`, including on previews.

Redirects remain temporary: `permanent: false` produces 307, matching `NextResponse.redirect`. Changing these to permanent 308 redirects is a separate SEO decision.

## Route budget and filtering

Vercel permits 2,048 routes per deployment. The data module contains 1,324 rules. Configuration keeps the first duplicate source, matching the old `.find`, and removes 386 sources containing fragments plus 206 later duplicates. No query-string sources were present. The result is 732 configured redirects (733 in the manifest including Next's built-in base-path redirect).

Fragment sources cannot match because browsers do not send URL fragments to servers. No path-to-regexp-invalid source remained after filtering; `next build` accepted all 732 routes.

## Preview checks

Replace `$PREVIEW_URL` with the Vercel preview hostname:

```sh
curl -sI "$PREVIEW_URL/admin/tls_ssl"
curl -sI "$PREVIEW_URL/admin/config/site-config"
curl -sI "$PREVIEW_URL/admin/config/site-config.md"
curl -sI "$PREVIEW_URL/v/5.0/admin/tls_ssl"
curl -sI "$PREVIEW_URL/@5.0"
curl -sI "$PREVIEW_URL/changelog.rss"
```

Expect, respectively: 307 to `/self-hosted/http-https-configuration`; 200 HTML with no `x-middleware-*` headers; 200 `text/markdown`; 307 to the 5.0 site with the redirected path; 307 to the 5.0 site root; and 307 to the technical changelog feed.

Task 5c of the Vercel audit tracked in #1905. Note: this PR and the "run checks once" PR both edit `next.config.js`; whichever merges second needs a trivial rebase.
