### PR TITLE
spell check: update inline comments whose text changed

### DIFF
--- a/dev/post-spelling-review.mjs
+++ b/dev/post-spelling-review.mjs
@@ -258,6 +258,14 @@ async function syncInlineComments(findings) {
 			continue;
 		}
 		if (wanted.has(key)) {
+			const body = inlineBody(wanted.get(key));
+			if (body !== comment.body) {
+				await githubWrite(
+					'PATCH',
+					`/repos/${REPOSITORY}/pulls/comments/${comment.id}`,
+					{body}
+				);
+			}
 			wanted.delete(key);
 		} else {
 			await githubWrite(


### PR DESCRIPTION
Follow-up to #1917. The inline-comment sync matches comments by marker (file, line, word), so a wording change never reached a comment that was already posted; it kept the old text until the finding went away. Now a comment whose body differs from what we would post is updated in place.

<!-- pr-stack-merge-order -->
## Merge order for the PR-check stack

Trial-merged onto `main` in this order with no conflicts:

1. #1918 Vercel build log comment — independent; first so the other PRs' Vercel failures get a readable log
2. #1916 check-links report format — adds `dev/sync-review-comments.sh`, which #1880 calls
3. #1880 redirect check — needs #1916 merged first
4. #1919 spell check comment updates — independent
5. #1910 check-links, generated-docs sync PR — conflicts with #1916 on `dev/check-links.mjs`; rebase after #1916 merges

Squash-merge each, then rebase the next onto `main`.

#1920 (broken) and #1921 (fixed) are the example PRs that exercise every check; never merge, close them once the stack has landed.
