### PR TITLE
ci/vercel: Skip preview builds for PRs that only touch non-site files

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ':(exclude).github' ':(exclude).agents' ':(exclude).amp' ':(exclude).vscode' ':(exclude)AGENTS.md' ':(exclude)README.md' ':(exclude).gitignore' ':(exclude)cspell*'"
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
 	"$schema": "https://openapi.vercel.sh/vercel.json",
-	"ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ':(exclude).github' ':(exclude).agents' ':(exclude).amp' ':(exclude).vscode' ':(exclude)AGENTS.md' ':(exclude)README.md' ':(exclude).gitignore' ':(exclude)cspell*'"
+	"ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ':(exclude).github' ':(exclude).agents' ':(exclude).amp' ':(exclude).vscode' ':(exclude)AGENTS.md' ':(exclude)README.md' ':(exclude).gitignore' ':(exclude)cspell*' ':(exclude)dev/TODO.md'"
 }


### PR DESCRIPTION
## Why

PRs that only change CI workflows, agent config, or repo docs (`.github/`, `AGENTS.md`, cspell lists, ...) currently trigger a full Vercel build and preview deploy that has nothing to preview.

## What

Adds `vercel.json` with an [`ignoreCommand`](https://vercel.com/docs/project-configuration/vercel-json#ignorecommand). Vercel runs it before each build: exit 0 skips, exit 1 builds.

The command diffs `HEAD^..HEAD` with these paths excluded: `.github`, `.agents`, `.amp`, `.vscode`, `AGENTS.md`, `README.md`, `.gitignore`, `cspell*`, `dev/TODO.md`. If nothing else changed, the build is skipped. Everything the site builds from (`docs/`, `src/`, `public/`, `dev/`, root configs, lockfile) still builds. `dev/` stays build-relevant because `next.config.js` runs the `dev/check-*.mjs` scripts during `next build`.

## Verification

- Ran the exact command against the last 8 commits on `main`: all touched site files and all correctly returned BUILD (including c89ef417, which was mostly `.github`/cspell/README but also touched `src/data/redirects.ts`).
- Synthetic commit touching only `.gitignore`, `cspell-allow-list.txt`, `.github/x/y.yml`: exit 0 (SKIP).
- Synthetic commit touching `docs/`: exit 1 (BUILD).

## Caveats

- Vercel clones `--depth=10` and this compares only the last commit. A push of several commits where only the last is non-site-only would be skipped. Squash merges to `main` are one commit, so production is unaffected.
- A skipped build shows on the PR as a canceled Vercel deployment, not a green check. The `main` ruleset has no required status checks, so this does not block merging.
- This PR itself only adds `vercel.json`, which is not in the exclude list, so Vercel should still build it.
