### PR TITLE
site/api-md: Prerender markdown routes at build time; enable Fluid compute

### DIFF
--- a/src/app/api/md/[...slug]/route.ts
+++ b/src/app/api/md/[...slug]/route.ts
@@ -1,8 +1,19 @@
 import {allPosts} from 'contentlayer/generated';
-import {NextRequest, NextResponse} from 'next/server';
+import {NextResponse} from 'next/server';
+
+// Prerender every post's markdown at build time; unknown slugs 404 without
+// invoking a function.
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+	// The root index.mdx has an empty path; a catch-all needs at least one segment.
+	return allPosts
+		.filter(post => post._raw.flattenedPath !== '')
+		.map(post => ({slug: post._raw.flattenedPath.split('/')}));
+}
 
 export async function GET(
-	_: NextRequest,
+	_: Request,
 	{params}: {params: {slug: string[]}}
 ) {
 	const docPath = params.slug.join('/');

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
 	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"fluid": true,
 	"ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ':(exclude).github' ':(exclude).agents' ':(exclude).amp' ':(exclude).vscode' ':(exclude)AGENTS.md' ':(exclude)README.md' ':(exclude).gitignore' ':(exclude)cspell*'"
 }


### PR DESCRIPTION
Vercel audit items 5a and 5b (see #1905, `dev/TODO.md` item 5). Stacked on #1901 because both edit `vercel.json`; merge #1901 first, then retarget this to `main`.

## What changes

**`/api/md/[...slug]`** (serves `<page>.md`, which the middleware rewrites to this route):
- `generateStaticParams()` returns every post's slug, so Next writes each markdown response to disk during `next build` (`.next/server/app/api/md/**/*.body`). Vercel serves those from the CDN: no function invocation, no cold start.
- `dynamicParams = false` makes unknown slugs 404 at the edge without invoking a function. Behaviour change: an unknown `.md` URL now gets the site's HTML 404 page (like any other unknown URL) instead of the plain-text `Not Found` the function used to return.
- The root `index.mdx` is skipped: its flattened path is empty and a catch-all needs at least one segment. `/api/md` was never a valid URL for this route; the first build attempt failed on exactly that.

**`vercel.json`**: `"fluid": true` turns on [Fluid compute](https://vercel.com/docs/fluid-compute) for the remaining functions (`/api/og/[...path]`, the `[...slug]` page renderer for non-prerendered paths). Fluid lets one instance handle many concurrent requests instead of one cold start per request, and bills active CPU time rather than wall-clock. Memory/CPU size still lives in the dashboard (Settings → Functions), not in `vercel.json`.

## Verification (local)

- `pnpm build`: `/api/md/[...slug]` shows as `●` (SSG) with ~500 paths; build time unchanged (about 40 s locally).
- `pnpm start`, then:
  - `/api/md/admin/config/site-config` → 200 `text/markdown`, 47 902 B
  - `/api/md/cli/references/auth` → 200 `text/markdown`, body starts with `# src auth`
  - `/api/md/does/not/exist` → 404

## Verification (after the preview deploys)

Compare against production for the same URL:

```sh
for u in https://sourcegraph.com/docs/admin/config/site-config.md <preview>/docs/admin/config/site-config.md; do
  curl -so /dev/null -w '%{http_code} %{time_total}s\n' -D - "$u" | grep -iE 'x-vercel-cache|^[0-9]{3} '
done
```

Expect the preview to answer with `x-vercel-cache: HIT` (or `PRERENDER`) and a faster `time_total` on cold paths. For `/api/og/...`, expect similar or better latency under Fluid; nothing should be slower.
