### PR TITLE
Add dev/TODO.md with Vercel audit tasks

### DIFF
--- a/cspell-allow-list.txt
+++ b/cspell-allow-list.txt
@@ -67,6 +67,7 @@ behaviour
 behaviours
 beyang
 bgwriter
+bingbot
 binutils
 bitbucketcloud
 bitbucketserver
@@ -407,6 +408,7 @@ pooler
 PREEMPTIBLE
 preg
 premade
+prerender
 prerendered
 Príncipe
 privkey

--- a/dev/TODO.md
+++ b/dev/TODO.md
@@ -65,12 +65,14 @@ pre-redirect host, so they come back as `docs.sourcegraph.com/docs/_next/...`
 → 302 → `sourcegraph.com/docs/docs/_next/...` → 404.
 
 Fix (Cloudflare, not this repo):
+
 - Make the `docs.sourcegraph.com` redirect a **301** so Bing drops the old
   URLs from its index and stops crawling them.
 - Add a rule so `docs.sourcegraph.com/docs/*` redirects to
   `sourcegraph.com/docs/$1` without doubling the prefix.
 
 Fix (this repo):
+
 - Every page sets `<link rel="canonical" href="https://sourcegraph.com/docs">`
   (`src/app/layout.tsx` `alternates.canonical: '/docs'`, never
   overridden). Set a per-page canonical in `src/app/[...slug]/page.tsx`

--- a/dev/TODO.md
+++ b/dev/TODO.md
@@ -1,82 +1,46 @@
 # TODO
 
-Vercel project: `sourcegraph-docs` (team `sourcegraph-f8c71130`). Audit
-artifacts live in `logs/vercel-audit/` (git-ignored). One PR per task;
-link PRs here as they open, delete tasks when they merge.
+Vercel project `sourcegraph-docs`. One PR per task; delete a task when
+its PR merges.
 
 ## 1. Node 20 build image is deprecated (separate thread)
 
-Vercel build log warns that Node 20.x deployments fail after 2026-10-01.
-`contentlayer` 0.3.4 emits `assert { type: 'json' }`, which Node ≥ 22
-rejects; migrate to `contentlayer2` / `next-contentlayer2` ≥ 0.5.0 first,
-then set Node 22 in `.tool-versions` and `package.json#engines`.
+Node 20.x deployments fail after 2026-10-01. `contentlayer` 0.3.4 emits
+`assert { type: 'json' }`, which Node ≥ 22 rejects. Migrate to
+`contentlayer2` / `next-contentlayer2` ≥ 0.5.0, then set Node 22 in
+`.tool-versions` and `package.json#engines`.
 
 ## 2. 24 MB shared JS chunk on every page
 
 `src/components/Toc.tsx` and `src/components/ContentTabs.jsx` are
