### PR TITLE
fix/links: Fix broken heading links (44 reworded, self-hosted)

### DIFF
--- a/docs/self-hosted/deploy/docker-compose/operations.mdx
+++ b/docs/self-hosted/deploy/docker-compose/operations.mdx
@@ -97,7 +97,7 @@ docker exec codeinsights-db sh -c 'pg_dump -C --clean --if-exists --username pos
 
 ### Restore Sourcegraph databases into a new environment
 
-The following instructions apply **only if you are restoring your databases into a new deployment** of Sourcegraph ie: a new virtual machine. If you are restoring a previously running environment, see the instructions for [restoring a previously running deployment](#restoring-sourcegraph-databases-into-an-existing-environment)
+The following instructions apply **only if you are restoring your databases into a new deployment** of Sourcegraph ie: a new virtual machine. If you are restoring a previously running environment, see the instructions for [restoring a previously running deployment](#restore-sourcegraph-databases-into-an-existing-environment)
 
 1\. Copy the database dump files into the `deploy-sourcegraph-docker/docker-compose` directory.
 

--- a/docs/self-hosted/deploy/docker-compose/upgrade.mdx
+++ b/docs/self-hosted/deploy/docker-compose/upgrade.mdx
@@ -11,7 +11,7 @@ This document describes the process to update a Docker Compose Sourcegraph insta
 
 A [standard upgrade](/self-hosted/updates/#upgrade-types) occurs between a Sourcegraph version and the minor or major version released immediately after it. If you would like to jump forward several versions, you must perform a [multi-version upgrade](#multi-version-upgrades) instead.
 
-If you've [configured Docker Compose with a release branch](/self-hosted/deploy/docker-compose/#step-1-prepare-the-deployment-repository), please merge the upstream release tag for the next minor version into your `release` branch.
+If you've [configured Docker Compose with a release branch](/self-hosted/deploy/docker-compose#step-1-fork-the-deployment-repository), please merge the upstream release tag for the next minor version into your `release` branch.
 
 In the following example, the release branch is being upgraded to <CURRENT_VERSION_STRING />.
 

--- a/docs/self-hosted/deploy/kubernetes/azure.mdx
+++ b/docs/self-hosted/deploy/kubernetes/azure.mdx
@@ -47,7 +47,7 @@ Connect to the cluster for future `kubectl` commands:
 az aks get-credentials --resource-group sourcegraphResourceGroup --name sourcegraphCluster
 ```
 
-Follow the [Sourcegraph cluster installation instructions](/self-hosted/deploy/kubernetes/configure#configure-a-storage-class) with `storageClass` set to `managed-premium` in `config.json`:
+Follow the [Sourcegraph cluster installation instructions](/self-hosted/deploy/kubernetes/configure#storage-class) with `storageClass` set to `managed-premium` in `config.json`:
 
 ```diff
 -    "storageClass": "default"

--- a/docs/self-hosted/deploy/kubernetes/configure.mdx
+++ b/docs/self-hosted/deploy/kubernetes/configure.mdx
@@ -20,9 +20,9 @@ This guide will demonstrate how to customize a Kubernetes deployment (**non-Helm
 
 ## Overview
 
-To ensure optimal performance and functionality of your Sourcegraph deployment, please only include components listed in the [kustomization.template.yaml file](/self-hosted/deploy/kubernetes/kustomize/#kustomization-yaml) for your instance overlay. These components include settings that have been specifically designed and tested for Sourcegraph and do not require any additional configuration changes.
+To ensure optimal performance and functionality of your Sourcegraph deployment, please only include components listed in the [kustomization.template.yaml file](/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) for your instance overlay. These components include settings that have been specifically designed and tested for Sourcegraph and do not require any additional configuration changes.
 
-The order of components listed in the [kustomization.template.yaml file](/self-hosted/deploy/kubernetes/kustomize/#kustomization-yaml) is important and should be maintained. The components are listed in a specific order to ensure proper dependency management and compatibility between components. Reordering components can introduce conflicts or prevent components from interacting as expected. Only modify the component order if explicitly instructed to do so by the documentation. Otherwise, leave the component order as-is to avoid issues.
+The order of components listed in the [kustomization.template.yaml file](/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) is important and should be maintained. The components are listed in a specific order to ensure proper dependency management and compatibility between components. Reordering components can introduce conflicts or prevent components from interacting as expected. Only modify the component order if explicitly instructed to do so by the documentation. Otherwise, leave the component order as-is to avoid issues.
 
 Following these guidelines will help you create a seamless deployment and avoid conflicts.
 
@@ -45,7 +45,7 @@ To enable cluster metrics monitoring, you will need to [deploy cAdvisor](#deploy
 
 ### RBAC
 
-Sourcegraph has removed Role-Based Access Control (RBAC) resources from the default base cluster for the Kustomize deployment. This means that [service discovery](#service-discovery) is not enabled by default, and the endpoints for each service replica must be manually added to the frontend ConfigMap. When using the [size components](#instance-size-based-resources) included in the [kustomization file built for Sourcegraph](/self-hosted/deploy/kubernetes/kustomize/#kustomization-yaml), service endpoints are automatically added to the ConfigMap.
+Sourcegraph has removed Role-Based Access Control (RBAC) resources from the default base cluster for the Kustomize deployment. This means that [service discovery](#service-discovery) is not enabled by default, and the endpoints for each service replica must be manually added to the frontend ConfigMap. When using the [size components](#instance-size-based-resources) included in the [kustomization file built for Sourcegraph](/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files), service endpoints are automatically added to the ConfigMap.
 
 ### Non-Privileged
 
@@ -550,7 +550,7 @@ components:
     - ../../components/storage-class/name-update
 ```
 
-**Step 2**: Enter the value of your existing storage class name in your [buildConfig.yaml file](/self-hosted/deploy/kubernetes/kustomize#buildconfig-yaml) using the `STORAGECLASS_NAME` config key
+**Step 2**: Enter the value of your existing storage class name in your [buildConfig.yaml file](/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) using the `STORAGECLASS_NAME` config key
 
 Example, add `STORAGECLASS_NAME=sourcegraph` if `sourcegraph` is the name for the existing storage class:
 
@@ -577,7 +577,7 @@ components:
     - ../../components/storage-class/name-update
 ```
 
-**Step 2**: Enter the value of your existing storage class name in your [buildConfig.yaml](/self-hosted/deploy/kubernetes/kustomize/#buildconfig-yaml) file using the `STORAGECLASS_NAME` config key
+**Step 2**: Enter the value of your existing storage class name in your [buildConfig.yaml](/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) file using the `STORAGECLASS_NAME` config key
 
 Example, set `STORAGECLASS_NAME=sourcegraph` if `sourcegraph` is the name for the existing storage class:
 
@@ -601,7 +601,7 @@ components:
     - ../../components/storage-class/cloud
 ```
 
-Update the following variables in your [buildConfig.yaml](/self-hosted/deploy/kubernetes/kustomize/#buildconfig-yaml) file. Replace them with the correct values according to the instructions provided by your cloud provider:
+Update the following variables in your [buildConfig.yaml](/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) file. Replace them with the correct values according to the instructions provided by your cloud provider:
 
 ```yaml
 # instances/$INSTANCE_NAME/buildConfig.yaml
@@ -693,7 +693,7 @@ data:
 # the data is abbreviated in this example
 ```
 
-**Step 3**: Configure the TLS settings of your Ingress by adding the following variables to your [buildConfig.yaml](/self-hosted/deploy/kubernetes/kustomize/#buildconfig-yaml) file:
+**Step 3**: Configure the TLS settings of your Ingress by adding the following variables to your [buildConfig.yaml](/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) file:
 
 - **TLS_HOST**: your domain name
 - **TLS_INGRESS_CLASS_NAME**: ingress class name required by your cluster-issuer
@@ -783,7 +783,7 @@ components:
 
 To configure the hostname for your Sourcegraph ingress, follow these steps:
 
-**Step 1**: In your [buildConfig.yaml](/self-hosted/deploy/kubernetes/kustomize/#buildconfig-yaml) file, include the `HOST_DOMAIN` variable and set it to your desired hostname, for example:
+**Step 1**: In your [buildConfig.yaml](/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) file, include the `HOST_DOMAIN` variable and set it to your desired hostname, for example:
 
 ```yaml
 # instances/$INSTANCE_NAME/buildConfig.yaml
@@ -955,7 +955,7 @@ components:
 
 ### Frontend
 
-To update the environment variables for the **sourcegraph-frontend** service, add the new environment variables to the end of the _FRONTEND ENV VARS_ section at the bottom of your [kustomization file](/self-hosted/deploy/kubernetes/kustomize/#kustomizationyaml). For example:
+To update the environment variables for the **sourcegraph-frontend** service, add the new environment variables to the end of the _FRONTEND ENV VARS_ section at the bottom of your [kustomization file](/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files). For example:
 
 ```yaml
 # instances/$INSTANCE_NAME/kustomization.yaml
@@ -1065,7 +1065,7 @@ Similar changes will be required for other pods and services, depending on the s
 
 For optimal performance and resilience, it is recommended to use an external database when deploying Sourcegraph. For more information on database requirements, please refer to the [Postgres guide](/self-hosted/postgres).
 
-To connect Sourcegraph to an existing PostgreSQL instance, add the relevant environment variables ([such as PGHOST, PGPORT, PGUSER, etc.](http://www.postgresql.org/docs/current/static/libpq-envars.html)) to the frontend ConfigMap by adding the new environment variables to the end of the _FRONTEND ENV VARS_ section at the bottom of your [kustomization file](/self-hosted/deploy/kubernetes/kustomize/#kustomizationyaml). For example:
+To connect Sourcegraph to an existing PostgreSQL instance, add the relevant environment variables ([such as PGHOST, PGPORT, PGUSER, etc.](http://www.postgresql.org/docs/current/static/libpq-envars.html)) to the frontend ConfigMap by adding the new environment variables to the end of the _FRONTEND ENV VARS_ section at the bottom of your [kustomization file](/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files). For example:
 
 ```yaml
 # instances/$INSTANCE_NAME/kustomization.yaml
@@ -1235,7 +1235,7 @@ components:
     - ../../components/enable/private-registry
 ```
 
-**Step 2:** Set the `PRIVATE_REGISTRY` variable in your [buildConfig.yaml](/self-hosted/deploy/kubernetes/kustomize/#buildconfig-yaml) file. For example:
+**Step 2:** Set the `PRIVATE_REGISTRY` variable in your [buildConfig.yaml](/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) file. For example:
 
 ```yaml
 # instances/$INSTANCE_NAME/buildConfig.yaml
@@ -1255,7 +1255,7 @@ components:
     - ../../components/resources/imagepullsecrets
 ```
 
-**Step 2:** Set the `IMAGE_PULL_SECRET_NAME` variable in your [buildConfig.yaml](/self-hosted/deploy/kubernetes/kustomize/#buildconfig-yaml) file.
+**Step 2:** Set the `IMAGE_PULL_SECRET_NAME` variable in your [buildConfig.yaml](/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) file.
 
 For example:
 
@@ -1285,7 +1285,7 @@ patches:
 
 ## Multi-version upgrade
 
-In order to perform a [multi-version upgrade](/self-hosted/updates/#multi-version-upgrades), all pods must be scaled down to 0 except databases, which can be handled by including the `utils/multi-version-upgrade` component:
+In order to perform a [multi-version upgrade](/self-hosted/updates#upgrade-types), all pods must be scaled down to 0 except databases, which can be handled by including the `utils/multi-version-upgrade` component:
 
 ```yaml
 # instances/$INSTANCE_NAME/kustomization.yaml

--- a/docs/self-hosted/deploy/kubernetes/kustomize.mdx
+++ b/docs/self-hosted/deploy/kubernetes/kustomize.mdx
@@ -66,7 +66,7 @@ Create a copy of the [instances/template](/self-hosted/deploy/kubernetes/kustomi
 
 ### **Step 3**: Set up the configuration files
 
-**1.** Rename the [kustomization.template.yaml](/self-hosted/deploy/kubernetes/kustomize/#kustomization-yaml) file in `instances/my-sourcegraph` to `kustomization.yaml`.
+**1.** Rename the [kustomization.template.yaml](/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) file in `instances/my-sourcegraph` to `kustomization.yaml`.
 
 -   The `kustomization.yaml` file is used to configure your Sourcegraph instance.
 
@@ -74,7 +74,7 @@ Create a copy of the [instances/template](/self-hosted/deploy/kubernetes/kustomi
   $ mv instances/my-sourcegraph/kustomization.template.yaml instances/my-sourcegraph/kustomization.yaml
 ```
 
-**2.** Rename the [buildConfig.template.yaml](/self-hosted/deploy/kubernetes/kustomize/#buildconfig-yaml) file in `instances/my-sourcegraph` to `buildConfig.yaml`.
+**2.** Rename the [buildConfig.template.yaml](/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) file in `instances/my-sourcegraph` to `buildConfig.yaml`.
 
 -   The `buildConfig.yaml` file is used to configure components included in your `kustomization` file if required.
 

--- a/docs/self-hosted/deploy/kubernetes/kustomize/eks.mdx
+++ b/docs/self-hosted/deploy/kubernetes/kustomize/eks.mdx
@@ -126,7 +126,7 @@ components:
     - ../../components/clusters/aws/managed-cert
 ```
 
-Step 2: Set the `AWS_MANAGED_CERT_ARN` variable with the `ARN of your AWS-managed TLS certificate` under the [BUILD CONFIGURATIONS](/self-hosted/deploy/kubernetes/kustomize/#buildconfig-yaml) section:
+Step 2: Set the `AWS_MANAGED_CERT_ARN` variable with the `ARN of your AWS-managed TLS certificate` under the [BUILD CONFIGURATIONS](/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) section:
 
 ```yaml
 # instances/$INSTANCE_NAME/buildConfig.yaml

--- a/docs/self-hosted/deploy/kubernetes/kustomize/gke.mdx
+++ b/docs/self-hosted/deploy/kubernetes/kustomize/gke.mdx
@@ -129,7 +129,7 @@ components:
     - ../../components/clusters/gke/managed-cert
 ```
 
-Step 2: Set the `GKE_MANAGED_CERT_NAME` variable with your Google-managed certificate name under the [BUILD CONFIGURATIONS](/self-hosted/deploy/kubernetes/kustomize#buildconfig-yaml) section:
+Step 2: Set the `GKE_MANAGED_CERT_NAME` variable with your Google-managed certificate name under the [BUILD CONFIGURATIONS](/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) section:
 
 ```yaml
 # instances/$INSTANCE_NAME/buildConfig.yaml

--- a/docs/self-hosted/deploy/kubernetes/kustomize/migrate.mdx
+++ b/docs/self-hosted/deploy/kubernetes/kustomize/migrate.mdx
@@ -75,7 +75,7 @@ Create a copy of the [instances/template](/self-hosted/deploy/kubernetes/kustomi
 
 The `kustomization.yaml` file is used to configure your Sourcegraph instance.
 
-**1.** Rename the [kustomization.template.yaml](/self-hosted/deploy/kubernetes/kustomize/#kustomization-yaml) file in `instances/my-sourcegraph` to `kustomization.yaml`.
+**1.** Rename the [kustomization.template.yaml](/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) file in `instances/my-sourcegraph` to `kustomization.yaml`.
 
 -   The `kustomization.yaml` file is used to configure your Sourcegraph instance.
 
@@ -85,7 +85,7 @@ The `kustomization.yaml` file is used to configure your Sourcegraph instance.
 
 #### buildConfig.yaml
 
-**2.** Rename the [buildConfig.template.yaml](/self-hosted/deploy/kubernetes/kustomize/#buildconfig-yaml) file in `instances/my-sourcegraph` to `buildConfig.yaml`.
+**2.** Rename the [buildConfig.template.yaml](/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) file in `instances/my-sourcegraph` to `buildConfig.yaml`.
 
 -   The `buildConfig.yaml` file is used to configure components included in your `kustomization` file when required.
 

--- a/docs/self-hosted/deploy/kubernetes/operations.mdx
+++ b/docs/self-hosted/deploy/kubernetes/operations.mdx
@@ -17,7 +17,7 @@ Operations guides specific to managing [Sourcegraph on Kubernetes](/self-hosted/
 
 ## Featured guides
 
-Trying to deploy Sourcegraph on Kubernetes? Refer to our [installation guide](/self-hosted/deploy/kubernetes/#installation).
+Trying to deploy Sourcegraph on Kubernetes? Refer to our [installation guide](/self-hosted/deploy/kubernetes#quickstart).
 
 ## Configure
 

--- a/docs/self-hosted/deploy/kubernetes/troubleshoot.mdx
+++ b/docs/self-hosted/deploy/kubernetes/troubleshoot.mdx
@@ -34,7 +34,7 @@ Run `kubectl version` to verify the **Client Version** matches the **Server Vers
 
 Run `kubectl get ingresses -A` to check if there is more than one ingress for `sourcegraph-frontend`. You can delete the duplicate with `kubectl delete ingress sourcegraph-frontend --namespace $YOUR_NAMESPACE`
 
-> NOTE: See our ["configuration guide"](/self-hosted/deploy/kubernetes/configure#security-configure-network-access) for more information on network access.
+> NOTE: See our ["configuration guide"](/self-hosted/deploy/kubernetes/configure#network-access) for more information on network access.
 
 #### Error: error when creating "base/cadvisor/cadvisor.ClusterRoleBinding.yaml": subjects[0].namespace: Required value
 

--- a/docs/self-hosted/deploy/machine-images/aws-ami.mdx
+++ b/docs/self-hosted/deploy/machine-images/aws-ami.mdx
@@ -187,7 +187,7 @@ Now that your instance is confirmed to be working, and you have HTTPS working th
 Please take time to review the following before proceeding with the upgrades:
 
 - [Technical changelog](https://sourcegraph.com/changelog/releases)
-- [Update policy](/self-hosted/updates#update-policy)
+- [Update policy](/self-hosted/updates#release-schedule-and-versioning)
 - [Update notes](https://sourcegraph.com/changelog/self-hosted/kubernetes)
 
 <Callout type="warning">Back up your volumes before each upgrade!</Callout>

--- a/docs/self-hosted/deploy/machine-images/gce.mdx
+++ b/docs/self-hosted/deploy/machine-images/gce.mdx
@@ -165,7 +165,7 @@ As a result, setting up a static IP for your Sourcegraph instance is strongly re
 Please take time to review the following before proceeding with the upgrades:
 
 -   [Technical changelog](https://sourcegraph.com/changelog/releases)
--   [Update policy](/self-hosted/updates#update-policy)
+-   [Update policy](/self-hosted/updates#release-schedule-and-versioning)
 -   [Update notes](https://sourcegraph.com/changelog/self-hosted/kubernetes)
 -   [Multi-version upgrade procedure](https://sourcegraph.com/changelog/self-hosted/kubernetes)
 

--- a/docs/self-hosted/deploy/repositories.mdx
+++ b/docs/self-hosted/deploy/repositories.mdx
@@ -75,4 +75,4 @@ git checkout $YOUR_RELEASE_BRANCH
 git merge {CURRENT_VERSION}
 ```
 
-A [standard upgrade](/self-hosted/updates#standard-upgrades) occurs between two minor versions of Sourcegraph. If you are looking to jump forward several versions, you must perform a [multi-version upgrade](/self-hosted/updates#multi-version-upgrades) instead.
+A [standard upgrade](/self-hosted/updates#upgrade-types) occurs between two minor versions of Sourcegraph. If you are looking to jump forward several versions, you must perform a [multi-version upgrade](/self-hosted/updates#upgrade-types) instead.

--- a/docs/self-hosted/deploy/single-node/script.mdx
+++ b/docs/self-hosted/deploy/single-node/script.mdx
@@ -83,7 +83,7 @@ We recommend deploying your own reverse proxy to terminate TLS connections with 
 ## Upgrade
 
 -   [Technical changelog](https://sourcegraph.com/changelog/releases)
--   [Update policy](/self-hosted/updates#update-policy)
+-   [Update policy](/self-hosted/updates#release-schedule-and-versioning)
 -   [Update notes](https://sourcegraph.com/changelog/self-hosted/kubernetes)
 -   [Multi-version upgrade procedure](https://sourcegraph.com/changelog/self-hosted/kubernetes)
 

--- a/docs/self-hosted/external-services/index.mdx
+++ b/docs/self-hosted/external-services/index.mdx
@@ -21,7 +21,7 @@ See the following guides to use an external or managed version of each service t
 -   See [Using your own PostgreSQL server](/self-hosted/external-services/postgres) to replace the bundled PostgreSQL instances.
 -   See [Using your own Redis server](/self-hosted/external-services/redis) to replace the bundled Redis instances.
 -   See [Using a managed object storage service (S3 or GCS)](/self-hosted/external-services/object-storage) to replace the bundled blobstore instance.
--   See [Using an external Jaeger instance](/self-hosted/observability/tracing#Use-an-external-Jaeger-instance) to replace the bundled Jaeger instance.
+-   See [Using an external Jaeger instance](/self-hosted/observability/tracing#jaeger) to replace the bundled Jaeger instance.
 
 > NOTE: Using Sourcegraph with an external service is a [paid feature](https://about.sourcegraph.com/pricing). [Contact us](https://about.sourcegraph.com/contact/sales) to get a trial license.
 

--- a/docs/self-hosted/how-to/dirty-database.mdx
+++ b/docs/self-hosted/how-to/dirty-database.mdx
@@ -107,7 +107,7 @@ If you're running into errors such as being unable to create a unique index due 
 
 ### 3. Add a migration log entry
 
-**Ensure the migration applied, then signal that the migration has been run**. Run the `migrator` instance against your database to create an explicit migration log. For the following, consult the [Kubernetes](/self-hosted/updates/migrator/migrator-operations#kubernetes), [Docker-compose](/self-hosted/updates/migrator/migrator-operations#docker--docker-compose), or [local development](/self-hosted/updates/migrator/migrator-operations#local-development) instructions on how to manually run database operations. The specific migrator command to run is:
+**Ensure the migration applied, then signal that the migration has been run**. Run the `migrator` instance against your database to create an explicit migration log. For the following, consult the [Kubernetes](/self-hosted/updates/migrator/migrator-operations#kubernetes-helm), [Docker-compose](/self-hosted/updates/migrator/migrator-operations#docker-compose), or [local development](/self-hosted/updates/migrator/migrator-operations#local-development) instructions on how to manually run database operations. The specific migrator command to run is:
 
 -   For Kubernetes: replace container args with `["add-log", "-db=<schema>", "-version=<version>"]`
 -   For Docker-compose: replace container args with `"add-log" "-db=<schema>" "-version=<version>"`

--- a/docs/self-hosted/how-to/index.mdx
+++ b/docs/self-hosted/how-to/index.mdx
@@ -1,8 +1,8 @@
 # How-to guides
 
 -   [How to manually execute database migrations with `migrator`](/self-hosted/updates/migrator/migrator-operations)
-    -   Commands: [up](/self-hosted/updates/migrator/migrator-operations#up), [upto](/self-hosted/updates/migrator/migrator-operations#upto), [downto](/self-hosted/updates/migrator/migrator-operations#downto), [validate](/self-hosted/updates/migrator/migrator-operations#validate), [add-log](/self-hosted/updates/migrator/migrator-operations#add-log)
-    -   Environments: [Kubernetes](/self-hosted/updates/migrator/migrator-operations#kubernetes), [Docker compose](/self-hosted/updates/migrator/migrator-operations#docker--docker-compose), [Local development](/self-hosted/updates/migrator/migrator-operations#local-development)
+    -   Commands: [up](/self-hosted/updates/migrator/migrator-operations#up), [upto](/self-hosted/updates/migrator/migrator-operations#upgrade), [downto](/self-hosted/updates/migrator/migrator-operations#downgrade), [validate](/self-hosted/updates/migrator/migrator-operations#validate), [add-log](/self-hosted/updates/migrator/migrator-operations#add-log)
+    -   Environments: [Kubernetes](/self-hosted/updates/migrator/migrator-operations#kubernetes-helm), [Docker compose](/self-hosted/updates/migrator/migrator-operations#docker-compose), [Local development](/self-hosted/updates/migrator/migrator-operations#local-development)
 -   [How to troubleshoot a dirty database](/self-hosted/how-to/dirty-database)
 -   [How to rollback the Postgres database](/self-hosted/how-to/rollback-database)
 -   [How to apply privileged migrations](/self-hosted/how-to/privileged-migrations)
@@ -20,7 +20,7 @@
 -   [How to determine cause for Precise-code-intel-worker in CrashLoopBackOff status](/self-hosted/how-to/precise-code-intel-worker-crashloopbackoff)
 -   [How to troubleshoot a failure to update repositories when new repositories are added](/admin/how-to/update-repo-failure)
 -   [How to run postgres queries in your Sourcegraph instance](/self-hosted/how-to/run-psql)
--   [How to purge deleted repository data from Sourcegraph](/admin/how-to/remove-repo#manually-purge-deleted-repository-data-from-disk)
+-   [How to purge deleted repository data from Sourcegraph](/admin/how-to/remove-repo#remove-corrupted-repository-data-from-sourcegraph)
 -   [How to address common monorepo problems](/admin/how-to/monorepo-issues)
 -   [How to Set a password for Redis using a ConfigMap](/self-hosted/how-to/redis-configmap)
 -   [How to import a set of internal repositories to Sourcegraph](/admin/how-to/internal-github-repos)

--- a/docs/self-hosted/how-to/unfinished-migration.mdx
+++ b/docs/self-hosted/how-to/unfinished-migration.mdx
@@ -15,11 +15,11 @@ ERROR: Unfinished migrations. Please revert Sourcegraph to the previous version 
 
 ## Resolution
 
-If you were performing a [standard upgrade](/self-hosted/updates/#standard-upgrades) between two minor versions, then the suggested action is to perform an infrastructure rollback and continue running the previous instance version until the violating out-of-band migrations have completed. The progress of the migrations can be checked [in the UI](#checking-progress). Older versions of Sourcegraph may have performed schema migrations prior to this check, but a schema rollback should not be necessary as our database schemas are backwards-compatible with one minor version.
+If you were performing a [standard upgrade](/self-hosted/updates#upgrade-types) between two minor versions, then the suggested action is to perform an infrastructure rollback and continue running the previous instance version until the violating out-of-band migrations have completed. The progress of the migrations can be checked [in the UI](#checking-progress). Older versions of Sourcegraph may have performed schema migrations prior to this check, but a schema rollback should not be necessary as our database schemas are backwards-compatible with one minor version.
 
 Alternatively to rolling back and waiting, the unfinished migrations can be run directly via the `migrator`. See the [command documentation](/self-hosted/updates/migrator/migrator-operations#run-out-of-band-migrations) for additional details.
 
-[Multi-version upgrades](/self-hosted/updates/#multi-version-upgrades) and downgrade operations ensure that the required out-of-band migrations have completed or finished rolling back. If this is not the case, contact support as it indicates a non-obvious error in your environment or a bug Sourcegraph's migration tooling.
+[Multi-version upgrades](/self-hosted/updates#upgrade-types) and downgrade operations ensure that the required out-of-band migrations have completed or finished rolling back. If this is not the case, contact support as it indicates a non-obvious error in your environment or a bug Sourcegraph's migration tooling.
 
 As an emergency escape hatch, the environment variable `SRC_DISABLE_OOBMIGRATION_VALIDATION` can be set to `true` on the `frontend` and `worker` services to disable the startup check. This is not recommended as it may result in broken features or data loss.
 

--- a/docs/self-hosted/observability/troubleshooting.mdx
+++ b/docs/self-hosted/observability/troubleshooting.mdx
@@ -269,7 +269,7 @@ Network panel](https://developers.google.com/web/tools/chrome-devtools/network).
 
 ### Check resource usage
 
-[Access Prometheus](/self-hosted/observability/metrics#accessing-prometheus) and examine the following metrics:
+[Access Prometheus](/self-hosted/observability/metrics#accessing-prometheus-directly) and examine the following metrics:
 
 **Memory:** `process_resident_memory_bytes` is a gauge that tracks memory usage per backend process.
 
@@ -314,11 +314,11 @@ title > Edit > copying the expression in the Metrics field.
 If you are looking for the trace associated with a specific request,
 
 -   [Find the trace ID in the HTTP response in the browser developer tools "Network" tab](#check-browser-network-panel).
--   [Access Jaeger](/self-hosted/observability/tracing#accessing-jaeger) and look up the trace ID.
+-   [Access Jaeger](/self-hosted/observability/tracing#jaeger) and look up the trace ID.
 
 If you do not have a specific request or cannot find the trace ID,
 
--   [Access Jaeger](/self-hosted/observability/tracing#accessing-jaeger).
+-   [Access Jaeger](/self-hosted/observability/tracing#jaeger).
 -   Search for a matching span by setting the appropriate fields in the sidebar.
 
 2 ways: start with a span ID, or manually locate your span by searching the Jaeger GUI

--- a/docs/self-hosted/updates/migrator/migrator-operations.mdx
+++ b/docs/self-hosted/updates/migrator/migrator-operations.mdx
@@ -204,7 +204,7 @@ The `up` command (the default behavior of the `migrator` service) applies all mi
 
 > WARNING: The target migration leaves of this command are defined at `migrator` **compile time** and does not accept a version argument. This is the only command where the Sourcegraph instance version and `migrator` version are expected to match.
 
-Users should generally prefer the command [`upto`](#upto), which accepts more explicit bounds and does not depend on the migrator compilation version.
+Users should generally prefer the command [`upgrade`](#upgrade), which accepts more explicit bounds and does not depend on the migrator compilation version.
 
 ```sh
 up \

--- a/docs/self-hosted/updates/migrator/upgrading-early-versions.mdx
+++ b/docs/self-hosted/updates/migrator/upgrading-early-versions.mdx
@@ -24,7 +24,7 @@ In `v3.37.0` the `migrator` service was introduced. Docker-compose and Kubernete
 In version `3.27` `pgsql` and `codeintel-db` databases were upgraded from Postgres 11 to Postgres 12. **If upgrading from 3.26 or before to 3.27 or later**, the `pgsql` and `codeintel-db` databases must have their Postgres version upgraded. If this step is not performed, then the following upgrade procedure will fail fast (and leave all existing data untouched).
 
 -   If using an external database, follow the [upgrading external PostgreSQL instances](/self-hosted/postgres#upgrading-external-postgresql-instances) guide.
--   Otherwise, perform the following steps from the [upgrading internal Postgres instances](/self-hosted/postgres#upgrading-internal-postgresql-instances) guide.
+-   Otherwise, perform the following steps from the [upgrading internal Postgres instances](/self-hosted/postgres#upgrading-built-in-postgresql) guide.
 
 The following procedures describe how to upgrade the Postgres version:
 


### PR DESCRIPTION
Linear [FE-499: Fix doc site issues](https://linear.app/sourcegraph/issue/FE-499/fix-doc-site-issues)

Smaller, more easily reviewed subset of fixes from https://github.com/sourcegraph/docs/pull/1861

`#anchor` links under `docs/self-hosted/` whose target heading was reworded. The section still exists; the link now uses the current heading's slug.

Review: for each row, the new heading should be the same topic as the old anchor's words. Rows where the heading was replaced rather than renamed (e.g. several anchors collapsed onto one `#configuration` or `#upgrade-types` section) are the ones worth a second look.

Most rows are the Kustomize page: `#buildconfig-yaml` / `#kustomization-yaml` became one `#step-3-set-up-the-configuration-files` section (18 links), and the updates page: `#standard-upgrades` / `#multi-version-upgrades` → `#upgrade-types`, `#update-policy` → `#release-schedule-and-versioning`.

Checker findings (`npm run check-links -- --check-anchors`, from #1858, with its heading-slug fix): 278 on main → 234 on this branch.

## Verification

The docs site serves its not-found page with HTTP 200 (fix in progress), so status codes prove nothing. Instead, every changed link was fetched on this PR's Vercel preview and the rendered HTML checked for two `id`s: the target page's own first heading (taken from its MDX source — the 404 page never has it) and the link's `#fragment`. Script: `node dev/verify-links-live.mjs --site <preview-url>`, coming in #1858.

Old links point at the current production site so you can see the breakage; new links point at the preview and land on the heading.

Checked 44 changed links against https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app: 44 resolve, 0 fail.
Page rendered = the target page's first heading id is present (the 404 page never has it); Anchor = the #fragment is an id on the page. Old links point at the current site.

<details><summary>All 44 links</summary>

| File containing the link | Old link (broken today) | New link (preview) | Page rendered | Anchor found |
|--------------------------|-------------------------|--------------------|---------------|--------------|
| `docs/self-hosted/deploy/docker-compose/operations.mdx` | [`#restoring-sourcegraph-databases-into-an-existing-environment`](https://sourcegraph.com/docs/self-hosted/deploy/docker-compose/operations#restoring-sourcegraph-databases-into-an-existing-environment) | [`#restore-sourcegraph-databases-into-an-existing-environment`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/docker-compose/operations#restore-sourcegraph-databases-into-an-existing-environment) | ✅ | ✅ |
| `docs/self-hosted/deploy/docker-compose/upgrade.mdx` | [`/self-hosted/deploy/docker-compose/#step-1-prepare-the-deployment-repository`](https://sourcegraph.com/docs/self-hosted/deploy/docker-compose#step-1-prepare-the-deployment-repository) | [`/self-hosted/deploy/docker-compose#step-1-fork-the-deployment-repository`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/docker-compose#step-1-fork-the-deployment-repository) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/azure.mdx` | [`/self-hosted/deploy/kubernetes/configure#configure-a-storage-class`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/configure#configure-a-storage-class) | [`/self-hosted/deploy/kubernetes/configure#storage-class`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/configure#storage-class) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/configure.mdx` | [`/self-hosted/deploy/kubernetes/kustomize/#kustomization-yaml`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/kustomize#kustomization-yaml) | [`/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/configure.mdx` | [`/self-hosted/deploy/kubernetes/kustomize/#kustomization-yaml`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/kustomize#kustomization-yaml) | [`/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/configure.mdx` | [`/self-hosted/deploy/kubernetes/kustomize/#kustomization-yaml`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/kustomize#kustomization-yaml) | [`/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/configure.mdx` | [`/self-hosted/deploy/kubernetes/kustomize#buildconfig-yaml`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/kustomize#buildconfig-yaml) | [`/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/configure.mdx` | [`/self-hosted/deploy/kubernetes/kustomize/#buildconfig-yaml`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/kustomize#buildconfig-yaml) | [`/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/configure.mdx` | [`/self-hosted/deploy/kubernetes/kustomize/#buildconfig-yaml`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/kustomize#buildconfig-yaml) | [`/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/configure.mdx` | [`/self-hosted/deploy/kubernetes/kustomize/#buildconfig-yaml`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/kustomize#buildconfig-yaml) | [`/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/configure.mdx` | [`/self-hosted/deploy/kubernetes/kustomize/#buildconfig-yaml`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/kustomize#buildconfig-yaml) | [`/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/configure.mdx` | [`/self-hosted/deploy/kubernetes/kustomize/#kustomizationyaml`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/kustomize#kustomizationyaml) | [`/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/configure.mdx` | [`/self-hosted/deploy/kubernetes/kustomize/#kustomizationyaml`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/kustomize#kustomizationyaml) | [`/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/configure.mdx` | [`/self-hosted/deploy/kubernetes/kustomize/#buildconfig-yaml`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/kustomize#buildconfig-yaml) | [`/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/configure.mdx` | [`/self-hosted/deploy/kubernetes/kustomize/#buildconfig-yaml`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/kustomize#buildconfig-yaml) | [`/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/configure.mdx` | [`/self-hosted/updates/#multi-version-upgrades`](https://sourcegraph.com/docs/self-hosted/updates#multi-version-upgrades) | [`/self-hosted/updates#upgrade-types`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/updates#upgrade-types) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/kustomize.mdx` | [`/self-hosted/deploy/kubernetes/kustomize/#kustomization-yaml`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/kustomize#kustomization-yaml) | [`/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/kustomize.mdx` | [`/self-hosted/deploy/kubernetes/kustomize/#buildconfig-yaml`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/kustomize#buildconfig-yaml) | [`/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/kustomize/eks.mdx` | [`/self-hosted/deploy/kubernetes/kustomize/#buildconfig-yaml`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/kustomize#buildconfig-yaml) | [`/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/kustomize/gke.mdx` | [`/self-hosted/deploy/kubernetes/kustomize#buildconfig-yaml`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/kustomize#buildconfig-yaml) | [`/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/kustomize/migrate.mdx` | [`/self-hosted/deploy/kubernetes/kustomize/#kustomization-yaml`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/kustomize#kustomization-yaml) | [`/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/kustomize/migrate.mdx` | [`/self-hosted/deploy/kubernetes/kustomize/#buildconfig-yaml`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/kustomize#buildconfig-yaml) | [`/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/kustomize#step-3-set-up-the-configuration-files) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/operations.mdx` | [`/self-hosted/deploy/kubernetes/#installation`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes#installation) | [`/self-hosted/deploy/kubernetes#quickstart`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes#quickstart) | ✅ | ✅ |
| `docs/self-hosted/deploy/kubernetes/troubleshoot.mdx` | [`/self-hosted/deploy/kubernetes/configure#security-configure-network-access`](https://sourcegraph.com/docs/self-hosted/deploy/kubernetes/configure#security-configure-network-access) | [`/self-hosted/deploy/kubernetes/configure#network-access`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/deploy/kubernetes/configure#network-access) | ✅ | ✅ |
| `docs/self-hosted/deploy/machine-images/aws-ami.mdx` | [`/self-hosted/updates#update-policy`](https://sourcegraph.com/docs/self-hosted/updates#update-policy) | [`/self-hosted/updates#release-schedule-and-versioning`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/updates#release-schedule-and-versioning) | ✅ | ✅ |
| `docs/self-hosted/deploy/machine-images/gce.mdx` | [`/self-hosted/updates#update-policy`](https://sourcegraph.com/docs/self-hosted/updates#update-policy) | [`/self-hosted/updates#release-schedule-and-versioning`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/updates#release-schedule-and-versioning) | ✅ | ✅ |
| `docs/self-hosted/deploy/repositories.mdx` | [`/self-hosted/updates#standard-upgrades`](https://sourcegraph.com/docs/self-hosted/updates#standard-upgrades) | [`/self-hosted/updates#upgrade-types`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/updates#upgrade-types) | ✅ | ✅ |
| `docs/self-hosted/deploy/repositories.mdx` | [`/self-hosted/updates#multi-version-upgrades`](https://sourcegraph.com/docs/self-hosted/updates#multi-version-upgrades) | [`/self-hosted/updates#upgrade-types`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/updates#upgrade-types) | ✅ | ✅ |
| `docs/self-hosted/deploy/single-node/script.mdx` | [`/self-hosted/updates#update-policy`](https://sourcegraph.com/docs/self-hosted/updates#update-policy) | [`/self-hosted/updates#release-schedule-and-versioning`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/updates#release-schedule-and-versioning) | ✅ | ✅ |
| `docs/self-hosted/external-services/index.mdx` | [`/self-hosted/observability/tracing#Use-an-external-Jaeger-instance`](https://sourcegraph.com/docs/self-hosted/observability/tracing#Use-an-external-Jaeger-instance) | [`/self-hosted/observability/tracing#jaeger`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/observability/tracing#jaeger) | ✅ | ✅ |
| `docs/self-hosted/how-to/dirty-database.mdx` | [`/self-hosted/updates/migrator/migrator-operations#kubernetes`](https://sourcegraph.com/docs/self-hosted/updates/migrator/migrator-operations#kubernetes) | [`/self-hosted/updates/migrator/migrator-operations#kubernetes-helm`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/updates/migrator/migrator-operations#kubernetes-helm) | ✅ | ✅ |
| `docs/self-hosted/how-to/dirty-database.mdx` | [`/self-hosted/updates/migrator/migrator-operations#docker--docker-compose`](https://sourcegraph.com/docs/self-hosted/updates/migrator/migrator-operations#docker--docker-compose) | [`/self-hosted/updates/migrator/migrator-operations#docker-compose`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/updates/migrator/migrator-operations#docker-compose) | ✅ | ✅ |
| `docs/self-hosted/how-to/index.mdx` | [`/self-hosted/updates/migrator/migrator-operations#upto`](https://sourcegraph.com/docs/self-hosted/updates/migrator/migrator-operations#upto) | [`/self-hosted/updates/migrator/migrator-operations#upgrade`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/updates/migrator/migrator-operations#upgrade) | ✅ | ✅ |
| `docs/self-hosted/how-to/index.mdx` | [`/self-hosted/updates/migrator/migrator-operations#downto`](https://sourcegraph.com/docs/self-hosted/updates/migrator/migrator-operations#downto) | [`/self-hosted/updates/migrator/migrator-operations#downgrade`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/updates/migrator/migrator-operations#downgrade) | ✅ | ✅ |
| `docs/self-hosted/how-to/index.mdx` | [`/self-hosted/updates/migrator/migrator-operations#kubernetes`](https://sourcegraph.com/docs/self-hosted/updates/migrator/migrator-operations#kubernetes) | [`/self-hosted/updates/migrator/migrator-operations#kubernetes-helm`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/updates/migrator/migrator-operations#kubernetes-helm) | ✅ | ✅ |
| `docs/self-hosted/how-to/index.mdx` | [`/self-hosted/updates/migrator/migrator-operations#docker--docker-compose`](https://sourcegraph.com/docs/self-hosted/updates/migrator/migrator-operations#docker--docker-compose) | [`/self-hosted/updates/migrator/migrator-operations#docker-compose`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/updates/migrator/migrator-operations#docker-compose) | ✅ | ✅ |
| `docs/self-hosted/how-to/index.mdx` | [`/admin/how-to/remove-repo#manually-purge-deleted-repository-data-from-disk`](https://sourcegraph.com/docs/admin/how-to/remove-repo#manually-purge-deleted-repository-data-from-disk) | [`/admin/how-to/remove-repo#remove-corrupted-repository-data-from-sourcegraph`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/admin/how-to/remove-repo#remove-corrupted-repository-data-from-sourcegraph) | ✅ | ✅ |
| `docs/self-hosted/how-to/unfinished-migration.mdx` | [`/self-hosted/updates/#standard-upgrades`](https://sourcegraph.com/docs/self-hosted/updates#standard-upgrades) | [`/self-hosted/updates#upgrade-types`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/updates#upgrade-types) | ✅ | ✅ |
| `docs/self-hosted/how-to/unfinished-migration.mdx` | [`/self-hosted/updates/#multi-version-upgrades`](https://sourcegraph.com/docs/self-hosted/updates#multi-version-upgrades) | [`/self-hosted/updates#upgrade-types`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/updates#upgrade-types) | ✅ | ✅ |
| `docs/self-hosted/observability/troubleshooting.mdx` | [`/self-hosted/observability/metrics#accessing-prometheus`](https://sourcegraph.com/docs/self-hosted/observability/metrics#accessing-prometheus) | [`/self-hosted/observability/metrics#accessing-prometheus-directly`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/observability/metrics#accessing-prometheus-directly) | ✅ | ✅ |
| `docs/self-hosted/observability/troubleshooting.mdx` | [`/self-hosted/observability/tracing#accessing-jaeger`](https://sourcegraph.com/docs/self-hosted/observability/tracing#accessing-jaeger) | [`/self-hosted/observability/tracing#jaeger`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/observability/tracing#jaeger) | ✅ | ✅ |
| `docs/self-hosted/observability/troubleshooting.mdx` | [`/self-hosted/observability/tracing#accessing-jaeger`](https://sourcegraph.com/docs/self-hosted/observability/tracing#accessing-jaeger) | [`/self-hosted/observability/tracing#jaeger`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/observability/tracing#jaeger) | ✅ | ✅ |
| `docs/self-hosted/updates/migrator/migrator-operations.mdx` | [`#upto`](https://sourcegraph.com/docs/self-hosted/updates/migrator/migrator-operations#upto) | [`#upgrade`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/updates/migrator/migrator-operations#upgrade) | ✅ | ✅ |
| `docs/self-hosted/updates/migrator/upgrading-early-versions.mdx` | [`/self-hosted/postgres#upgrading-internal-postgresql-instances`](https://sourcegraph.com/docs/self-hosted/postgres#upgrading-internal-postgresql-instances) | [`/self-hosted/postgres#upgrading-built-in-postgresql`](https://sourcegraph-docs-git-fix-reworded-a-15f39f-sourcegraph-f8c71130.vercel.app/self-hosted/postgres#upgrading-built-in-postgresql) | ✅ | ✅ |

</details>

## Amp threads

- [Docs - Fix broken heading links](https://ampcode.com/threads/T-01a07623-9d65-7356-96b8-2bebb31ffa5a)



---
Replaces #1869 (branch renamed to `marc/fix-reworded-anchors-self-hosted`).
