### PR TITLE
cspell: drop resolved allow-list entries, allow words that escaped the PR check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,9 +46,6 @@ next-env.d.ts
 # We ignore the generated file as it should always be generated
 public/changelog.rss
 
-# script output
-/logs
-
 # env file
 .env
 
@@ -57,4 +54,5 @@ public/changelog.rss
 
 public/technical-changelog.rss
 
+# script output
 logs/

--- a/cspell-allow-list.txt
+++ b/cspell-allow-list.txt
@@ -13,17 +13,9 @@ VXNlcjox
 # Base64-encoded GraphQL ID "SearchJob:1"
 U2VhcmNoSm9iOjY5
 
-# base64 for `RegistryExtension:` in synced / generated file `docs/cli/references/extensions/delete.mdx`
-# The twist is that the command it documents doesn't exist anymore
-# TODO: Delete docs for commands which no longer exist
-# TODO: Remove after merging
-UmVnaXN0cnlFeHRlbnNpb246
-
 # Fragments of truncated shell output in examples
 actr
 autol
-eror    # TODO: Remove after merging 1884
-functio # TODO: Remove after merging 1885
 ified
 mtok
 pousr
@@ -188,6 +180,7 @@ dumpall
 eastus
 eksctl
 ELEC
+elif
 emailaddress
 encrypter
 Enry
@@ -345,6 +338,7 @@ myteam
 myvalue
 nameid
 nameopt
+navigations
 NETRC
 nodeport
 noeviction
@@ -395,6 +389,7 @@ pgbouncer
 pgcrypto
 PGDATABASE
 PGDATASOURCE
+pgdump
 PGHOST
 PGPASSWORD
 PGPORT
@@ -412,6 +407,7 @@ pooler
 PREEMPTIBLE
 preg
 premade
+prerendered
 Príncipe
 privkey
 projectname
@@ -479,6 +475,7 @@ showcerts
 SIEM
 sigalg
 SLES
+slurpfile
 Snek
 snekpm
 somerandom
@@ -498,6 +495,7 @@ standardly
 starcoder
 Starlark
 startedat
+startswith
 statefulsets
 stepscontainer
 stepsenv
@@ -582,6 +580,7 @@ vegeta
 vercel
 Verilog
 VHDL
+Viktor
 vscodesourcegraph
 waitlist
 Weaveworks
@@ -589,6 +588,7 @@ winsize
 workspacesin
 workspacesonlyfetchworkspace
 workspacesrootatlocationof
+worktree
 XGET
 xlarge
 yourorgname


### PR DESCRIPTION
## Why

Follow-up to #1853.

- Three allow-list entries carried `TODO: remove after merging` notes that are now resolved: `eror` (#1884), `functio` (#1885), and the `RegistryExtension:` base64 ID that only occurred in `cli/references/extensions/delete.mdx`, deleted in #1886.
- #1858 and #1887 merged before the spellcheck workflow existed, and #1889's checks ran before #1853 merged, so `npx cspell@10 --no-progress --dot '**/*'` on `main` reports 12 words in 6 files (`worktree`, `startswith`, `elif`, `slurpfile` in `check-links.yml`; `navigations`, `prerendered` in the 404 components; `Viktor`, `pgdump` in the new CLI pages). The PR check only looks at added lines, so these would never surface again; they are allowed so a full run is clean.
- `.gitignore` had both `/logs` (#1898) and `logs/` (#1853); kept the broader one with its comment.

## Verification

- `npx cspell@10 --no-progress --dot '**/*'`: `main` → 12 issues in 6 files; this branch → 0.
- The removed words no longer occur anywhere in `docs/` or `src/` (checked with `rg`).
