### PR TITLE
docs: Prefix branches with the name of the human who owns them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@
 -   **Check links**: `npm run check -- links --check-anchors --check-self-links` (CI comments on PRs that break links; see `dev/check-links.mjs`; the build runs it without flags, so only dead page links fail a deploy). When moving a page or renaming a heading, update every link to it; a redirect in `src/data/redirects.ts` does not satisfy the check. Link to this site with relative paths (`/admin/config/site-config`), never `https://sourcegraph.com/docs/…` or `https://docs.sourcegraph.com/…`. To also probe the external links you added: `npm run check -- links --check-anchors --check-self-links --check-external --diff <(git diff -U0 origin/main)`
 -   **Prove changed links resolve on a deploy**: `node dev/verify-links-live.mjs --site <vercel-preview-url>` prints a Markdown table for the PR description
 
+## Branches
+
+-   Prefix every branch with a name that identifies the human it belongs to (first name, username, or nickname), then a slash: `marc/fix-moved-page-links`. Agents use the name of the human they are working for, never their own
+
 ## AI Chat Integration
 
 This site uses **runLLM** for the AI chat widget. The integration is implemented via:

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ You can easily update existing docs pages using [GitHub's file editor](https://d
 
 ### (Advanced) Local dev environment
 
-To add new or update existing docs content. Create a new branch and checkout by via:
+To add new or update existing docs content, create a new branch and check it out. Prefix the branch with a name that identifies you (first name, username, or nickname), so it's clear who owns each branch:
 
 ```sh
-git switch -c BRANCH_NAME_HERE
+git switch -c YOUR_NAME/BRANCH_NAME_HERE
 ```
 
 ### Folder structure


### PR DESCRIPTION
## Problem

- Branch names on this repo don't say who owns them, so nobody can tell whose stale branch is safe to prune, or who to ask about an open one

## Solution

- README (contributor guide) and AGENTS.md (agent guide): prefix every branch with a name that identifies the human (first name, username, or nickname), then a slash: `marc/fix-moved-page-links`
- Agents use the name of the human they work for, never their own
