### PR TITLE
check-links: don't fail the generated-docs sync PR over absolute self-links it can't fix

### DIFF
--- a/dev/check-links.mjs
+++ b/dev/check-links.mjs
@@ -13,7 +13,8 @@
  * - Invalid file paths
  * - With --check-self-links, absolute links to this site (https://sourcegraph.com/docs/...,
  *   the legacy https://docs.sourcegraph.com/... host, http://, //, www.), which
- *   should be relative links; the finding proposes one, following src/data/redirects.ts
+ *   should be relative links; the finding proposes one, following src/data/redirects.ts.
+ *   Files that sourcegraph/sourcegraph generates are exempt unless the target is missing
  * - With --check-external, external links on added lines that return 404 or 410
  *
  * next.config.js runs this with no flags on every build, so only dead page links
@@ -297,6 +298,16 @@ function relativeSelfLink(url) {
 	return anchor ? `${route}#${anchor}` : route;
 }
 
+// Files that doc/_generated.push.sh in sourcegraph/sourcegraph overwrites on every
+// sync, so a fix here is undone by the next sync PR. Their absolute self-links are
+// findings only when the target is missing; the repository that owns them is named.
+const UPSTREAM_GENERATED_REGEX =
+	/^(?:self-hosted\/observability\/(?:alerts|dashboards)\.mdx|cli\/references\/|cody\/capabilities\/supported-models\.mdx|admin\/telemetry\/(?:protocol|private-metadata-allowlist)\.mdx)/;
+
+function isUpstreamGenerated(currentFile) {
+	return UPSTREAM_GENERATED_REGEX.test(path.relative(DOCS_DIR, currentFile).replace(/\\/g, '/'));
+}
+
 // Absolute self-links break on preview deployments and local dev, and hide moved
 // pages behind redirects, so they are findings even when the target exists. The
 // fix is the relative link, following src/data/redirects.ts when the page moved.
@@ -304,18 +315,20 @@ function relativeSelfLink(url) {
 function validateSelfLink(url, currentFile, maps) {
 	const relative = relativeSelfLink(url);
 	const anchor = relative.split('#')[1];
+	const generated = isUpstreamGenerated(currentFile);
 	const visited = new Set();
 	let candidate = relative;
 	while (true) {
 		const moved = candidate === relative ? '' : ' to a moved page';
 		const problem = validateLink({ url: candidate }, currentFile, maps);
 		if (!problem) {
-			return { error: `Absolute self-link${moved}; use "${candidate}" instead`, fix: candidate };
+			return generated ? null : { error: `Absolute self-link${moved}; use "${candidate}" instead`, fix: candidate };
 		}
 		const destination = maps.redirects.get(candidate.split('#')[0]);
 		if (!destination || visited.has(destination)) {
 			const replaced = moved ? `; "${candidate}" replaced it, but` : ', and';
-			return { error: `Absolute self-link${moved}${replaced} ${problem[0].toLowerCase()}${problem.slice(1)}` };
+			const owner = generated ? ' (generated in sourcegraph/sourcegraph; fix it there)' : '';
+			return { error: `Absolute self-link${moved}${replaced} ${problem[0].toLowerCase()}${problem.slice(1)}${owner}` };
 		}
 		visited.add(destination);
 		candidate = isSelfLink(destination) ? relativeSelfLink(destination) : destination;


### PR DESCRIPTION
## Why

#1858 added the `Check links` job (`--check-anchors --check-self-links`), and #1899 rewrote the absolute `https://sourcegraph.com/docs/…` links in the generated observability/telemetry pages to relative ones. The sync bot ([`doc/_generated.push.sh`](https://github.com/sourcegraph/sourcegraph/blob/main/doc/_generated.push.sh)) regenerates those files from Go sources that still contain the absolute links, so its next push to `sync/generated-docs` (#1883) reintroduces them, and the job flags each one as new against `main`.

Replaying the bot's output (#1883 head `80fb54e4`, applied over `main`) through the job's exact command gives exit 1 with **26 findings**, all "Absolute self-link" in `alerts.mdx`, `dashboards.mdx`, `protocol.mdx` and `private-metadata-allowlist.mdx`. Nothing in this repo can make that go green: the fix belongs in the generators.

## What

In the files `_generated.push.sh` overwrites (`self-hosted/observability/{alerts,dashboards}.mdx`, `cli/references/**`, `cody/capabilities/supported-models.mdx`, `admin/telemetry/{protocol,private-metadata-allowlist}.mdx`), an absolute self-link is a finding only when its (redirect-followed) target is missing, and the message says `(generated in sourcegraph/sourcegraph; fix it there)`. Everywhere else the check is unchanged. `next build` runs without `--check-self-links`, so deploys are unaffected.

## Verification

- Same replay with this branch: 26 → **2** findings, both real dead anchors in upstream source (`monitoring/definitions/worker.go` → `/admin/code-hosts/github#github-com-rate-limits`, `zoekt.go` → `/code-search/features#shard-merging`). Upstream fix: sourcegraph/sourcegraph PR to follow.
- `node dev/check-links.mjs --check-anchors --check-self-links --format json` on this branch vs `main`: 248 findings each, 0 new, 0 removed.
- `npx tsc --noEmit` passes.

<!-- pr-stack-merge-order -->
## Merge order for the PR-check stack

Trial-merged onto `main` in this order with no conflicts:

1. #1918 Vercel build log comment — independent; first so the other PRs' Vercel failures get a readable log
2. #1916 check-links report format — adds `dev/sync-review-comments.sh`, which #1880 calls
3. #1880 redirect check — needs #1916 merged first
4. #1919 spell check comment updates — independent
5. #1910 check-links, generated-docs sync PR — conflicts with #1916 on `dev/check-links.mjs`; rebase after #1916 merges

Squash-merge each, then rebase the next onto `main`.

#1920 (broken) and #1921 (fixed) are the example PRs that exercise every check; never merge, close them once the stack has landed.
