### PR TITLE
site: Redirect / to /docs on production deployments

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,19 +1,34 @@
 const {withContentlayer} = require('next-contentlayer2');
 /** @type {import('next').NextConfig} */
 
+// in prod, we serve the docs from sourcegraph.com/docs, and this requires special config on the GFE side
+// in preview/development, this is not necessary.
+//
+// VERCEL_ENV is a system env var set by Vercel
+// https://vercel.com/docs/projects/environment-variables/system-environment-variables
+const basePath = process.env.VERCEL_ENV === 'production' ? '/docs' : '';
+
 const nextConfig = {
 	reactStrictMode: true,
 	swcMinify: true,
-	// in prod, we serve the docs from sourcegraph.com/docs, and this requires special config on the GFE side
-	// in preview/development, this is not necessary.
-	//
-	// VERCEL_ENV is a system env var set by Vercel
-	// https://vercel.com/docs/projects/environment-variables/system-environment-variables
-	// basePath: process.env.VERCEL_ENV === 'production' ? '/docs' : '',
-	basePath: process.env.VERCEL_ENV === 'production' ? '/docs' : '',
+	basePath,
 	env: {
-		NEXT_PUBLIC_DOCS_BASE_PATH:
-			process.env.VERCEL_ENV === 'production' ? '/docs' : ''
+		NEXT_PUBLIC_DOCS_BASE_PATH: basePath
+	},
+	// With basePath set, nothing serves `/`, so the *.vercel.app deployment URL
+	// that Vercel links from Slack / GitHub 404s. sourcegraph.com never proxies
+	// `/` to us, so this only affects visitors opening that raw URL. Stay on the
+	// same host so they see this exact deployment, not whatever is live.
+	async redirects() {
+		if (!basePath) return [];
+		return [
+			{
+				source: '/',
+				destination: basePath,
+				basePath: false,
+				permanent: false
+			}
+		];
 	}
 };
 


### PR DESCRIPTION
## Problem

Vercel's Slack and GitHub posts for a production deploy link "Visit" to the raw deployment URL, e.g. `https://sourcegraph-docs-rmeucrf94-sourcegraph-f8c71130.vercel.app/`. In production `basePath` is `/docs`, so nothing serves `/` and Vercel returns a 404. People click away thinking the deploy is broken.

| deployment | `/` | `/docs` |
|---|---|---|
| preview | 200 | 404 |
| production | **404** | 200 |

## Change

When `basePath` is set, redirect `/` → `/docs` on the same host (`basePath: false` so the source matches the bare `/`). Same host, not `sourcegraph.com/docs`, so the visitor sees the exact deployment in the post rather than whatever is live. 307 so nothing gets cached if we change it later.

Preview deployments have no `basePath`, so `redirects()` returns `[]` and `/` keeps serving the homepage as today.

sourcegraph.com never proxies `/` to Vercel (only `/docs/*`), so the live site is unaffected.

Also hoisted the duplicated `VERCEL_ENV` ternary into one `basePath` const so `basePath`, `NEXT_PUBLIC_DOCS_BASE_PATH`, and the redirect can't drift.

## Verified

`VERCEL_ENV=production npx next dev`:

```
/            307 → /docs
/docs        200
/docs/admin  200
```

Without `VERCEL_ENV`: `/` 200, `/admin` 200, no redirect.

## Note

#1942 also adds a `redirects` key to `next.config.js`; whichever merges second will need a one-line conflict resolution (keep both entries).