-`'use client'` and import `allPosts` from `contentlayer/generated`, so
-every post's raw + compiled body lands in one client chunk
-(`7180-*.js`: 24.4 MB raw, 2.78 MB gzip; First Load JS 2.95 MB). Its hash
-changes on every deploy, so the CDN and every browser re-download it.
-Confirmed in Chrome DevTools: 51 requests, 3.4 MB transferred, 28.0 MB
-resources for one page; 2,539 kB of that is this chunk.
-Fix: compute what those components need on the server
-(`src/app/[...slug]/page.tsx`) and pass it as props.
-
-## 3. Pin the toolchain
-
-PR #1906. Watch the preview build log for `Using pnpm@10`.
-
-## 4. Dead Langbase secrets
-
-`NEXT_LB_PIPE_API_KEY` and `LANGBASE_PIPE_ASK_SG_API_KEY` are set in all
-three environments. No other team project, no repo in the org, and no
-current code references them (Langbase was removed in #1898). Delete
-them from the Vercel project and rotate at Langbase.
+`'use client'` and import `allPosts`, so every post's raw and compiled
+body ships in one client chunk (`7180-*.js`: 24.4 MB raw, 2.78 MB gzip,
+re-downloaded after every deploy). Fix: resolve the post on the server
+in `src/app/[...slug]/page.tsx` and pass only what each component needs
+as props (`Toc`: the post `_id`; `ContentTabs`: the rendered fallback
+tab), then drop the `allPosts` imports.
 
 ## 5. Runtime
 
-- a./b. PR #1912 (stacked on #1901): prerender `/api/md/[...slug]`,
-  enable Fluid compute. After the preview deploys, compare `.md` and
-  `/api/og` latency and `x-vercel-cache` against production.
-- c. Draft PR #1907: static redirects moved to `next.config.js`;
-  middleware kept for `.md` rewrites and version patterns. Conflicts with
-  #1908 on `next.config.js`; merge one, rebase the other.
+- Skip builds for non-site changes: #1901.
+- Prerender `/api/md/[...slug]`, enable Fluid compute: #1912 (stacked on
+  #1901; retarget to `main` after it merges).
+- Static redirects out of middleware: draft #1907 (rebase on `main` now
+  that #1908 merged).
 
 ## 6. Build
 
-- a. Draft PR #1908: run `dev/check-*.mjs` once from the `build` script.
-- b. Draft PR #1909: caniuse-lite bump, lint warnings to zero.
-- c. Build cache is ~880 MB because `node_modules` is ~894 MB and
-  `.next/cache` ~303 MB (`@next/swc` 110 MB, `next` 101 MB, `mermaid`
-  65 MB, `@effect-ts/system` 45 MB via contentlayer, `typescript` 38 MB,
-  `lucide-react` 30 MB). No quick win; revisit after task 1 replaces
-  contentlayer and if `mermaid` can be loaded client-side only.
-- d. Web Analytics and Speed Insights: disabled 2026-09-11 via API.
+- Lint warnings and stale `caniuse-lite`: draft #1909.
 
-## 7. Doubled base path 404s
+## 7. Doubled base path 404s and wrong canonical
 
-Source found via `vercel.com/api/logs/request-logs` (the `vercel logs`
-CLI drops referer/user-agent): 98 % are bingbot with referer
-`https://docs.sourcegraph.com/<page>`. Cloudflare answers
-`docs.sourcegraph.com/*` with a **302** to `sourcegraph.com/docs/*`, and
-Bing resolves the page's `/docs/_next/...` asset URLs against the
-pre-redirect host, so they come back as `docs.sourcegraph.com/docs/_next/...`
-→ 302 → `sourcegraph.com/docs/docs/_next/...` → 404.
+`sourcegraph.com/docs/docs/_next/...` 404s are bingbot following the
+Cloudflare **302** from `docs.sourcegraph.com/<page>` and resolving the
+page's `/docs/_next/...` asset URLs against the old host.
 
-Fix (Cloudflare, not this repo):
-
-- Make the `docs.sourcegraph.com` redirect a **301** so Bing drops the old
-  URLs from its index and stops crawling them.
-- Add a rule so `docs.sourcegraph.com/docs/*` redirects to
-  `sourcegraph.com/docs/$1` without doubling the prefix.
-
-Fix (this repo):
-
-- Every page sets `<link rel="canonical" href="https://sourcegraph.com/docs">`
-  (`src/app/layout.tsx` `alternates.canonical: '/docs'`, never
-  overridden). Set a per-page canonical in `src/app/[...slug]/page.tsx`
-  `generateMetadata` so crawlers consolidate on the real URL.
-- Optional guard in `next.config.js#redirects()`:
-  `{source: '/docs/:path*', destination: '/:path*', permanent: true}`
-  (Next prepends `basePath`, so this matches `/docs/docs/*`).
+- Cloudflare: make the `docs.sourcegraph.com` redirect a 301, and
+  redirect `docs.sourcegraph.com/docs/*` to `sourcegraph.com/docs/$1`
+  without doubling the prefix.
+- Repo: every page emits `<link rel="canonical" href="https://sourcegraph.com/docs">`
+  (`src/app/layout.tsx` `alternates.canonical: '/docs'`). Set a per-page
+  canonical in `src/app/[...slug]/page.tsx#generateMetadata`.

--- a/dev/TODO.md
+++ b/dev/TODO.md
@@ -24,7 +24,7 @@ tab), then drop the `allPosts` imports.
 
 - Skip builds for non-site changes: #1901.
 - Prerender `/api/md/[...slug]`, enable Fluid compute: #1912 (stacked on
