### PR TITLE
feat/redirects: BAD IDEA - DON'T MERGE - Apply heading (#fragment) redirects in the browser

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import {Providers} from '@/app/providers';
+import {FragmentRedirect} from '@/components/FragmentRedirect';
 import {Layout} from '@/components/Layout';
 import {TECHNICAL_CHANGELOG_RSS_URL} from '@/data/constants';
 import clsx from 'clsx';
@@ -89,6 +90,7 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
 				className="flex min-h-full bg-light-bg dark:bg-dark-bg"
 			>
 				<Suspense fallback={null}>
+					<FragmentRedirect />
 					<Providers>
 						<Layout>{children}</Layout>
 					</Providers>

--- a/src/components/FragmentRedirect.tsx
+++ b/src/components/FragmentRedirect.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import {updatedRedirectsData} from '@/data/redirects';
+import {usePathname} from 'next/navigation';
+import {useEffect} from 'react';
+
+const basePath = process.env.NEXT_PUBLIC_DOCS_BASE_PATH || '';
+
+function splitHash(url: string): {path: string; hash: string} {
+	const i = url.indexOf('#');
+	return i === -1
+		? {path: url, hash: ''}
+		: {path: url.slice(0, i), hash: url.slice(i)};
+}
+
+// Entries in src/data/redirects.ts whose source has a `#fragment`. The
+// middleware can never match these, because browsers do not send the fragment
+// to the server, so they are applied here instead.
+const fragmentRedirects = updatedRedirectsData.filter(r =>
+	r.source.includes('#')
+);
+const bySource = new Map<string, string>();
+for (const r of fragmentRedirects) {
+	// First entry wins, matching the middleware's Array.find semantics.
+	if (!bySource.has(r.source)) bySource.set(r.source, r.destination);
+}
+
+/**
+ * `pathname` excludes the basePath (as returned by usePathname());
+ * `hash` includes the leading '#'.
+ */
+export function resolveFragmentRedirect(
+	pathname: string,
+	hash: string
+): string | undefined {
+	if (!hash) return undefined;
+	const exact = bySource.get(pathname + hash);
+	if (exact) return exact;
+	// The middleware may already have redirected the path, and the browser
+	// carries the (now stale) fragment over to the new page. Match an entry
+	// that points at this page and whose source fragment is the one we have.
+	const carried = fragmentRedirects.find(r => {
+		const dest = splitHash(r.destination);
+		return (
+			dest.path === pathname &&
+			splitHash(r.source).hash === hash &&
+			dest.hash !== hash
+		);
+	});
+	return carried?.destination;
+}
+
+/**
+ * Applies heading redirects (`/page#old-heading`) from src/data/redirects.ts
+ * in the browser, after the page loads and again whenever the fragment changes.
+ */
+export function FragmentRedirect() {
+	const pathname = usePathname();
+
+	useEffect(() => {
+		const apply = () => {
+			const destination = resolveFragmentRedirect(
+				pathname,
+				window.location.hash
+			);
+			if (!destination) return;
+
+			if (destination.startsWith('http')) {
+				window.location.replace(destination);
+				return;
+			}
+
+			const dest = splitHash(destination);
+			if (dest.path !== pathname) {
+				window.location.replace(basePath + destination);
+				return;
+			}
+
+			// Same page: fix the URL in place and scroll to the new heading.
+			window.history.replaceState(null, '', basePath + destination);
+			if (dest.hash) {
+				document
+					.getElementById(decodeURIComponent(dest.hash.slice(1)))
+					?.scrollIntoView();
+			}
+		};
+
+		apply();
+		window.addEventListener('hashchange', apply);
+		return () => window.removeEventListener('hashchange', apply);
+	}, [pathname]);
+
+	return null;
+}

--- a/src/data/redirects.ts
+++ b/src/data/redirects.ts
@@ -1,5 +1,14 @@
 import {TECHNICAL_CHANGELOG_RSS_URL} from './constants';
 