-  #1901; retarget to `main` after it merges).
+  #1901; change its base to `main` after it merges).
 - Static redirects out of middleware: draft #1907 (rebase on `main` now
   that #1908 merged).
 
@@ -44,3 +44,21 @@ page's `/docs/_next/...` asset URLs against the old host.
 - Repo: every page emits `<link rel="canonical" href="https://sourcegraph.com/docs">`
   (`src/app/layout.tsx` `alternates.canonical: '/docs'`). Set a per-page
   canonical in `src/app/[...slug]/page.tsx#generateMetadata`.
+
+## 8. GitHub repo settings (needs an org admin)
+
+Already on: delete branch on merge, squash-only merges, auto-merge,
+squash title/body from PR, `main` ruleset blocks deletion and force-push
+and requires a PR with 1 approval.
+
+- Add required status checks to the `main` ruleset: the link check and
+  the Vercel build. Today "Broken links introduced by this PR" and
+  "CSpell (advisory)" can be red and the PR still merges.
+- Add a "Require signed commits" rule to the `main` ruleset.
+- Turn off `allow_update_branch` ("Always suggest updating PR branches");
+  the button rewrites commits unsigned.
+- Turn on `dismiss_stale_reviews_on_push`; consider
+  `require_last_push_approval` and `required_review_thread_resolution`.
+- Turn off Projects (`has_projects`); Issues are already off.
+- Add `CODEOWNERS` and `.github/dependabot.yml`; confirm Actions
+  permissions and Dependabot alerts are on (not readable without admin).

--- a/dev/TODO.md
+++ b/dev/TODO.md
@@ -1,0 +1,66 @@
+# TODO
+
+Vercel project: `sourcegraph-docs` (team `sourcegraph-f8c71130`). Audit
+artifacts live in `logs/vercel-audit/` (git-ignored). One PR per task;
+link PRs here as they open, delete tasks when they merge.
+
+## 1. Node 20 build image is deprecated (separate thread)
+
+Vercel build log warns that Node 20.x deployments fail after 2026-10-01.
+`contentlayer` 0.3.4 emits `assert { type: 'json' }`, which Node ≥ 22
+rejects; migrate to `contentlayer2` / `next-contentlayer2` ≥ 0.5.0 first,
+then set Node 22 in `.tool-versions` and `package.json#engines`.
+
+## 2. 24 MB shared JS chunk on every page
+
+`src/components/Toc.tsx` and `src/components/ContentTabs.jsx` are
+`'use client'` and import `allPosts` from `contentlayer/generated`, so
+every post's raw + compiled body lands in one client chunk
+(`7180-*.js`: 24.4 MB raw, 2.78 MB gzip; First Load JS 2.95 MB).
+Fix: compute what those components need on the server
+(`src/app/[...slug]/page.tsx`) and pass it as props.
+
+## 3. Pin the toolchain
+
+Build log picks `pnpm@9` "based on project creation date" while
+`.tool-versions` says pnpm 10.25.0 / Node 20.19.6. Add `packageManager`
+and `engines` to `package.json`.
+
+## 4. Dead Langbase secrets
+
+`NEXT_LB_PIPE_API_KEY` and `LANGBASE_PIPE_ASK_SG_API_KEY` are set in all
+three environments. No other team project, no repo in the org, and no
+current code references them (Langbase was removed in #1898). Delete
+them from the Vercel project and rotate at Langbase.
+
+## 5. Runtime
+
+- a. `/api/md/[...slug]` (reached via the `*.md` middleware rewrite) is a
+  dynamic lambda with `cache-control: max-age=0, must-revalidate`.
+  Prerender it (`force-static` + `generateStaticParams`).
+- b. Functions run on `standard_legacy` memory with Fluid compute off.
+  Enable Fluid in `vercel.json`; validate `/api/og` and `.md` latency on
+  the preview before merging.
+- c. `src/middleware.ts` runs on every page and linear-scans ~5,900
+  redirects from `src/data/redirects.ts`. Move static redirects to
+  `next.config.js#redirects()`; keep middleware for `.md` rewrites and
+  version patterns.
+
+## 6. Build
+
+- a. `dev/check-*.mjs` and `generate-mermaid-icons.mjs` run twice per
+  build because `next.config.js` is evaluated twice. Run them once from
+  the `build` script. Fix `generate-mermaid-logos` script, which points
+  at a nonexistent file.
+- b. `caniuse-lite` is stale and `next lint` warns on `<img>` in
+  `Logo.tsx`, `mdx/LinkCards.tsx`, `mdx/ProductCards.tsx`,
+  `mdx/ZoomableImage.tsx`, `api/og/[...path]/route.tsx`, plus a hook
+  dependency in `ContentTabs.jsx`.
+- c. Build cache upload is ~880 MB (~60 s of a ~140 s build). Measure
+  what is in it before deciding whether it can shrink.
+
+## 7. Doubled base path 404s
+
+Runtime logs show 404s for `/docs/docs/_next/static/...`, all for the
+not-found page's asset set. Find the referer (Observability query API,
+log drain, or reproduce in a browser) and fix the source.

--- a/dev/TODO.md
+++ b/dev/TODO.md
@@ -16,15 +16,16 @@ then set Node 22 in `.tool-versions` and `package.json#engines`.
 `src/components/Toc.tsx` and `src/components/ContentTabs.jsx` are
 `'use client'` and import `allPosts` from `contentlayer/generated`, so
 every post's raw + compiled body lands in one client chunk
-(`7180-*.js`: 24.4 MB raw, 2.78 MB gzip; First Load JS 2.95 MB).
+(`7180-*.js`: 24.4 MB raw, 2.78 MB gzip; First Load JS 2.95 MB). Its hash
+changes on every deploy, so the CDN and every browser re-download it.
+Confirmed in Chrome DevTools: 51 requests, 3.4 MB transferred, 28.0 MB
+resources for one page; 2,539 kB of that is this chunk.
 Fix: compute what those components need on the server
 (`src/app/[...slug]/page.tsx`) and pass it as props.
 
 ## 3. Pin the toolchain
 
-Build log picks `pnpm@9` "based on project creation date" while
-`.tool-versions` says pnpm 10.25.0 / Node 20.19.6. Add `packageManager`
-and `engines` to `package.json`.
+PR #1906. Watch the preview build log for `Using pnpm@10`.
 
 ## 4. Dead Langbase secrets
 
@@ -35,32 +36,45 @@ them from the Vercel project and rotate at Langbase.
 
 ## 5. Runtime
 
-- a. `/api/md/[...slug]` (reached via the `*.md` middleware rewrite) is a
-  dynamic lambda with `cache-control: max-age=0, must-revalidate`.
-  Prerender it (`force-static` + `generateStaticParams`).
-- b. Functions run on `standard_legacy` memory with Fluid compute off.
-  Enable Fluid in `vercel.json`; validate `/api/og` and `.md` latency on
-  the preview before merging.
-- c. `src/middleware.ts` runs on every page and linear-scans ~5,900
-  redirects from `src/data/redirects.ts`. Move static redirects to
-  `next.config.js#redirects()`; keep middleware for `.md` rewrites and
-  version patterns.
+- a./b. PR #1912 (stacked on #1901): prerender `/api/md/[...slug]`,
+  enable Fluid compute. After the preview deploys, compare `.md` and
+  `/api/og` latency and `x-vercel-cache` against production.
+- c. Draft PR #1907: static redirects moved to `next.config.js`;
+  middleware kept for `.md` rewrites and version patterns. Conflicts with
+  #1908 on `next.config.js`; merge one, rebase the other.
 
 ## 6. Build
 