+// Path redirects (`/old-page` -> `/new-page`) are applied server-side by
+// src/middleware.ts.
+//
+// Heading redirects, where the source has a `#fragment`
+// (`/page#old-heading` -> `/page#new-heading`), are applied in the browser by
+// src/components/FragmentRedirect.tsx, because browsers never send the
+// fragment to the server.
+//
+// For a given source, the first matching entry wins.
 const redirectsData = [
 	{
 		source: '/integration/img/disable_extension.png',
@@ -5896,7 +5905,7 @@ const redirectsData = [
 	},
 ];
 
-const updatedRedirectsData = redirectsData.map(redirect => {
+export const updatedRedirectsData = redirectsData.map(redirect => {
 	return {
 		source: String(redirect.source).replace(
 			'http://localhost:3000/docs',
@@ -5908,7 +5917,3 @@ const updatedRedirectsData = redirectsData.map(redirect => {
 		)
 	};
 });
-
-module.exports = {
-	updatedRedirectsData
-};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,8 +3,7 @@ import {NextResponse} from 'next/server';
 import docsConfig from '../docs.config.js';
 
 import {TECHNICAL_CHANGELOG_RSS_URL} from './data/constants';
-
-const {updatedRedirectsData} = require('./data/redirects.ts');
+import {updatedRedirectsData} from './data/redirects';
 
 function createRedirectUrl(
 	request: NextRequest,


### PR DESCRIPTION
## Problem

`src/data/redirects.ts` contains 386 entries whose `source` includes a `#fragment`, e.g.

```ts
{source: '/cody/quickstart#introduction', destination: '/cody/quickstart#cody-quickstart'}
```

Browsers never send the fragment to the server, so `src/middleware.ts` (which matches `r.source === pathname`) has never fired for any of them — and neither did the Next `redirects()` config they were originally added to in 2023. Verified on the live site: https://sourcegraph.com/docs/batch_changes/explanations/permissions_in_batch_changes#code-host-interactions-in-batch-changes serves the not-found page with no `Location` header.

This also means there has been no way to add a redirect when renaming a heading, so inbound anchored links silently break.

## Change

- `src/components/FragmentRedirect.tsx`: client component rendered once in the root layout. After load (and on `hashchange`) it looks up `pathname + location.hash` in the `#` entries of the same redirects list. Same-page hit → `history.replaceState` + scroll to the new heading (no reload). Cross-page hit → `location.replace`. It also handles the two-step case where the middleware redirects the path and the browser carries a stale fragment onto the new page.
- `src/data/redirects.ts`: exported as ESM (`export const updatedRedirectsData`) so the middleware and the client component import the same list. No entries were moved, added, or removed. Added a header comment explaining which entries are handled where.
- `src/middleware.ts`: `require` → `import`. Behaviour unchanged.

Heading renames are now handled by adding one line to the existing list: `{source: '/page#old-heading', destination: '/page#new-heading'}`.

## Verification (dev server, headless Chromium)

| Requested URL | Landed on |
|---|---|
| `/batch_changes/explanations/permissions_in_batch_changes#code-host-interactions-in-batch-changes` (404 today) | `/batch-changes/permissions-in-batch-changes#code-host-interactions-in-batch-changes`, scrolled to heading |
| `/cody/quickstart#introduction` (same-page rename) | `/cody/quickstart#cody-quickstart`, no reload, scrolled to heading |
| `/cody/clients/install-vscode#requirements` (what the browser lands on after the middleware's 307 from `/cody/overview/install-vscode#requirements`) | `/cody/clients/install-vscode#prerequisites` |
| `/cody/quickstart#prerequisites` (valid anchor, control) | unchanged |
| `/admin/http_https_configuration` (middleware path redirect, control) | 307 → `/self-hosted/http-https-configuration` |

`eslint` clean on changed files; `node dev/check-links.mjs` passes; `tsc` errors are pre-existing (`contentlayer/generated`).

## Notes / follow-ups (not in this PR)

- The `#` entries now ship to the client as part of the redirects chunk (~15 KB compressed, cached across pages). Most of the 386 point at long-gone Cody pages and could be pruned.
- The bare `/batch_changes/explanations/permissions_in_batch_changes` (no anchor) still 404s; it needs a fragment-less entry.
- 203 duplicate sources and 108 entries whose destination no longer exists were found while auditing; separate cleanup.
- Pre-existing: `createRedirectUrl` hardcodes `/docs`, so middleware redirects 404 in local dev; `notFound()` pages return HTTP 200 in production.

## Amp threads

- [Redirect list cleanup](https://ampcode.com/threads/T-01a07e6f-db41-74af-bbeb-f8952e637289)



---
Replaces #1879 (branch renamed to `marc/fragment-redirects`).