-- a. `dev/check-*.mjs` and `generate-mermaid-icons.mjs` run twice per
-  build because `next.config.js` is evaluated twice. Run them once from
-  the `build` script. Fix `generate-mermaid-logos` script, which points
-  at a nonexistent file.
-- b. `caniuse-lite` is stale and `next lint` warns on `<img>` in
-  `Logo.tsx`, `mdx/LinkCards.tsx`, `mdx/ProductCards.tsx`,
-  `mdx/ZoomableImage.tsx`, `api/og/[...path]/route.tsx`, plus a hook
-  dependency in `ContentTabs.jsx`.
-- c. Build cache upload is ~880 MB (~60 s of a ~140 s build). Measure
-  what is in it before deciding whether it can shrink.
+- a. Draft PR #1908: run `dev/check-*.mjs` once from the `build` script.
+- b. Draft PR #1909: caniuse-lite bump, lint warnings to zero.
+- c. Build cache is ~880 MB because `node_modules` is ~894 MB and
+  `.next/cache` ~303 MB (`@next/swc` 110 MB, `next` 101 MB, `mermaid`
+  65 MB, `@effect-ts/system` 45 MB via contentlayer, `typescript` 38 MB,
+  `lucide-react` 30 MB). No quick win; revisit after task 1 replaces
+  contentlayer and if `mermaid` can be loaded client-side only.
+- d. Web Analytics and Speed Insights: disabled 2026-09-11 via API.
 
 ## 7. Doubled base path 404s
 
-Runtime logs show 404s for `/docs/docs/_next/static/...`, all for the
-not-found page's asset set. Find the referer (Observability query API,
-log drain, or reproduce in a browser) and fix the source.
+Source found via `vercel.com/api/logs/request-logs` (the `vercel logs`
+CLI drops referer/user-agent): 98 % are bingbot with referer
+`https://docs.sourcegraph.com/<page>`. Cloudflare answers
+`docs.sourcegraph.com/*` with a **302** to `sourcegraph.com/docs/*`, and
+Bing resolves the page's `/docs/_next/...` asset URLs against the
+pre-redirect host, so they come back as `docs.sourcegraph.com/docs/_next/...`
+→ 302 → `sourcegraph.com/docs/docs/_next/...` → 404.
+
+Fix (Cloudflare, not this repo):
+- Make the `docs.sourcegraph.com` redirect a **301** so Bing drops the old
+  URLs from its index and stops crawling them.
+- Add a rule so `docs.sourcegraph.com/docs/*` redirects to
+  `sourcegraph.com/docs/$1` without doubling the prefix.
+
+Fix (this repo):
+- Every page sets `<link rel="canonical" href="https://sourcegraph.com/docs">`
+  (`src/app/layout.tsx` `alternates.canonical: '/docs'`, never
+  overridden). Set a per-page canonical in `src/app/[...slug]/page.tsx`
+  `generateMetadata` so crawlers consolidate on the real URL.
+- Optional guard in `next.config.js#redirects()`:
+  `{source: '/docs/:path*', destination: '/:path*', permanent: true}`
+  (Next prepends `basePath`, so this matches `/docs/docs/*`).


### PR DESCRIPTION
Tracks the follow-ups from the Vercel project audit of `sourcegraph-docs` (one PR per task, linked from the file as they open).

Item 1 (Node 20 deprecation / contentlayer2) is being handled in a separate thread.


---
Replaces #1905 (branch renamed to `marc/todo/vercel-audit`).
